### PR TITLE
Able to set custom AWS S3 settings for coverband

### DIFF
--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -4,8 +4,8 @@ module Coverband
     attr_accessor :redis, :root_paths, :root,
                   :ignore, :additional_files, :percentage, :verbose, :reporter,
                   :stats, :logger, :startup_delay, :trace_point_events,
-                  :include_gems, :memory_caching, :s3_bucket, :coverage_file, :store,
-                  :disable_on_failure_for
+                  :include_gems, :memory_caching, :coverage_file, :store, :disable_on_failure_for,
+                  :s3_bucket, :s3_region, :s3_access_key_id, :s3_secret_access_key
 
     # deprecated, but leaving to allow old configs to 'just work'
     # remove for 2.0

--- a/lib/coverband/reporters/simple_cov_report.rb
+++ b/lib/coverband/reporters/simple_cov_report.rb
@@ -37,7 +37,12 @@ module Coverband
           Coverband.configuration.logger.info "report is ready and viewable: open #{SimpleCov.coverage_dir}/index.html"
         end
 
-        S3ReportWriter.new(Coverband.configuration.s3_bucket).persist! if Coverband.configuration.s3_bucket
+        s3_writer_options = {
+          region: Coverband.configuration.s3_region,
+          access_key_id: Coverband.configuration.s3_access_key_id,
+          secret_access_key: Coverband.configuration.s3_secret_access_key
+        }
+        S3ReportWriter.new(Coverband.configuration.s3_bucket, s3_writer_options).persist! if Coverband.configuration.s3_bucket
       end
 
     end

--- a/lib/coverband/s3_report_writer.rb
+++ b/lib/coverband/s3_report_writer.rb
@@ -1,7 +1,10 @@
 class S3ReportWriter
 
-  def initialize(bucket_name)
+  def initialize(bucket_name, options = {})
     @bucket_name = bucket_name
+    @region = options[:region]
+    @access_key_id = options[:access_key_id]
+    @secret_access_key = options[:secret_access_key]
     begin
       require 'aws-sdk'
     rescue
@@ -29,7 +32,14 @@ class S3ReportWriter
   end
 
   def s3
-    Aws::S3::Resource.new
+    client_options = {
+      region: @region,
+      access_key_id: @access_key_id,
+      secret_access_key: @secret_access_key
+    }
+    resource_options = { client: Aws::S3::Client.new(client_options) }
+    resource_options = {} if client_options.values.any?(&:nil?)
+    Aws::S3::Resource.new(resource_options)
   end
 
   def bucket

--- a/lib/coverband/s3_web.rb
+++ b/lib/coverband/s3_web.rb
@@ -13,9 +13,16 @@ module Coverband
     private
 
     def s3
-      @s3 ||= Aws::S3::Client.new
+      @s3 ||= begin
+        client_options = {
+          region: Coverband.configuration.s3_region,
+          access_key_id: Coverband.configuration.s3_access_key_id,
+          secret_access_key: Coverband.configuration.s3_secret_access_key
+        }
+        client_options = {} if client_options.values.any?(&:nil?)
+        Aws::S3::Client.new(client_options)
+      end
     end
-
   end
 
 end


### PR DESCRIPTION
Add support for separate AWS S3 settings of region/bucket/key/secret for coverband in case when we don't want to use default AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY. 

Old behaviour, reading from AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY:
```ruby
Coverband.configure do |config|
  ...
  config.s3_bucket = 'bucket_name'
  ...
end
```

New behaviour, set all settings for coverband only:
```ruby
Coverband.configure do |config|
  ...
  config.s3_bucket = ENV['COVERBAND_AWS_BUCKET']
  config.s3_region = ENV['COVERBAND_AWS_REGION']
  config.s3_access_key_id = ENV['COVERBAND_AWS_KEY']
  config.s3_secret_access_key = ENV['COVERBAND_AWS_SECRET']
  ...
end
```

