### PR TITLE
Took shell call to open out

### DIFF
--- a/lib/coverband/reporter.rb
+++ b/lib/coverband/reporter.rb
@@ -58,7 +58,7 @@ module Coverband
       puts "report: "
       puts scov_style_report.inspect
       SimpleCov::Result.new(scov_style_report).format!
-      `open coverage/index.html`
+      puts "report is ready and viewable: open #{SimpleCov.coverage_dir}/index.html"
     end
 
     def self.merge_existing_coverage(scov_style_report, existing_coverage)


### PR DESCRIPTION
My server being headless and browserless chokes on a call to try and open the report after generation. I changed this to just print out the command if the user wants to take the next step and view it.

Nice Gem, btw. This thing has good potential.
