### PR TITLE
Filter out files with no coverage

### DIFF
--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -36,7 +36,7 @@ module Coverband
         end
 
         if @store
-          @store.save_report(@file_line_usage)
+          @store.save_report(files_with_line_usage)
           @file_line_usage.clear
         elsif @verbose
           @logger.debug 'coverage report: '
@@ -56,6 +56,12 @@ module Coverband
       end
 
       private
+
+      def files_with_line_usage
+        @file_line_usage.select do |_file_name, coverage|
+          coverage.values.any? { |value| value != 0 }
+        end
+      end
 
       def array_diff(latest, original)
         latest.map.with_index { |v, i| (v && original[i]) ? v - original[i] : nil }


### PR DESCRIPTION
With rails eager loading on, I notice that 95-99% of the files being reported to redis have no coverage data but we are still sending requests to redis for these files. I have a hunch that this will solve many people's performance issues after the first request.