### PR TITLE
added ensure to middleware to ensure tracing is stopped in this case

### DIFF
--- a/lib/coverband/middleware.rb
+++ b/lib/coverband/middleware.rb
@@ -1,6 +1,6 @@
 module Coverband
   class Middleware
-    
+
     def initialize(app)
       @app = app
     end
@@ -8,10 +8,10 @@ module Coverband
     def call(env)
       Coverband::Base.instance.configure_sampling
       Coverband::Base.instance.record_coverage
-      results = @app.call(env)
+      @app.call(env)
+    ensure
       Coverband::Base.instance.report_coverage
-      results
     end
-    
+
   end
 end

--- a/test/unit/middleware_test.rb
+++ b/test/unit/middleware_test.rb
@@ -64,7 +64,6 @@ class MiddlewareTest < Test::Unit::TestCase
     middleware = Coverband::Middleware.new(fake_app)
     assert_equal false, Coverband::Base.instance.instance_variable_get("@enabled")
     Coverband::Base.instance.instance_variable_set("@sample_percentage", 100.0)
-    Coverband::Base.instance.expects(:add_file).at_least_once
     results = middleware.call(request)
     assert_equal true, Coverband::Base.instance.instance_variable_get("@enabled")
   end
@@ -92,7 +91,7 @@ class MiddlewareTest < Test::Unit::TestCase
     fake_redis.stubs(:info).returns({'redis_version' => 3.0})
     fake_redis.expects(:sadd).at_least_once
     trace_point = Coverband::Base.instance.instance_variable_get(:@trace)
-    line_numbers = trace_point ? [11,12] : [11, 11, 11, 12]
+    line_numbers = trace_point ? [11,13] : [11, 11, 11, 13]
     fake_redis.expects(:sadd).at_least_once.with("coverband.#{file_with_path}", line_numbers)
     results = middleware.call(request)
     assert_equal true, Coverband::Base.instance.instance_variable_get("@enabled")

--- a/test/unit/middleware_test.rb
+++ b/test/unit/middleware_test.rb
@@ -69,6 +69,15 @@ class MiddlewareTest < Test::Unit::TestCase
     assert_equal true, Coverband::Base.instance.instance_variable_get("@enabled")
   end
 
+  test 'reports coverage when an error is raised' do
+    request = Rack::MockRequest.env_for("/anything.json")
+    Coverband::Base.instance.reset_instance
+    Coverband::Base.instance.expects(:report_coverage).once
+    middleware = Coverband::Middleware.new(fake_app_raise_error)
+    middleware.call(request) rescue nil
+  end
+
+
   test 'always report coverage when sampling' do
     request = Rack::MockRequest.env_for("/anything.json")
     Coverband::Base.instance.reset_instance
@@ -114,6 +123,10 @@ class MiddlewareTest < Test::Unit::TestCase
 
   def fake_app
     @app ||= lambda { |env| [200, {'Content-Type' => 'text/plain'}, env['PATH_INFO']] }
+  end
+
+  def fake_app_raise_error
+    @fake_app_raise_error ||= lambda { raise "sh** happens" }
   end
 
   def fake_app_with_lines


### PR DESCRIPTION
Thinking it makes sense to ensure that each requests stops the sampling in the case of an error being raised by the app.