### PR TITLE
Exclude files in config ignore for baseline

### DIFF
--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sinatra'
   spec.add_development_dependency 'classifier-reborn'
   spec.add_development_dependency 'aws-sdk', '~> 2'
-  spec.add_runtime_dependency "simplecov", '~> 0.11' 
+  spec.add_runtime_dependency "simplecov", '~> 0.11'
   spec.add_runtime_dependency "json"
   # TODO make redis optional dependancy as we add additional adapters
   spec.add_runtime_dependency "redis"

--- a/lib/coverband/baseline.rb
+++ b/lib/coverband/baseline.rb
@@ -4,7 +4,6 @@ module Coverband
     def self.record
       require 'coverage'
       Coverage.start
-      #binding.pry
       yield
 
       project_directory = File.expand_path(Coverband.configuration.root)

--- a/lib/coverband/baseline.rb
+++ b/lib/coverband/baseline.rb
@@ -4,6 +4,7 @@ module Coverband
     def self.record
       require 'coverage'
       Coverage.start
+      #binding.pry
       yield
 
       project_directory = File.expand_path(Coverband.configuration.root)
@@ -15,6 +16,15 @@ module Coverband
 
     def self.parse_baseline(back_compat = nil)
       Coverband.configuration.store.coverage
+    end
+
+    def self.exclude_files(files)
+      Coverband.configuration.ignore.each do |ignore|
+        path = Coverband.configuration.root + "/#{ignore}"
+        excludes = File.directory?(path) ? Dir.glob("#{path}/**/*") : [path]
+        files -= excludes
+      end
+      files
     end
 
     private

--- a/lib/coverband/tasks.rb
+++ b/lib/coverband/tasks.rb
@@ -21,14 +21,16 @@ namespace :coverband do
           end
         end
         if defined? Rails
-          Dir.glob("#{Rails.root}/app/**/*.rb").sort.each { |file| 
+          files = Coverband::Baseline.exclude_files(Dir.glob("#{Rails.root}/app/**/*.rb"))
+          files.sort.each { |file|
               begin
                 require_dependency file
               rescue Exception
                 #ignore
               end }
           if File.exists?("#{Rails.root}/lib")
-            Dir.glob("#{Rails.root}/lib/**/*.rb").sort.each { |file|
+            files = Coverband::Baseline.exclude_files(Dir.glob("#{Rails.root}/lib/**/*.rb"))
+            files.sort.each { |file|
               begin
                 require_dependency file
               rescue Exception
@@ -78,5 +80,4 @@ namespace :coverband do
   task :clear  => :environment do
     Coverband.configuration.store.clear!
   end
-
 end

--- a/test/unit/baseline_test.rb
+++ b/test/unit/baseline_test.rb
@@ -38,6 +38,20 @@ class ReporterTest < Test::Unit::TestCase
     assert_equal(results, {"filename.rb" => [0,nil,1]})
   end
 
+  test "exclude_files" do
+    Coverband.configure do |config|
+      config.redis             = nil
+      config.store             = nil
+      config.root              = '/full/remote_app/path'
+      config.coverage_file     = '/tmp/fake_file.json'
+      config.ignore            = ['ignored_file.rb']
+    end
+    root = Coverband.configuration.root
+    files = [root + '/ignored_file.rb', root + '/fakefile.rb']
+    expected_files =[root + '/fakefile.rb']
+    assert_equal(expected_files, Coverband::Baseline.exclude_files(files))
+  end
+
   # todo test redis and file stores baseline
 
   test "convert_coverage_format" do


### PR DESCRIPTION
👋 This pull request updates the baseline task to exclude files that are excluded by Coverband.configuration.ignore. 

The idea here is two-fold: 
1. Why do we need to include these files in the baseline if they're being ignored in the coverage reporting?

2. Files that get executed on initialization can be added here. This includes stuff like schema's for dummy apps in engines and other executable scripts. Thus - preventing the baseline task from destroying a person's database. 

I'm not sure that this is the final solution to https://github.com/danmayer/coverband/issues/89 - ultimately we should be blocking anything from being executed. But - this is a stopgap and hopefully also seems like a logical addition to the task. 