### PR TITLE
Ignore "docs" folder when building the gem

### DIFF
--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/danmayer/coverband'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files`.split("\n")
+  spec.files         = `git ls-files`.split("\n").reject { |f| f.start_with?('docs') }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']


### PR DESCRIPTION
No need to release 24 MB of gif files.

Fixes #122