### PR TITLE
#99 Using the file argument to self.configure in lib/coverband.rb

### DIFF
--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -38,7 +38,7 @@ module Coverband
       if File.exists?(configuration_file)
         require configuration_file
       else
-        raise ArgumentError, "configure requires a block or the existance of a #{CONFIG_FILE} in your project"
+        raise ArgumentError, "configure requires a block, the existance of a #{CONFIG_FILE} in your project, or a path to a config file passed in to configure"
       end
     end
   end

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -29,13 +29,14 @@ module Coverband
   end
 
   def self.configure(file = nil)
+    configuration_file = file || CONFIG_FILE
+
     configuration
     if block_given?
       yield(configuration)
     else
-      if File.exists?(CONFIG_FILE)
-        file ||= CONFIG_FILE
-        require file
+      if File.exists?(configuration_file)
+        require configuration_file
       else
         raise ArgumentError, "configure requires a block or the existance of a #{CONFIG_FILE} in your project"
       end


### PR DESCRIPTION
This allows a caller of Coverband.configure to not only pass in a block or have a file in ./config/coverband.rb, but to put the configuration file anywhere they want and pass it in as an argument. If the argument is unused, then the existing behavior is preserved. This should make it easier to invoke an application that uses Coverband from any working directory.