### PR TITLE
Test for Redis versions < 2.4 before storing arrays

### DIFF
--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -1,6 +1,7 @@
 require 'redis'
 
 require 'coverband/version'
+require 'coverband/redis_store'
 require 'coverband/base'
 require 'coverband/reporter'
 require 'coverband/middleware'

--- a/lib/coverband/redis_store.rb
+++ b/lib/coverband/redis_store.rb
@@ -1,0 +1,45 @@
+module Coverband
+  class RedisStore
+    def initialize(redis)
+      @redis = redis
+    end
+
+    def store_report(report)
+      store_array('coverband', report.keys)
+
+      report.each do |file, lines|
+        store_array("coverband.#{file}", lines)
+      end
+    end
+
+    def sadd_supports_array?
+      # if the value is false, ||= would reevaluate the right side
+      return @_sadd_supports_array if defined?(@_sadd_supports_array)
+
+      @_sadd_supports_array = recent_gem_version? && recent_server_version?
+    end
+
+    private
+
+    attr_reader :redis
+
+    def store_array(key, values)
+      if sadd_supports_array?
+        redis.sadd(key, values)
+      else
+        values.each do |value|
+          redis.sadd(key, value)
+        end
+      end
+      values
+    end
+
+    def recent_server_version?
+      Gem::Version.new(redis.info['redis_version']) >= Gem::Version.new('2.4')
+    end
+
+    def recent_gem_version?
+      Gem::Version.new(Redis::VERSION) >= Gem::Version.new('3.0')
+    end
+  end
+end

--- a/test/unit/middleware_test.rb
+++ b/test/unit/middleware_test.rb
@@ -39,19 +39,19 @@ class MiddlewareTest < Test::Unit::TestCase
   should 'always unset function when sampling' do
     request = Rack::MockRequest.env_for("/anything.json")
     middleware = Coverband::Middleware.new(fake_app)
-    assert_equal false, middleware.instance_variable_get("@function_set")
+    assert_equal false, middleware.instance_variable_get("@tracer_set")
     middleware.instance_variable_set("@sample_percentage", 100.0)
     results = middleware.call(request)
-    assert_equal false, middleware.instance_variable_get("@function_set")
+    assert_equal false, middleware.instance_variable_get("@tracer_set")
   end
 
   should 'always unset function when not sampling' do
     request = Rack::MockRequest.env_for("/anything.json")
     middleware = Coverband::Middleware.new(fake_app)
-    assert_equal false, middleware.instance_variable_get("@function_set")
+    assert_equal false, middleware.instance_variable_get("@tracer_set")
     middleware.instance_variable_set("@sample_percentage", 0.0)
     results = middleware.call(request)
-    assert_equal false, middleware.instance_variable_get("@function_set")
+    assert_equal false, middleware.instance_variable_get("@tracer_set")
   end
 
   should 'always record coverage, set trace func, and add_files when sampling' do
@@ -70,7 +70,7 @@ class MiddlewareTest < Test::Unit::TestCase
     assert_equal false, middleware.instance_variable_get("@enabled")
     middleware.instance_variable_set("@sample_percentage", 100.0)
     fake_redis = Redis.new
-    middleware.instance_variable_set("@reporter", fake_redis)
+    middleware.instance_variable_set("@reporter", Coverband::RedisStore.new(fake_redis))
     fake_redis.expects(:sadd).at_least_once
     fake_redis.expects(:sadd).at_least_once.with("coverband.#{FAKE_RACK_APP_PATH}", [4,5,6])
     results = middleware.call(request)

--- a/test/unit/redis_store_test.rb
+++ b/test/unit/redis_store_test.rb
@@ -1,0 +1,82 @@
+require File.expand_path('../test_helper', File.dirname(__FILE__))
+
+class RedisStoreTest < Test::Unit::TestCase
+  context '#store_report' do
+    setup do
+      @redis = Redis.current.tap { |redis|
+        redis.stubs(:sadd).with(anything, anything)
+      }
+
+      @store = Coverband::RedisStore.new(@redis)
+    end
+
+    should "it stores the files into coverband" do
+      @redis.expects(:sadd).with('coverband', [
+        '/Users/danmayer/projects/cover_band_server/app.rb',
+        '/Users/danmayer/projects/cover_band_server/server.rb'
+      ])
+
+      @store.store_report(test_data)
+    end
+
+    should "it stores the file lines of the file app.rb" do
+      @redis.expects(:sadd).with(
+        'coverband./Users/danmayer/projects/cover_band_server/app.rb',
+        [54, 55]
+      )
+
+      @store.store_report(test_data)
+    end
+
+    should "it stores the file lines of the file server.rb" do
+      @redis.expects(:sadd).with(
+        'coverband./Users/danmayer/projects/cover_band_server/server.rb',
+        [5]
+      )
+
+      @store.store_report(test_data)
+    end
+
+    context 'when the redis server version is too old' do
+      setup do
+        @redis.stubs(:info).returns("redis_version"=>"2.2.3")
+      end
+
+      should "it store the files with separate calls into coverband" do
+        @redis.expects(:sadd).with('coverband', '/Users/danmayer/projects/cover_band_server/app.rb')
+        @redis.expects(:sadd).with('coverband', '/Users/danmayer/projects/cover_band_server/server.rb')
+
+        @store.store_report(test_data)
+      end
+    end
+
+    context 'when the redis gem version is too old' do
+      setup do
+        @gem_version = Redis::VERSION
+        Redis.send(:remove_const, :VERSION)
+        Redis::VERSION = '2.2.2'
+      end
+
+      teardown do
+        Redis.send(:remove_const, :VERSION)
+        Redis::VERSION = @gem_version
+      end
+
+      should "it store the files with separate calls into coverband" do
+        @redis.expects(:sadd).with('coverband', '/Users/danmayer/projects/cover_band_server/app.rb')
+        @redis.expects(:sadd).with('coverband', '/Users/danmayer/projects/cover_band_server/server.rb')
+
+        @store.store_report(test_data)
+      end
+    end
+  end
+
+  private
+
+  def test_data
+    {
+      "/Users/danmayer/projects/cover_band_server/app.rb"=>[54, 55],
+      "/Users/danmayer/projects/cover_band_server/server.rb"=>[5]
+    }
+  end
+end


### PR DESCRIPTION
SADD only supports multiple member arguments since version 2.4, see http://redis.io/commands/sadd. The last Ubuntu LTS still installs 2.2 per default.

Also I factored the Redis functionality of the base class into it's own class (but the reporter still uses redis directly) and did other small refactorings.
