### PR TITLE
Fix type error

### DIFF
--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -58,7 +58,7 @@ module Coverband
       private
 
       def array_diff(latest, original)
-        latest.map.with_index { |v, i| v ? v - original[i] : nil }
+        latest.map.with_index { |v, i| (v && original[i]) ? v - original[i] : nil }
       end
 
       def previous_results

--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -51,6 +51,7 @@ module Coverband
         if @verbose
           @logger.info 'coverage missing'
           @logger.info "error: #{err.inspect} #{err.message}"
+          @logger.info err.backtrace
         end
       end
 

--- a/lib/coverband/collectors/trace.rb
+++ b/lib/coverband/collectors/trace.rb
@@ -23,6 +23,7 @@ module Coverband
         if @verbose
           @logger.info 'error stating recording coverage'
           @logger.info "error: #{err.inspect} #{err.message}"
+          @logger.info err.backtrace
         end
       end
 
@@ -60,6 +61,7 @@ module Coverband
         if @verbose
           @logger.info 'coverage missing'
           @logger.info "error: #{err.inspect} #{err.message}"
+          @logger.info err.backtrace
         end
       end
 


### PR DESCRIPTION
Prevent from `TypeError: nil can't be coerced into Integer` if  `original` array has `nil` value at this index.
