### PR TITLE
Fix big data issue.

### DIFF
--- a/lib/coverband/base.rb
+++ b/lib/coverband/base.rb
@@ -167,7 +167,7 @@ module Coverband
             @file_line_usage[file][line] += 1
           end
           file_lines = (@files[file] ||= [])
-          file_lines << line
+          file_lines.push(line) unless file_lines.include?(line)
         end
       end
     end

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -83,4 +83,14 @@ class BaseTest < Test::Unit::TestCase
     coverband.save
   end
 
+  test "tracer should collect uniq line numbers" do
+    dog_file = File.expand_path('./dog.rb', File.dirname(__FILE__))
+    coverband = Coverband::Base.instance.reset_instance
+    coverband.start
+    100.times { Dog.new.bark }
+    assert_equal 1, coverband.instance_variable_get("@files")[dog_file].select{ |i| 3 == i }.count
+    coverband.stop
+    coverband.save
+  end
+
 end


### PR DESCRIPTION
Because we not collect line usage statistics, we can store evaluates lines only once.
I faced with big data issue when couple of iterators over 100 000 records kill the script.
As a result I can not write data into Redis (connection die with ECONNRESET).

So here is the fix and some test.
