### PR TITLE
pipeline redis operations to decrease overhead of repeated calls

### DIFF
--- a/test/unit/adapters_redis_store_test.rb
+++ b/test/unit/adapters_redis_store_test.rb
@@ -17,13 +17,13 @@ class RedisTest < Test::Unit::TestCase
 
   def test_coverage
     @redis.sadd(BASE_KEY, 'dog.rb')
-    @store.send(:store_map, "#{BASE_KEY}.dog.rb", example_hash)
-    expected = { 'dog.rb' => example_hash }
+    @store.send(:pipelined_save, combined_report)
+    expected = {'dog.rb' => example_hash}
     assert_equal expected, @store.coverage
   end
 
   def test_covered_lines_for_file
-    @store.send(:store_map, "#{BASE_KEY}.dog.rb", example_hash)
+    @store.send(:pipelined_save, combined_report)
     assert_equal [["1", "1"], ["2", "2"]], @store.covered_lines_for_file('dog.rb').sort
   end
 
@@ -46,6 +46,15 @@ class RedisTest < Test::Unit::TestCase
   end
 
   private
+
+  def combined_report
+    {
+      "#{BASE_KEY}.dog.rb" => {
+        new: example_hash,
+        existing: {}
+      }
+    }
+  end
 
   def test_data
     {

--- a/test/unit/reports_console_test.rb
+++ b/test/unit/reports_console_test.rb
@@ -15,6 +15,15 @@ class SimpleCovReportTest < Test::Unit::TestCase
     {'1' => '1', '2' => '2'}
   end
 
+  def combined_report
+    {
+      "#{BASE_KEY}.test/unit/dog.rb" => {
+        new: example_hash,
+        existing: {}
+      }
+    }
+  end
+
   test 'report data' do
     Coverband.configure do |config|
       config.redis             = @redis
@@ -25,7 +34,7 @@ class SimpleCovReportTest < Test::Unit::TestCase
     Coverband::Reporters::ConsoleReport.expects(:current_root).returns('./test/unit')
 
     @redis.sadd(BASE_KEY, 'test/unit/dog.rb')
-    @store.send(:store_map, "#{BASE_KEY}.test/unit/dog.rb", example_hash)
+    @store.send(:pipelined_save, combined_report)
 
     report = Coverband::Reporters::ConsoleReport.report(@store)
     expected = {"test/unit/dog.rb"=>[1, 2, nil, nil, nil, nil, nil]}


### PR DESCRIPTION
made to address performance concerns raised here: https://github.com/danmayer/coverband/issues/124 . Redis operations are pipelined (batched) so that only two calls total are made when saving report, instead of 2 calls per file in report.