### PR TITLE
Use Hash to track line usage instead of Array

### DIFF
--- a/lib/coverband/redis_store.rb
+++ b/lib/coverband/redis_store.rb
@@ -10,7 +10,7 @@ module Coverband
         store_array('coverband', report.keys)
 
         report.each do |file, lines|
-          store_array("coverband.#{file}", lines)
+          store_array("coverband.#{file}", lines.keys)
         end
       end
     end

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -75,7 +75,7 @@ class BaseTest < Test::Unit::TestCase
     coverband.instance_variable_set("@verbose", true)
     store = Coverband::RedisStore.new(Redis.new)
     coverband.instance_variable_set("@reporter", store)
-    store.expects(:store_report).once.with(has_entries(dog_file => [3]) )
+    store.expects(:store_report).once.with(has_entries(dog_file => { 3 => 5 }) )
     assert_equal false, coverband.instance_variable_get("@enabled")
     coverband.start
     5.times { Dog.new.bark }
@@ -83,12 +83,12 @@ class BaseTest < Test::Unit::TestCase
     coverband.save
   end
 
-  test "tracer should collect uniq line numbers" do
+  test "tracer should count line numbers" do
     dog_file = File.expand_path('./dog.rb', File.dirname(__FILE__))
     coverband = Coverband::Base.instance.reset_instance
     coverband.start
     100.times { Dog.new.bark }
-    assert_equal 1, coverband.instance_variable_get("@files")[dog_file].select{ |i| 3 == i }.count
+    assert_equal 100, coverband.instance_variable_get("@file_line_usage")[dog_file][3]
     coverband.stop
     coverband.save
   end

--- a/test/unit/memory_cache_store_test.rb
+++ b/test/unit/memory_cache_store_test.rb
@@ -9,12 +9,14 @@ module Coverband
       @memory_store = MemoryCacheStore.new(@store)
     end
 
+    def data
+      {
+        'file1' => { 3 => 1, 5 => 2 },
+        'file2' => { 1 => 1, 2 => 1 }
+      }
+    end
 
     test 'it passes data into store' do
-      data = {
-        'file1' => [ 3, 5 ],
-        'file2' => [1, 2]
-      }
       @store.expects(:store_report).with data
       @store.expects(:covered_lines_for_file).with('file1').returns []
       @store.expects(:covered_lines_for_file).with('file2').returns []
@@ -22,10 +24,6 @@ module Coverband
     end
 
     test 'it passes data into store only once' do
-      data = {
-        'file1' => [ 3, 5 ],
-        'file2' => [1, 2]
-      }
       @store.expects(:store_report).once.with data
       @store.expects(:covered_lines_for_file).with('file1').returns []
       @store.expects(:covered_lines_for_file).with('file2').returns []
@@ -33,32 +31,24 @@ module Coverband
     end
 
     test 'it only passes files and lines we have not hit yet' do
-      first_data = {
-        'file1' => [ 3, 5 ],
-        'file2' => [1, 2]
-      }
       second_data = {
-        'file1' => [ 3, 5, 10 ],
-        'file2' => [1, 2]
+        'file1' => { 3 => 1, 5 => 1, 10 => 1 },
+        'file2' => { 1 => 1, 2 => 1 }
       }
       @store.expects(:covered_lines_for_file).with('file1').returns []
       @store.expects(:covered_lines_for_file).with('file2').returns []
-      @store.expects(:store_report).once.with first_data
+      @store.expects(:store_report).once.with data
       @store.expects(:store_report).once.with(
-        'file1' => [10]
+        'file1' => { 10 => 1 }
       )
-      @memory_store.store_report first_data
+      @memory_store.store_report data
       @memory_store.store_report second_data
     end
 
     test 'it initializes cache with what is in store' do
-      data = {
-        'file1' => [ 3, 5 ],
-        'file2' => [1, 2]
-      }
       @store.expects(:covered_lines_for_file).with('file1').returns [3,5]
       @store.expects(:covered_lines_for_file).with('file2').returns [2]
-      @store.expects(:store_report).with( 'file2' => [1] )
+      @store.expects(:store_report).with('file2' => { 1 => 1 })
       @memory_store.store_report data
     end
 

--- a/test/unit/redis_store_test.rb
+++ b/test/unit/redis_store_test.rb
@@ -22,8 +22,8 @@ class RedisTest < Test::Unit::TestCase
 
   def test_data
     {
-      "/Users/danmayer/projects/cover_band_server/app.rb"=>[54, 55],
-      "/Users/danmayer/projects/cover_band_server/server.rb"=>[5]
+      "/Users/danmayer/projects/cover_band_server/app.rb" => { 54 => 1, 55 => 2 },
+      "/Users/danmayer/projects/cover_band_server/server.rb" => { 5 => 1 }
     }
   end
 end


### PR DESCRIPTION
Hash#include? is much faster Array#include?

Hash does take more memory than Array, but I think that performance improvement is worth it.

Here is the benchmark that I used: 

And the results (`array` is the current used)

````
Memory Comparison:
            array: :      11840 allocated
             hash: :      50136 allocated - 4.23x more
              set: :      50176 allocated - 4.24x more

Speed Comparasion: 
              set: :      276.3 i/s
             hash: :      275.7 i/s - same-ish: difference falls within error
            array: :       34.4 i/s - 8.04x  slower
````

By using Hash we also get line usage count for free (related to #23), since using a simple Set is not better than Hash.