### PR TITLE
Use Rails.application.eager_load! instead of manually requiring app/**/*.rb and lib/**/*.rb

### DIFF
--- a/lib/coverband/tasks.rb
+++ b/lib/coverband/tasks.rb
@@ -39,12 +39,7 @@ namespace :coverband do
 
       safely_import_files(Coverband.configuration.additional_files.flatten)
 
-      if defined? Rails
-        safely_import_files(Dir.glob("#{Rails.root}/app/**/*.rb"))
-        if File.exists?("#{Rails.root}/lib")
-          safely_import_files(Dir.glob("#{Rails.root}/lib/**/*.rb"))
-        end
-      end
+      Rails.application.eager_load! if defined? Rails
     end
   end
 


### PR DESCRIPTION
See: #97

I think it might be a better idea to use `Rails.application.eager_load!`, which only loads code that your application is actually using. This is safer than loading all Ruby files in `app/**/*.rb` or `lib/**/*.rb`, because these folders might contain some Ruby scripts that could have unintended consequences.