### PR TITLE
fix type mismatch error

### DIFF
--- a/lib/coverband/tasks.rb
+++ b/lib/coverband/tasks.rb
@@ -36,14 +36,14 @@ namespace :coverband do
         require baseline_file if File.exist?(baseline_file)
       end
 
-      safely_import_files(Coverband.configuration.additional_files.flatten)
-
       if defined? Rails
+        Rails.application.eager_load!
         safely_import_files(Dir.glob("#{Rails.root}/app/**/*.rb"))
         if File.exist?("#{Rails.root}/lib")
           safely_import_files(Dir.glob("#{Rails.root}/lib/**/*.rb"))
         end
       end
+      safely_import_files(Coverband.configuration.additional_files.flatten)
     end
   end
 


### PR DESCRIPTION
If you have multiple files with one derived `basic`  class and other 'extension' classes without inheritance, when you run baseline task  you can receive error: `TypeError: superclass mismatch for class classname`.
For example two files:
**a1.rb** 
`
class A1 < TracePoint
end`
**a1_ext.rb** 
`class A1
end`
If you load them in order basic -> extension you get TypeError in `safely_import_files` method. To prevent it i change require order and add  Rails.application.eager_load! for rails env.