### PR TITLE
Include checksum as part of key for each file in store

### DIFF
--- a/test/unit/adapters_redis_store_test.rb
+++ b/test/unit/adapters_redis_store_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require File.expand_path('../test_helper', File.dirname(__FILE__))
+require File.expand_path('./dummy_checksum_generator', File.dirname(__FILE__))
 
 class RedisTest < Test::Unit::TestCase
   BASE_KEY = Coverband::Adapters::RedisStore::BASE_KEY
@@ -12,22 +13,33 @@ class RedisTest < Test::Unit::TestCase
   def setup
     @redis = Redis.new
     @redis.flushdb
-    @store = Coverband::Adapters::RedisStore.new(@redis)
+    @store = Coverband::Adapters::RedisStore.new(
+      @redis,
+      checksum_generator: DummyChecksumGenerator.new('fakechecksum')
+    )
+  end
+
+  def test_invalidation_on_file_change
+    @store.instance_variable_set(:@checksum_generator, DummyChecksumGenerator.new('1234'))
+    @store.save_report('lib/puppy.rb' => { 54 => 1, 55 => 0 })
+    @store.instance_variable_set(:@checksum_generator, DummyChecksumGenerator.new('234'))
+    @store.save_report('lib/puppy.rb' => { 54 => 0, 55 => 1 })
+    assert_equal({ '54' => '0', '55' => '1' }, @store.covered_lines_for_file('lib/puppy.rb'))
   end
 
   def test_coverage
     @redis.sadd(BASE_KEY, 'dog.rb')
-    @store.send(:store_map, "#{BASE_KEY}.dog.rb", example_hash)
+    @store.send(:store_map, "#{BASE_KEY}.dog.rb", 'fakechecksum', example_hash)
     expected = { 'dog.rb' => example_hash }
     assert_equal expected, @store.coverage
   end
 
   def test_covered_lines_for_file
-    @store.send(:store_map, "#{BASE_KEY}.dog.rb", example_hash)
+    @store.send(:store_map, "#{BASE_KEY}.dog.rb", 'fakechecksum', example_hash)
     assert_equal [["1", "1"], ["2", "2"]], @store.covered_lines_for_file('dog.rb').sort
   end
 
-  def test_covered_lines_for_file__hash
+  def test_covered_lines_for_file_hash
     @redis.mapped_hmset("#{BASE_KEY}.dog.rb", '1' => 1, '2' => 2)
     @store = Coverband::Adapters::RedisStore.new(@redis)
     expected = [%w[1 1], %w[2 2]]
@@ -60,8 +72,9 @@ class RedisStoreTestV3Hash < RedisTest
     @redis = Redis.current.tap do |redis|
       redis.stubs(:sadd).with(anything, anything)
     end
+    @redis.flushdb
 
-    @store = Coverband::Adapters::RedisStore.new(@redis)
+    @store = Coverband::Adapters::RedisStore.new(@redis, checksum_generator: DummyChecksumGenerator.new('fakechecksum'))
   end
 
   test 'it stores the files into coverband' do
@@ -76,11 +89,11 @@ class RedisStoreTestV3Hash < RedisTest
   test 'it stores the file lines of the file app.rb' do
       @redis.expects(:mapped_hmset).with(
       "#{BASE_KEY}./Users/danmayer/projects/cover_band_server/app.rb",
-      '54' => 1, '55' => 2
+      '54' => 1, '55' => 2, 'checksum' => 'fakechecksum'
     )
     @redis.expects(:mapped_hmset).with(
       "#{BASE_KEY}./Users/danmayer/projects/cover_band_server/server.rb",
-      '5' => 1
+        '5' => 1, 'checksum' => 'fakechecksum'
     )
 
     @store.save_report(test_data)

--- a/test/unit/dummy_checksum_generator.rb
+++ b/test/unit/dummy_checksum_generator.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class DummyChecksumGenerator
+  def initialize(checksum)
+    @checksum = checksum
+  end
+
+  def generate(file)
+    @checksum
+  end
+end
+

--- a/test/unit/reports_console_test.rb
+++ b/test/unit/reports_console_test.rb
@@ -25,10 +25,11 @@ class SimpleCovReportTest < Test::Unit::TestCase
     Coverband::Reporters::ConsoleReport.expects(:current_root).returns('./test/unit')
 
     @redis.sadd(BASE_KEY, 'test/unit/dog.rb')
-    @store.send(:store_map, "#{BASE_KEY}.test/unit/dog.rb", example_hash)
+    @store.send(:store_map, "#{BASE_KEY}.test/unit/dog.rb",
+                Digest::MD5.file('test/unit/dog.rb'), example_hash)
 
     report = Coverband::Reporters::ConsoleReport.report(@store)
-    expected = {"test/unit/dog.rb"=>[1, 2, nil, nil, nil, nil, nil]}
+    expected = { 'test/unit/dog.rb' => [1, 2, nil, nil, nil, nil, nil] }
     assert_equal(expected, report)
   end
 end

--- a/test/unit/reports_simple_cov_test.rb
+++ b/test/unit/reports_simple_cov_test.rb
@@ -26,7 +26,7 @@ class ReportsSimpleCovTest < Test::Unit::TestCase
     Coverband.configuration.logger.stubs('info')
 
     @redis.sadd(BASE_KEY, 'test/unit/dog.rb')
-    @store.send(:store_map, "#{BASE_KEY}.test/unit/dog.rb", example_hash)
+    @store.send(:store_map, 'fakechecksum', "#{BASE_KEY}.test/unit/dog.rb", example_hash)
 
     SimpleCov.expects(:track_files)
     SimpleCov.expects(:add_not_loaded_files).returns({})
@@ -48,7 +48,7 @@ class ReportsSimpleCovTest < Test::Unit::TestCase
     Coverband::Reporters::SimpleCovReport.expects(:current_root).at_least_once.returns('/tmp/root_dir')
 
     @redis.sadd(BASE_KEY, 'test/unit/dog.rb')
-    @store.send(:store_map, "#{BASE_KEY}.test/unit/dog.rb", example_hash)
+    @store.send(:store_map, 'fakechecksum', "#{BASE_KEY}.test/unit/dog.rb", example_hash)
     SimpleCov.expects(:track_files)
     SimpleCov.expects(:add_not_loaded_files).returns('fake_file.rb' => [1])
     SimpleCov::Result.any_instance.expects(:format!)


### PR DESCRIPTION
Fixes: https://github.com/danmayer/coverband/issues/118

This PR adds a checksum key to each file in redis. The checksum is computed with with the contents of the file. Before persisting to redis, we determine if the checksum has changed. If so we overwrite the values for the given file in redis, if not we merge them.

Was speaking with @kbaum and we are thinking it makes sense to add a cache for the checksum so we don't have to compute the hash every time.