### PR TITLE
Added in memory caching configuration to reduce calls to redis

### DIFF
--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -26,5 +26,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "simplecov"
   spec.add_runtime_dependency "json"
   spec.add_runtime_dependency "redis"
-  spec.add_runtime_dependency "thread_safe"
 end

--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "simplecov"
   spec.add_runtime_dependency "json"
   spec.add_runtime_dependency "redis"
+  spec.add_runtime_dependency "thread_safe"
 end

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -4,6 +4,7 @@ require 'logger'
 require 'coverband/version'
 require 'coverband/configuration'
 require 'coverband/redis_store'
+require 'coverband/memory_cache_store'
 require 'coverband/base'
 require 'coverband/reporter'
 require 'coverband/middleware'
@@ -11,7 +12,7 @@ require 'coverband/middleware'
 module Coverband
 
   CONFIG_FILE = './config/coverband.rb'
-  
+
   class << self
     attr_accessor :configuration_data
   end
@@ -41,5 +42,5 @@ module Coverband
   def self.configuration
     self.configuration_data ||= Configuration.new
   end
-  
+
 end

--- a/lib/coverband/base.rb
+++ b/lib/coverband/base.rb
@@ -45,7 +45,7 @@ module Coverband
       @ignore_patterns = Coverband.configuration.ignore + ["internal:prelude"]
       @ignore_patterns += ['gems'] unless Coverband.configuration.include_gems
       @sample_percentage = Coverband.configuration.percentage
-      @reporter = Coverband::RedisStore.new(Coverband.configuration.redis) if Coverband.configuration.redis
+      @reporter = Coverband::MemoryCacheStore.new(Coverband::RedisStore.new(Coverband.configuration.redis)) if Coverband.configuration.redis
       @stats    = Coverband.configuration.stats
       @verbose  = Coverband.configuration.verbose
       @logger   = Coverband.configuration.logger

--- a/lib/coverband/base.rb
+++ b/lib/coverband/base.rb
@@ -45,7 +45,10 @@ module Coverband
       @ignore_patterns = Coverband.configuration.ignore + ["internal:prelude"]
       @ignore_patterns += ['gems'] unless Coverband.configuration.include_gems
       @sample_percentage = Coverband.configuration.percentage
-      @reporter = Coverband::MemoryCacheStore.new(Coverband::RedisStore.new(Coverband.configuration.redis)) if Coverband.configuration.redis
+      if Coverband.configuration.redis
+        @reporter = Coverband::RedisStore.new(Coverband.configuration.redis)
+        @reporter = Coverband::MemoryCacheStore.new(@reporter) if Coverband.configuration.memory_caching
+      end
       @stats    = Coverband.configuration.stats
       @verbose  = Coverband.configuration.verbose
       @logger   = Coverband.configuration.logger

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -1,6 +1,6 @@
 module Coverband
   class Configuration
-    attr_accessor :redis, :coverage_baseline, :root_paths, :root, :ignore, :percentage, :verbose, :reporter, :stats, :logger, :startup_delay, :baseline_file, :trace_point_events, :include_gems
+    attr_accessor :redis, :coverage_baseline, :root_paths, :root, :ignore, :percentage, :verbose, :reporter, :stats, :logger, :startup_delay, :baseline_file, :trace_point_events, :include_gems, :memory_caching
 
     def initialize
       @root = Dir.pwd
@@ -17,6 +17,7 @@ module Coverband
       @logger = Logger.new(STDOUT)
       @startup_delay = 0
       @trace_point_events = [:line]
+      @memory_caching = false
     end
 
     def logger

--- a/lib/coverband/memory_cache_store.rb
+++ b/lib/coverband/memory_cache_store.rb
@@ -1,0 +1,7 @@
+class MemoryCacheStore < Struct.new(:cache_store)
+
+  def store_report files
+    cache_store.store_report files
+  end
+
+end

--- a/lib/coverband/memory_cache_store.rb
+++ b/lib/coverband/memory_cache_store.rb
@@ -1,4 +1,3 @@
-require 'thread_safe'
 module Coverband
   class MemoryCacheStore
 
@@ -6,7 +5,7 @@ module Coverband
 
 
     def self.files_cache
-      @files_cache ||= ThreadSafe::Cache.new
+      @files_cache ||= Hash.new
     end
 
     def self.reset!

--- a/lib/coverband/memory_cache_store.rb
+++ b/lib/coverband/memory_cache_store.rb
@@ -1,7 +1,32 @@
-class MemoryCacheStore < Struct.new(:cache_store)
+class MemoryCacheStore
+
+  attr_accessor :store
+
+  def initialize(store)
+    @store = store
+    @files_cache = Hash.new
+  end
 
   def store_report files
-    cache_store.store_report files
+    filtered_files = filter(files)
+    store.store_report(filtered_files) if filtered_files.any?
+  end
+
+  private
+
+  def filter(files)
+    files.each_with_object(Hash.new) do |(file, lines), filtered_file_hash|
+      line_cache = @files_cache[file] ||= Set.new
+      lines.reject! do |line|
+        if line_cache.include? line
+          true
+        else
+          line_cache << line
+          false
+        end
+      end
+      filtered_file_hash[file] = lines if lines.any?
+    end
   end
 
 end

--- a/lib/coverband/memory_cache_store.rb
+++ b/lib/coverband/memory_cache_store.rb
@@ -1,32 +1,34 @@
-class MemoryCacheStore
+module Coverband
+  class MemoryCacheStore
 
-  attr_accessor :store
+    attr_accessor :store
 
-  def initialize(store)
-    @store = store
-    @files_cache = Hash.new
-  end
-
-  def store_report files
-    filtered_files = filter(files)
-    store.store_report(filtered_files) if filtered_files.any?
-  end
-
-  private
-
-  def filter(files)
-    files.each_with_object(Hash.new) do |(file, lines), filtered_file_hash|
-      line_cache = @files_cache[file] ||= Set.new
-      lines.reject! do |line|
-        if line_cache.include? line
-          true
-        else
-          line_cache << line
-          false
-        end
-      end
-      filtered_file_hash[file] = lines if lines.any?
+    def initialize(store)
+      @store = store
+      @files_cache = Hash.new
     end
-  end
 
+    def store_report files
+      filtered_files = filter(files)
+      store.store_report(filtered_files) if filtered_files.any?
+    end
+
+    private
+
+    def filter(files)
+      files.each_with_object(Hash.new) do |(file, lines), filtered_file_hash|
+        line_cache = @files_cache[file] ||= Set.new
+        lines.reject! do |line|
+          if line_cache.include? line
+            true
+          else
+            line_cache << line
+            false
+          end
+        end
+        filtered_file_hash[file] = lines if lines.any?
+      end
+    end
+
+  end
 end

--- a/lib/coverband/memory_cache_store.rb
+++ b/lib/coverband/memory_cache_store.rb
@@ -29,7 +29,8 @@ module Coverband
 
     def filter(files)
       files.each_with_object(Hash.new) do |(file, lines), filtered_file_hash|
-        line_cache = files_cache[file] ||= Set.new
+        #first time we see a file, we pre-init the in memory cache to whatever is in store(redis)
+        line_cache = files_cache[file] ||= Set.new(store.covered_lines_for_file(file))
         lines.reject! do |line|
           if line_cache.include? line
             true

--- a/lib/coverband/memory_cache_store.rb
+++ b/lib/coverband/memory_cache_store.rb
@@ -1,11 +1,20 @@
+require 'thread_safe'
 module Coverband
   class MemoryCacheStore
 
     attr_accessor :store
 
+
+    def self.files_cache
+      @files_cache ||= ThreadSafe::Cache.new
+    end
+
+    def self.reset!
+      files_cache.clear
+    end
+
     def initialize(store)
       @store = store
-      @files_cache = Hash.new
     end
 
     def store_report files
@@ -15,9 +24,13 @@ module Coverband
 
     private
 
+    def files_cache
+      self.class.files_cache
+    end
+
     def filter(files)
       files.each_with_object(Hash.new) do |(file, lines), filtered_file_hash|
-        line_cache = @files_cache[file] ||= Set.new
+        line_cache = files_cache[file] ||= Set.new
         lines.reject! do |line|
           if line_cache.include? line
             true

--- a/lib/coverband/redis_store.rb
+++ b/lib/coverband/redis_store.rb
@@ -15,6 +15,12 @@ module Coverband
       end
     end
 
+
+    def covered_lines_for_file(file)
+      @redis.smembers("coverband.#{file}").map(&:to_i)
+    end
+
+
     def sadd_supports_array?
       @_sadd_supports_array
     end

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../test_helper', File.dirname(__FILE__))
 require File.expand_path('./dog', File.dirname(__FILE__))
 
-require 'pry-byebug'
 class BaseTest < Test::Unit::TestCase
 
   test 'defaults to a redis store' do

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -1,7 +1,21 @@
 require File.expand_path('../test_helper', File.dirname(__FILE__))
 require File.expand_path('./dog', File.dirname(__FILE__))
 
+require 'pry-byebug'
 class BaseTest < Test::Unit::TestCase
+
+  test 'defaults to a redis store' do
+    coverband = Coverband::Base.instance.reset_instance
+    assert_equal Coverband::RedisStore, coverband.instance_variable_get('@reporter').class
+  end
+
+
+  test 'configure memory caching' do
+    Coverband.configuration.memory_caching = true
+    coverband = Coverband::Base.instance.reset_instance
+    assert_equal Coverband::MemoryCacheStore, coverband.instance_variable_get('@reporter').class
+    Coverband.configuration.memory_caching = false
+  end
 
   test "start should enable coverage" do
     coverband = Coverband::Base.instance.reset_instance

--- a/test/unit/memory_cache_store_test.rb
+++ b/test/unit/memory_cache_store_test.rb
@@ -5,6 +5,7 @@ module Coverband
   class MemoryCacheStoreTest < Test::Unit::TestCase
 
     def setup
+      MemoryCacheStore.reset!
       @store = mock('store')
       @memory_store = MemoryCacheStore.new(@store)
     end

--- a/test/unit/memory_cache_store_test.rb
+++ b/test/unit/memory_cache_store_test.rb
@@ -16,6 +16,8 @@ module Coverband
         'file2' => [1, 2]
       }
       @store.expects(:store_report).with data
+      @store.expects(:covered_lines_for_file).with('file1').returns []
+      @store.expects(:covered_lines_for_file).with('file2').returns []
       @memory_store.store_report data
     end
 
@@ -25,6 +27,8 @@ module Coverband
         'file2' => [1, 2]
       }
       @store.expects(:store_report).once.with data
+      @store.expects(:covered_lines_for_file).with('file1').returns []
+      @store.expects(:covered_lines_for_file).with('file2').returns []
       2.times { @memory_store.store_report data }
     end
 
@@ -37,6 +41,8 @@ module Coverband
         'file1' => [ 3, 5, 10 ],
         'file2' => [1, 2]
       }
+      @store.expects(:covered_lines_for_file).with('file1').returns []
+      @store.expects(:covered_lines_for_file).with('file2').returns []
       @store.expects(:store_report).once.with first_data
       @store.expects(:store_report).once.with(
         'file1' => [10]

--- a/test/unit/memory_cache_store_test.rb
+++ b/test/unit/memory_cache_store_test.rb
@@ -1,0 +1,22 @@
+require File.expand_path('../test_helper', File.dirname(__FILE__))
+require 'pry-byebug'
+
+class MemoryCacheStoreTest < Test::Unit::TestCase
+
+  def setup
+    @cache_store = mock('cache_store')
+    @memory_cache_store = MemoryCacheStore.new(@cache_store)
+  end
+
+
+  test 'it passes data into cache store' do
+    data = {
+      'file1' => [ 3, 5 ],
+      'file2' => [1, 2]
+    }
+    @cache_store.expects(:store_report).with data
+    @memory_cache_store.store_report data
+  end
+
+
+end

--- a/test/unit/memory_cache_store_test.rb
+++ b/test/unit/memory_cache_store_test.rb
@@ -51,5 +51,17 @@ module Coverband
       @memory_store.store_report second_data
     end
 
+    test 'it initializes cache with what is in store' do
+      data = {
+        'file1' => [ 3, 5 ],
+        'file2' => [1, 2]
+      }
+      @store.expects(:covered_lines_for_file).with('file1').returns [3,5]
+      @store.expects(:covered_lines_for_file).with('file2').returns [2]
+      @store.expects(:store_report).with( 'file2' => [1] )
+      @memory_store.store_report data
+    end
+
   end
+
 end

--- a/test/unit/memory_cache_store_test.rb
+++ b/test/unit/memory_cache_store_test.rb
@@ -4,19 +4,44 @@ require 'pry-byebug'
 class MemoryCacheStoreTest < Test::Unit::TestCase
 
   def setup
-    @cache_store = mock('cache_store')
-    @memory_cache_store = MemoryCacheStore.new(@cache_store)
+    @store = mock('store')
+    @memory_store = MemoryCacheStore.new(@store)
   end
 
 
-  test 'it passes data into cache store' do
+  test 'it passes data into store' do
     data = {
       'file1' => [ 3, 5 ],
       'file2' => [1, 2]
     }
-    @cache_store.expects(:store_report).with data
-    @memory_cache_store.store_report data
+    @store.expects(:store_report).with data
+    @memory_store.store_report data
   end
 
+  test 'it passes data into store only once' do
+    data = {
+      'file1' => [ 3, 5 ],
+      'file2' => [1, 2]
+    }
+    @store.expects(:store_report).once.with data
+    2.times { @memory_store.store_report data }
+  end
+
+  test 'it only passes files and lines we have not hit yet' do
+    first_data = {
+      'file1' => [ 3, 5 ],
+      'file2' => [1, 2]
+    }
+    second_data = {
+      'file1' => [ 3, 5, 10 ],
+      'file2' => [1, 2]
+    }
+    @store.expects(:store_report).once.with first_data
+    @store.expects(:store_report).once.with(
+      'file1' => [10]
+    )
+    @memory_store.store_report first_data
+    @memory_store.store_report second_data
+  end
 
 end

--- a/test/unit/memory_cache_store_test.rb
+++ b/test/unit/memory_cache_store_test.rb
@@ -1,47 +1,49 @@
 require File.expand_path('../test_helper', File.dirname(__FILE__))
 require 'pry-byebug'
 
-class MemoryCacheStoreTest < Test::Unit::TestCase
+module Coverband
+  class MemoryCacheStoreTest < Test::Unit::TestCase
 
-  def setup
-    @store = mock('store')
-    @memory_store = MemoryCacheStore.new(@store)
+    def setup
+      @store = mock('store')
+      @memory_store = MemoryCacheStore.new(@store)
+    end
+
+
+    test 'it passes data into store' do
+      data = {
+        'file1' => [ 3, 5 ],
+        'file2' => [1, 2]
+      }
+      @store.expects(:store_report).with data
+      @memory_store.store_report data
+    end
+
+    test 'it passes data into store only once' do
+      data = {
+        'file1' => [ 3, 5 ],
+        'file2' => [1, 2]
+      }
+      @store.expects(:store_report).once.with data
+      2.times { @memory_store.store_report data }
+    end
+
+    test 'it only passes files and lines we have not hit yet' do
+      first_data = {
+        'file1' => [ 3, 5 ],
+        'file2' => [1, 2]
+      }
+      second_data = {
+        'file1' => [ 3, 5, 10 ],
+        'file2' => [1, 2]
+      }
+      @store.expects(:store_report).once.with first_data
+      @store.expects(:store_report).once.with(
+        'file1' => [10]
+      )
+      @memory_store.store_report first_data
+      @memory_store.store_report second_data
+    end
+
   end
-
-
-  test 'it passes data into store' do
-    data = {
-      'file1' => [ 3, 5 ],
-      'file2' => [1, 2]
-    }
-    @store.expects(:store_report).with data
-    @memory_store.store_report data
-  end
-
-  test 'it passes data into store only once' do
-    data = {
-      'file1' => [ 3, 5 ],
-      'file2' => [1, 2]
-    }
-    @store.expects(:store_report).once.with data
-    2.times { @memory_store.store_report data }
-  end
-
-  test 'it only passes files and lines we have not hit yet' do
-    first_data = {
-      'file1' => [ 3, 5 ],
-      'file2' => [1, 2]
-    }
-    second_data = {
-      'file1' => [ 3, 5, 10 ],
-      'file2' => [1, 2]
-    }
-    @store.expects(:store_report).once.with first_data
-    @store.expects(:store_report).once.with(
-      'file1' => [10]
-    )
-    @memory_store.store_report first_data
-    @memory_store.store_report second_data
-  end
-
 end

--- a/test/unit/memory_cache_store_test.rb
+++ b/test/unit/memory_cache_store_test.rb
@@ -1,5 +1,4 @@
 require File.expand_path('../test_helper', File.dirname(__FILE__))
-require 'pry-byebug'
 
 module Coverband
   class MemoryCacheStoreTest < Test::Unit::TestCase

--- a/test/unit/redis_store_test.rb
+++ b/test/unit/redis_store_test.rb
@@ -2,6 +2,14 @@ require File.expand_path('../test_helper', File.dirname(__FILE__))
 
 class RedisTest < Test::Unit::TestCase
 
+  def test_covered_lines_for_file
+    @redis = Redis.new
+    @store = Coverband::RedisStore.new(@redis)
+    @redis.sadd('coverband.dog.rb', 1)
+    @redis.sadd('coverband.dog.rb', 2)
+    assert_equal @store.covered_lines_for_file('dog.rb').sort,  [1, 2]
+  end
+
   private
 
   def test_data

--- a/test/unit/redis_store_test.rb
+++ b/test/unit/redis_store_test.rb
@@ -2,12 +2,20 @@ require File.expand_path('../test_helper', File.dirname(__FILE__))
 
 class RedisTest < Test::Unit::TestCase
 
-  def test_covered_lines_for_file
+  def setup
     @redis = Redis.new
+    @redis.flushdb
     @store = Coverband::RedisStore.new(@redis)
+  end
+
+  def test_covered_lines_for_file
     @redis.sadd('coverband.dog.rb', 1)
     @redis.sadd('coverband.dog.rb', 2)
     assert_equal @store.covered_lines_for_file('dog.rb').sort,  [1, 2]
+  end
+
+  def test_covered_lines_when_null
+    assert_equal @store.covered_lines_for_file('dog.rb'),  []
   end
 
   private


### PR DESCRIPTION
MemoryCacheStore keeps list of lines hit in memory reducing the number of network trips to redis.  It also pre-initializes the cache with all lines currently persisted to redis.  The idea is we do not need to hit redis over and over again for lines that have already been covered.

```
Coverband.configure do |config|
  config.redis             = Redis.new
  #by default this is false
  config.memory_caching = true
end
```
