### PR TITLE
removing bundler as a dependency 

### DIFF
--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "mocha", "~> 0.14.0"
   spec.add_development_dependency "rack"

--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "mocha", "~> 0.14.0"
   spec.add_development_dependency "rack"

--- a/lib/coverband/version.rb
+++ b/lib/coverband/version.rb
@@ -1,3 +1,3 @@
 module Coverband
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end


### PR DESCRIPTION
I don't think we need bundler as a dependency and pinning to an old version may be causing issues.

I am getting this:

https://travis-ci.org/danmayer/coverband/jobs/100408176

Here is someone with a similar issue on travis.

https://github.com/bundler/bundler/issues/3558