### PR TITLE
Optional gem ignore

### DIFF
--- a/lib/coverband/base.rb
+++ b/lib/coverband/base.rb
@@ -42,7 +42,8 @@ module Coverband
       @file_usage = Hash.new(0)
       @file_line_usage = {}
       @startup_delay = Coverband.configuration.startup_delay
-      @ignore_patterns = Coverband.configuration.ignore + ['gems', "internal:prelude"]
+      @ignore_patterns = Coverband.configuration.ignore + ["internal:prelude"]
+      @ignore_patterns += ['gems'] unless Coverband.configuration.include_gems
       @sample_percentage = Coverband.configuration.percentage
       @reporter = Coverband::RedisStore.new(Coverband.configuration.redis) if Coverband.configuration.redis
       @stats    = Coverband.configuration.stats

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -1,6 +1,6 @@
 module Coverband
   class Configuration
-    attr_accessor :redis, :coverage_baseline, :root_paths, :root, :ignore, :percentage, :verbose, :reporter, :stats, :logger, :startup_delay, :baseline_file, :trace_point_events
+    attr_accessor :redis, :coverage_baseline, :root_paths, :root, :ignore, :percentage, :verbose, :reporter, :stats, :logger, :startup_delay, :baseline_file, :trace_point_events, :include_gems
 
     def initialize
       @root = Dir.pwd
@@ -10,6 +10,7 @@ module Coverband
       @baseline_file = './tmp/coverband_baseline.json'
       @root_paths = []
       @ignore = []
+      @include_gems = false
       @percentage = 0.0
       @verbose = false
       @reporter = 'scov'

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -5,4 +5,17 @@ class BaseTest < Test::Unit::TestCase
   test "defaults to line trace point event" do
     assert_equal Coverband.configuration.trace_point_events, [:line]
   end
+
+  test "defaults to ignore gems" do
+    assert_equal Coverband.configuration.include_gems, false
+    coverband = Coverband::Base.instance.reset_instance
+    assert_equal ['vendor', 'internal:prelude', 'gems'], coverband.instance_variable_get("@ignore_patterns")
+  end
+
+  test "doesn't ignore gems if include_gems = true" do
+    Coverband.configuration.include_gems = true
+    coverband = Coverband::Base.instance.reset_instance
+    assert_equal ['vendor', 'internal:prelude'], coverband.instance_variable_get("@ignore_patterns")
+  end
+
 end


### PR DESCRIPTION
This PR adds an include_gems configuration option so that we can be explicit about whether we want to ignore gems or not.