### PR TITLE
Use `count` instead of `increment` to measure this

### DIFF
--- a/lib/coverband/base.rb
+++ b/lib/coverband/base.rb
@@ -89,7 +89,7 @@ module Coverband
       if @reporter
         if @reporter.class.name.match(/redis/i)
           before_time = Time.now
-          @stats.increment "coverband.files.recorded_files", @files.length if @stats
+          @stats.count "coverband.files.recorded_files", @files.length if @stats
           @reporter.store_report(@files.dup)
           time_spent = Time.now - before_time
           @stats.timing "coverband.files.recorded_time", time_spent if @stats


### PR DESCRIPTION
I think we should be using `count` here instead of `increment`. Increment takes `step` as a second value, not the actual value, In fact, count is used by `increment` internally (https://github.com/reinh/statsd/blob/5d1d539e447053d28003c9b8f211dd5a35007dcd/lib/statsd.rb#L279).

It also makes it incompatible with some statsd clients (they take hash as a second argument).
