### PR TITLE
Normalize memory cache values

### DIFF
--- a/lib/coverband/adapters/memory_cache_store.rb
+++ b/lib/coverband/adapters/memory_cache_store.rb
@@ -36,10 +36,20 @@ module Coverband
 
       def filter(files)
         files.each_with_object({}) do |(file, covered_lines), filtered_file_hash|
-          if covered_lines != cached_file(file)
+          unless coverage_equivalent?(covered_lines, cached_file(file))
             files_cache[file] = covered_lines
             filtered_file_hash[file] = covered_lines
           end
+        end
+      end
+
+      def coverage_equivalent?(coverage1, coverage2)
+        normalized_report(coverage1) == normalized_report(coverage2)
+      end
+
+      def normalized_report(report)
+        report.each_with_object({}) do |(line_number,value), new_report|
+          new_report[line_number] = 1 if value > 0
         end
       end
 

--- a/lib/coverband/adapters/memory_cache_store.rb
+++ b/lib/coverband/adapters/memory_cache_store.rb
@@ -36,7 +36,7 @@ module Coverband
 
       def filter(files)
         files.each_with_object({}) do |(file, covered_lines), filtered_file_hash|
-          unless coverage_equivalent?(covered_lines, cached_file(file))
+          unless coverage_equivalent?(covered_lines, files_cache[file])
             files_cache[file] = covered_lines
             filtered_file_hash[file] = covered_lines
           end
@@ -48,14 +48,10 @@ module Coverband
       end
 
       def normalized_report(report)
-        report.each_with_object({}) do |(line_number,value), new_report|
-          new_report[line_number] = 1 if value > 0
-        end
-      end
-
-      def cached_file(file)
-        files_cache[file]  ||= store.covered_lines_for_file(file).each_with_object({}) do |(line_number, value), hash|
-          hash[line_number.to_i] = value.to_i
+        if report
+          report.each_with_object({}) do |(line_number,value), new_report|
+            new_report[line_number] = 1 if value > 0
+          end
         end
       end
     end

--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -22,9 +22,7 @@ module Coverband
           return
         end
 
-        new_results = nil
-        @semaphore.synchronize { new_results = new_coverage(::Coverage.peek_result.dup) }
-        new_results.each_pair do |file, line_counts|
+        ::Coverage.peek_result.dup.each_pair do |file, line_counts|
           next if @ignored_files.include?(file)
           next unless track_file?(file)
           add_file(file, line_counts)
@@ -56,36 +54,6 @@ module Coverband
       end
 
       private
-
-      def array_diff(latest, original)
-        latest.map.with_index { |v, i| (v && original[i]) ? v - original[i] : nil }
-      end
-
-      def previous_results
-        @@previous_results
-      end
-
-      def add_previous_results(val)
-        @@previous_results = val
-      end
-
-      def new_coverage(current_coverage)
-        if previous_results
-          new_results = {}
-          current_coverage.each_pair do |file, line_counts|
-            if previous_results[file]
-              new_results[file] = array_diff(line_counts, previous_results[file])
-            else
-              new_results[file] = line_counts
-            end
-          end
-        else
-          new_results = current_coverage
-        end
-
-        add_previous_results(current_coverage)
-        new_results.dup
-      end
 
       # TODO this seems like a dumb conversion for the already good coverage format
       # coverage is 0 based other implementation matches line number

--- a/test/unit/adapters_memory_cache_store_test.rb
+++ b/test/unit/adapters_memory_cache_store_test.rb
@@ -30,25 +30,42 @@ module Coverband
       @store.expects(:save_report).once.with data
       2.times { @memory_store.save_report data }
     end
+
     
     test 'it filters coverage for files with same exact data' do
  
+      report_first_request = {
+        'file1' => { 1 => 0, 2 => 1, 3 => 0 },
+        'file2' => { 1 => 5, 2 => 2, 3 => 0 }
+      }
+
+      report_second_request = {
+        'file1' => { 1 => 0, 2 => 1, 3 => 0 },
+        'file2' => { 1 => 5, 2 => 3, 3 => 1 }
+      }
+      @store.expects(:save_report).with({
+        'file1' => { 1 => 0, 2 => 1, 3 => 0 },
+        'file2' => { 1 => 5, 2 => 2, 3 => 0 }
+      })
+      @store.expects(:save_report).with({
+        'file2' => { 1 => 5, 2 => 3, 3 => 1 }
+      })
+      @memory_store.save_report(report_first_request)
+      @memory_store.save_report(report_second_request)
+    end
+
+    test 'it filters coverage for files with the same lines being hit' do
+
       report_first_request = {
         'file1' => { 1 => 0, 2 => 1, 3 => 0 },
         'file2' => { 1 => 5, 2 => 2 }
       }
 
       report_second_request = {
-        'file1' => { 1 => 0, 2 => 1, 3 => 0 },
-        'file2' => { 1 => 5, 2 => 3 }
+        'file1' => { 1 => 0, 2 => 2, 3 => 0 },
+        'file2' => { 1 => 6, 2 => 3 }
       }
-      @store.expects(:save_report).with({
-        'file1' => { 1 => 0, 2 => 1, 3 => 0 },
-        'file2' => { 1 => 5, 2 => 2 }
-      })
-      @store.expects(:save_report).with({
-        'file2' => { 1 => 5, 2 => 3 }
-      })
+      @store.expects(:save_report).once.with report_first_request
       @memory_store.save_report(report_first_request)
       @memory_store.save_report(report_second_request)
     end

--- a/test/unit/adapters_memory_cache_store_test.rb
+++ b/test/unit/adapters_memory_cache_store_test.rb
@@ -69,15 +69,5 @@ module Coverband
       @memory_store.save_report(report_first_request)
       @memory_store.save_report(report_second_request)
     end
-
-    test 'it initializes cache with what is in store' do
-      data = {
-        'file1' => { 1 => 0, 2 => 1, 3 => 0 },
-        'file2' => { 1 => 5, 2 => 2 }
-      }
-      Coverband::Adapters::RedisStore.new(@redis).save_report(data)
-      @store.expects(:save_report).never
-      @memory_store.save_report(data)
-    end
   end
 end

--- a/test/unit/collectors_coverage_test.rb
+++ b/test/unit/collectors_coverage_test.rb
@@ -103,21 +103,6 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
       coverband.save
     end
 
-    test 'coverage should count line numbers only the new calls' do
-      dog_file = File.expand_path('./dog.rb', File.dirname(__FILE__))
-      coverband.instance_variable_set('@sample_percentage', 100.0)
-      coverband.instance_variable_set('@store', nil)
-      original_count = Coverage.peek_result[dog_file][4]
-      coverband.start
-      100.times { Dog.new.bark }
-      coverband.stop
-      coverband.save
-      assert_equal (original_count + 100), coverband.instance_variable_get('@file_line_usage')[dog_file][5]
-      50.times { Dog.new.bark }
-      coverband.save
-      assert_equal 50, coverband.instance_variable_get('@file_line_usage')[dog_file][5]
-    end
-
     test 'coverage should count line numbers' do
       dog_file = File.expand_path('./dog.rb', File.dirname(__FILE__))
       coverband.instance_variable_set('@sample_percentage', 100.0)


### PR DESCRIPTION
This PR does two things:

First the memory cache filters out files that have no new coverage. Previously the memory cache was not filtering out files that were hitting the same lines over and over since the value of the line was being incremented.

Second, this PR removes the difference calculation on the coverage collector. With the memory cache enabled, I'm not sure why we would need something calculating the difference in coverage. I think we can just send the latest coverage from ruby ::Coverage.peek_result to the underlying store. If we go with this approach perhaps we should always have memory cache enabled?