### PR TITLE
Read/Write output to s3

### DIFF
--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "simplecov"
   spec.add_runtime_dependency "json"
   spec.add_runtime_dependency "redis"
+  spec.add_runtime_dependency 'aws-sdk', '~> 2'
 end

--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "mocha", "~> 0.14.0"
   spec.add_development_dependency "rack"
+  spec.add_development_dependency "rack-test"
   spec.add_development_dependency "test-unit"
   spec.add_runtime_dependency "simplecov"
   spec.add_runtime_dependency "json"

--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "json"
   spec.add_runtime_dependency "redis"
   spec.add_runtime_dependency 'aws-sdk', '~> 2'
+  spec.add_runtime_dependency 'sinatra'
 end

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -9,6 +9,7 @@ require 'coverband/memory_cache_store'
 require 'coverband/base'
 require 'coverband/reporter'
 require 'coverband/middleware'
+require 'coverband/s3_report_writer'
 
 module Coverband
 

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -1,5 +1,6 @@
 require 'redis'
 require 'logger'
+require 'aws-sdk'
 
 require 'coverband/version'
 require 'coverband/configuration'

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -1,6 +1,6 @@
 module Coverband
   class Configuration
-    attr_accessor :redis, :coverage_baseline, :root_paths, :root, :ignore, :percentage, :verbose, :reporter, :stats, :logger, :startup_delay, :baseline_file, :trace_point_events, :include_gems, :memory_caching
+    attr_accessor :redis, :coverage_baseline, :root_paths, :root, :ignore, :percentage, :verbose, :reporter, :stats, :logger, :startup_delay, :baseline_file, :trace_point_events, :include_gems, :memory_caching, :s3_bucket
 
     def initialize
       @root = Dir.pwd

--- a/lib/coverband/reporter.rb
+++ b/lib/coverband/reporter.rb
@@ -139,14 +139,9 @@ module Coverband
       else
         Coverband.configuration.logger.info "report is ready and viewable: open #{SimpleCov.coverage_dir}/index.html"
       end
-      persist_results if Coverband.configuration.s3_bucket
+      S3ReportWriter.new(Coverband.configuration.s3_bucket).persist! if Coverband.configuration.s3_bucket
     end
 
-    def self.persist_results
-      bucket = Aws::S3::Resource.new.bucket(Coverband.configuration.s3_bucket)
-      obj = bucket.object('coverband/index.html')
-      obj.put(body: File.read("#{SimpleCov.coverage_dir}/index.html").gsub("./assets/#{Gem::Specification.find_by_name('simplecov-html').version.version}/", ''))
-    end
 
     def self.merge_existing_coverage(scov_style_report, existing_coverage)
       existing_coverage.each_pair do |key, lines|

--- a/lib/coverband/reporter.rb
+++ b/lib/coverband/reporter.rb
@@ -143,10 +143,9 @@ module Coverband
     end
 
     def self.persist_results
-      s3 = Aws::S3::Resource.new
-      bucket = s3.bucket(Coverband.configuration.s3_bucket)
+      bucket = Aws::S3::Resource.new.bucket(Coverband.configuration.s3_bucket)
       obj = bucket.object('coverband/index.html')
-      obj.put(body: File.read("#{SimpleCov.coverage_dir}/index.html").gsub("./assets/0.10.0/", ''))
+      obj.put(body: File.read("#{SimpleCov.coverage_dir}/index.html").gsub("./assets/#{Gem::Specification.find_by_name('simplecov-html').version.version}/", ''))
     end
 
     def self.merge_existing_coverage(scov_style_report, existing_coverage)

--- a/lib/coverband/reporter.rb
+++ b/lib/coverband/reporter.rb
@@ -146,7 +146,7 @@ module Coverband
       s3 = Aws::S3::Resource.new
       bucket = s3.bucket(Coverband.configuration.s3_bucket)
       obj = bucket.object('coverband/index.html')
-      obj.put(body: File.read("#{SimpleCov.coverage_dir}/index.html"))
+      obj.put(body: File.read("#{SimpleCov.coverage_dir}/index.html").gsub("./assets/0.10.0/", ''))
     end
 
     def self.merge_existing_coverage(scov_style_report, existing_coverage)

--- a/lib/coverband/s3_report_writer.rb
+++ b/lib/coverband/s3_report_writer.rb
@@ -1,0 +1,30 @@
+class S3ReportWriter
+
+  def initialize(bucket_name)
+    @bucket_name = bucket_name
+  end
+
+  def persist!
+    object.put(body: coverage_content)
+  end
+
+  private
+
+  def coverage_content
+    File.read("#{SimpleCov.coverage_dir}/index.html").gsub("./assets/#{Gem::Specification.find_by_name('simplecov-html').version.version}/", '')
+  end
+
+  def object
+    bucket.object('coverband/index.html')
+  end
+
+  def s3
+    Aws::S3::Resource.new
+  end
+
+  def bucket
+    s3.bucket(@bucket_name)
+  end
+
+
+end

--- a/lib/coverband/s3_web.rb
+++ b/lib/coverband/s3_web.rb
@@ -7,7 +7,7 @@ module Coverband
     set :public_folder, proc { File.expand_path('public', Gem::Specification.find_by_name('simplecov-html').full_gem_path) }
 
     get '/' do
-      s3.get_object(bucket:'vts-temp', key:'coverband/index.html').body.read
+      s3.get_object(bucket: Coverband.configuration.s3_bucket, key:'coverband/index.html').body.read
     end
 
     private

--- a/lib/coverband/s3_web.rb
+++ b/lib/coverband/s3_web.rb
@@ -7,8 +7,13 @@ module Coverband
     set :public_folder, proc { File.expand_path('public', Gem::Specification.find_by_name('simplecov-html').full_gem_path) }
 
     get '/' do
-      s3 = Aws::S3::Client.new
       s3.get_object(bucket:'vts-temp', key:'coverband/index.html').body.read
+    end
+
+    private
+
+    def s3
+      @s3 ||= Aws::S3::Client.new
     end
 
   end

--- a/lib/coverband/s3_web.rb
+++ b/lib/coverband/s3_web.rb
@@ -1,0 +1,16 @@
+require 'sinatra/base'
+
+module Coverband
+
+  class S3Web < Sinatra::Base
+
+    set :public_folder, proc { File.expand_path('public', Gem::Specification.find_by_name('simplecov-html').full_gem_path) }
+
+    get '/' do
+      s3 = Aws::S3::Client.new
+      s3.get_object(bucket:'vts-temp', key:'coverband/index.html').body.read
+    end
+
+  end
+
+end

--- a/test/unit/s3_report_writer_test.rb
+++ b/test/unit/s3_report_writer_test.rb
@@ -1,0 +1,21 @@
+require File.expand_path('../test_helper', File.dirname(__FILE__))
+
+module Coverband
+
+  class S3ReportWriterTest < Test::Unit::TestCase
+
+    test 'it writes the coverage report to s3' do
+      s3 = mock('s3_resource')
+      bucket = mock('bucket')
+      object = mock('object')
+      s3.expects(:bucket).with('coverage-bucket').returns(bucket)
+      bucket.expects(:object).with('coverband/index.html').returns(object)
+      File.expects(:read).with("#{SimpleCov.coverage_dir}/index.html").returns("content ./assets/#{Gem::Specification.find_by_name('simplecov-html').version.version}/")
+      object.expects(:put).with(body: 'content ')
+      Aws::S3::Resource.expects(:new).returns(s3)
+      S3ReportWriter.new('coverage-bucket').persist!
+    end
+
+  end
+
+end

--- a/test/unit/s3_web_test.rb
+++ b/test/unit/s3_web_test.rb
@@ -1,0 +1,26 @@
+require File.expand_path('../test_helper', File.dirname(__FILE__))
+require File.expand_path('../../lib/coverband/s3_web', File.dirname(__FILE__))
+require 'rack/test'
+
+ENV['RACK_ENV'] = 'test'
+
+module Coverband
+  class S3WebTest < Test::Unit::TestCase
+
+    include Rack::Test::Methods
+
+    def app
+      Coverband::S3Web
+    end
+
+    test 'renders content from the coverband/index.html object' do
+      Coverband.configuration.s3_bucket = 'coverage-bucket'
+      s3 = mock('s3')
+      Aws::S3::Client.expects(:new).returns(s3)
+      s3.expects(:get_object).with(bucket: 'coverage-bucket', key: 'coverband/index.html').returns mock('response', body: mock('body', read: 'content'))
+      get '/'
+      assert last_response.ok?
+      assert_equal 'content', last_response.body
+    end
+  end
+end


### PR DESCRIPTION
This pull request allows for generating and reading coverage results within production.  

1. Simplifies sharing results with others on the team.  https://github.com/danmayer/coverband/issues/42
2. Avoids any complications with generating coverage data within production and generating report within dev

When the s3_bucket configuration is set, coverband will write to the ```coverband/index.html``` object within the s3_bucket.

```ruby
config.s3_bucket = 'yourapp-coverage-bucket'
```

Then mount the ```Coverband::S3Web``` sinatra app within your rails routes.rb.

```ruby
require 'coverband/s3_web'

YourApp::Application.routes.draw do
  authenticate :user, lambda { |u| u.admin? } do
    mount Coverband::S3Web => '/coverband/'
  end
end
```

Now when you run the rake coverband:coverage task, you'll need to ensure that the aws creds are set according the instructions within [aws-sdk](http://docs.aws.amazon.com/sdkforruby/api/index.html).

```bash
AWS_REGION=us-east-1 AWS_ACCESS_KEY_ID=1kdfslkdkd AWS_SECRET_ACCESS_KEY=dfkas93 rake coverband:coverage
```

