### PR TITLE
added ability to run tests with c-extension

### DIFF
--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "mocha", "~> 0.14.0"
   spec.add_development_dependency "rack"
+  spec.add_development_dependency "coverband_ext", "~> 1.1"
   spec.add_runtime_dependency "simplecov"
   spec.add_runtime_dependency "json"
   spec.add_runtime_dependency "redis"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require 'test/unit'
 require 'mocha/setup'
 require 'ostruct'
 require 'json'
+require 'coverband_ext' if ENV['C_EXT']
 
 SimpleCov.start do
   add_filter 'specs/ruby/1.9.1/gems/'


### PR DESCRIPTION
It is extremely handy to be able to run specs with c_extension included.  The simplest way i could make this happen is by adding a development dependency on coverband_ext.  Unfortunately, this means i needed to remove the dependency from coverband_ext -> coverband as it would have introduced a circular dependency.  I don't think this is a huge issue as the user should be explicitly including both coverband and coverband_ext within their Gemfile.

To run tests with c-ext:

```
C_EXT=T rake test
```

Also note that because this change depends on a change in coverband_ext, i bumped the version of coverband_ext to 1.1 to avoid confusion.

See related pull request here: https://github.com/danmayer/coverband_ext/pull/5

Also, note that 3 tests fail when we include the c_ext.  Will treat that as a separate issue.
