### PR TITLE
Coverband::Base#sample returns the result of the yield

### DIFF
--- a/lib/coverband/base.rb
+++ b/lib/coverband/base.rb
@@ -21,8 +21,9 @@ module Coverband
     def sample
       configure_sampling
       record_coverage
-      yield
+      result = yield
       report_coverage
+      result
     end
 
     def save

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -93,4 +93,8 @@ class BaseTest < Test::Unit::TestCase
     coverband.save
   end
 
+  test "sample should return the result of the block" do
+    coverband = Coverband::Base.instance.reset_instance
+    assert_equal 2, coverband.sample { 1 + 1 }
+  end
 end


### PR DESCRIPTION
This PR makes `Coverband::Base#sample` return the result of the `yield`. This was especially useful for me when writing a Coverband Sidekiq client middleware, which is as simple as this:

```ruby
class CoverbandSidekiqMiddleware
  def call(*)
    Coverband::Base.instance.sample { yield }
  end
end
```

 According to Sidekiq's design, `call` must return the result of the `yield`.