### PR TITLE
Add disable_on_failure feature

### DIFF
--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -4,7 +4,8 @@ module Coverband
     attr_accessor :redis, :root_paths, :root,
                   :ignore, :percentage, :verbose, :reporter, :stats,
                   :logger, :startup_delay, :trace_point_events,
-                  :include_gems, :memory_caching, :s3_bucket, :coverage_file, :store
+                  :include_gems, :memory_caching, :s3_bucket, :coverage_file, :store,
+                  :disable_on_failure_for
 
     # deprecated, but leaving to allow old configs to 'just work'
     # remove for 2.0
@@ -26,6 +27,7 @@ module Coverband
       @memory_caching = false
       @coverage_file = nil
       @store = nil
+      @disable_on_failure_for = nil
     end
 
     def logger


### PR DESCRIPTION
Hi!

Thanks for this software! hoping to delete some unused code soon :)

We've trying to use it in production but by failing to start the Redis service I've found that the web starts failing with 503. We saw huge Redis time since Coverband was waiting for Redis timeouts.

One solution for not having to compromise sampling rate is proposed here: One can optionally configure a prudential time for Coverband to disable itself after a failure. That would allow the service to become available again. While it doesn't you'll get no more than one affected request every `disable_on_failure_for` seconds (per thread).

Test pass but no new test was added for this feature yet. Docs aren't updated either. Will do those if you like the feature and want to merge :)