### PR TITLE
use md5 to avoid coverage drift on changes

### DIFF
--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -4,36 +4,78 @@ module Coverband
   module Adapters
     class Base
       def initialize
-        raise 'abstract'
+        @file_hash_cache = {}
       end
 
       def clear!
         raise 'abstract'
       end
 
-      def save_report(_report)
-        raise 'abstract'
+      # Note: This could lead to slight race on redis
+      # where multiple processes pull the old coverage and add to it then push
+      # the Coverband 2 had the same issue,
+      # and the tradeoff has always been acceptable
+      def save_report(report)
+        data = report.dup
+        merge_reports(data, get_full_report)
+        save_coverage(data)
       end
 
       def coverage
-        raise 'abstract'
+        simple_report(get_full_report)
       end
 
       def covered_files
-        raise 'abstract'
+        coverage.keys || []
       end
 
-      def covered_lines_for_file(_file)
-        raise 'abstract'
+      def covered_lines_for_file(file)
+        coverage[file] || []
       end
 
       protected
 
+      def save_coverage
+        raise 'abstract'
+      end
+
+      def get_report
+        raise 'abstract'
+      end
+
+      def get_full_report
+        get_report
+      end
+
+      def file_hash(file)
+        if @file_hash_cache[file]
+          @file_hash_cache[file]
+        else
+          @file_hash_cache[file] = Digest::MD5.file(file).hexdigest
+        end
+      end
+
+      def expand_report(report)
+        report.each_pair do |key, line_data|
+          extended_data = {
+            'first_updated_at' => Time.now.to_i,
+            'last_updated_at' => Time.now.to_i,
+            'file_hash' => file_hash(key),
+            'data' => line_data
+          }
+          report[key] = extended_data
+        end
+        report
+      end
+
       def merge_reports(new_report, old_report)
+        new_report = expand_report(new_report)
         keys = (new_report.keys + old_report.keys).uniq
         keys.each do |file|
-          new_report[file] = if new_report[file] && old_report[file]
-                               array_add(new_report[file], old_report[file])
+          new_report[file] = if new_report[file] &&
+                                old_report[file] &&
+                                new_report[file]['file_hash'] == old_report[file]['file_hash']
+                               merge_expanded_data(new_report[file], old_report[file])
                              elsif new_report[file]
                                new_report[file]
                              else
@@ -43,8 +85,25 @@ module Coverband
         new_report
       end
 
+      def merge_expanded_data(new_expanded, old_expanded)
+        {
+          'first_updated_at' => old_expanded['first_updated_at'],
+          'last_updated_at' => new_expanded['last_updated_at'],
+          'file_hash' => new_expanded['file_hash'],
+          'data' => array_add(new_expanded['data'], old_expanded['data'])
+        }
+      end
+
       def array_add(latest, original)
         latest.map.with_index { |v, i| (v && original[i]) ? v + original[i] : nil }
+      end
+
+      def simple_report(report)
+        simple = {}
+        report.each_pair do |key, extended_data|
+          simple[key] = extended_data['data']
+        end
+        simple
       end
     end
   end

--- a/lib/coverband/adapters/file_store.rb
+++ b/lib/coverband/adapters/file_store.rb
@@ -8,9 +8,8 @@ module Coverband
     # Not recommended for production deployment
     ###
     class FileStore < Base
-      attr_accessor :path
-
       def initialize(path, _opts = {})
+        super()
         @path = path
 
         config_dir = File.dirname(@path)
@@ -21,32 +20,15 @@ module Coverband
         File.delete(path) if File.exist?(path)
       end
 
-      def save_report(report)
-        merge_reports(report, coverage)
-        save_coverage(report)
-      end
-
-      def coverage
-        existing_data(path)
-      end
-
-      def covered_files
-        report = existing_data(path)
-        existing_data(path).merge(report).keys || []
-      end
-
-      def covered_lines_for_file(file)
-        report = existing_data(path)
-        report[file] || []
-      end
-
       private
+
+      attr_accessor :path
 
       def save_coverage(report)
         File.open(path, 'w') { |f| f.write(report.to_json) }
       end
 
-      def existing_data(path)
+      def get_report
         if File.exist?(path)
           JSON.parse(File.read(path))
         else

--- a/lib/coverband/version.rb
+++ b/lib/coverband/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Coverband
-  VERSION = '3.0.0'
+  VERSION = '3.0.1.alpha'
 end

--- a/test/benchmarks/benchmark.rake
+++ b/test/benchmarks/benchmark.rake
@@ -169,6 +169,18 @@ namespace :benchmarks do
   def reporting_speed
     report = fake_report
     store = benchmark_redis_store
+    store.clear!
+
+    ###
+    # this is a hack because in the benchmark we don't have real files
+    ###
+    def store.file_hash(file)
+      if @file_hash_cache[file]
+        @file_hash_cache[file]
+      else
+        @file_hash_cache[file] = Digest::MD5.file(__FILE__).hexdigest
+      end
+    end
 
     5.times { store.save_report(report) }
     Benchmark.ips do |x|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,6 +37,12 @@ def test(name, &block)
   end
 end
 
+def mock_file_hash
+  mock_file = mock('mock_file')
+  mock_file.expects(:hexdigest).at_least_once.returns('abcd')
+  Digest::MD5.expects(:file).at_least_once.returns(mock_file)
+end
+
 def example_line
   [0, 1, 2]
 end

--- a/test/unit/adapters_base_test.rb
+++ b/test/unit/adapters_base_test.rb
@@ -6,23 +6,44 @@ class AdaptersBaseTest < Test::Unit::TestCase
   def setup
     @test_file_path = '/tmp/coverband_filestore_test_path.json'
     @store = Coverband::Adapters::FileStore.new(@test_file_path)
+    mock_file_hash
   end
 
   def test_covered_merge
-    old_report = { '/Users/danmayer/projects/coverband_demo/config/coverband.rb' => [5, 7, nil],
-                   '/Users/danmayer/projects/coverband_demo/config/initializers/assets.rb' => [5, 5, nil],
-                   '/Users/danmayer/projects/coverband_demo/config/initializers/cookies_serializer.rb' => [5, 5, nil] }
-    new_report = { '/Users/danmayer/projects/coverband_demo/config/coverband.rb' => [5, 7, nil],
-                   '/Users/danmayer/projects/coverband_demo/config/initializers/filter_logging.rb' => [5, 5, nil],
-                   '/Users/danmayer/projects/coverband_demo/config/initializers/wrap_parameters.rb' => [5, 5, nil],
-                   '/Users/danmayer/projects/coverband_demo/app/controllers/application_controller.rb' => [5, 5, nil] }
+    old_time = 1541958097
+    current_time = Time.now.to_i
+    old_data = {
+      'first_updated_at' => old_time,
+      'last_updated_at' => current_time,
+      'file_hash' => 'abcd',
+      'data' => [5, 7, nil]
+    }
+    old_report = { '/projects/coverband_demo/config/coverband.rb' => old_data,
+                   '/projects/coverband_demo/config/initializers/assets.rb' => old_data,
+                   '/projects/coverband_demo/config/initializers/cookies_serializer.rb' => old_data }
+    new_report = { '/projects/coverband_demo/config/coverband.rb' => [5, 7, nil],
+                   '/projects/coverband_demo/config/initializers/filter_logging.rb' => [5, 7, nil],
+                   '/projects/coverband_demo/config/initializers/wrap_parameters.rb' => [5, 7, nil],
+                   '/projects/coverband_demo/app/controllers/application_controller.rb' => [5, 7, nil] }
+    expected_merge = {
+      'first_updated_at' => old_time,
+      'last_updated_at' => current_time,
+      'file_hash' => 'abcd',
+      'data' => [10, 14, nil]
+    }
+    new_data = {
+      'first_updated_at' => current_time,
+      'last_updated_at' => current_time,
+      'file_hash' => 'abcd',
+      'data' => [5, 7, nil]
+    }
     expected_result = {
-      '/Users/danmayer/projects/coverband_demo/app/controllers/application_controller.rb' => [5, 5, nil],
-      '/Users/danmayer/projects/coverband_demo/config/coverband.rb' => [10, 14, nil],
-      '/Users/danmayer/projects/coverband_demo/config/initializers/assets.rb' => [5, 5, nil],
-      '/Users/danmayer/projects/coverband_demo/config/initializers/cookies_serializer.rb' => [5, 5, nil],
-      '/Users/danmayer/projects/coverband_demo/config/initializers/filter_logging.rb' => [5, 5, nil],
-      '/Users/danmayer/projects/coverband_demo/config/initializers/wrap_parameters.rb' => [5, 5, nil]
+      '/projects/coverband_demo/app/controllers/application_controller.rb' => new_data,
+      '/projects/coverband_demo/config/coverband.rb' => expected_merge,
+      '/projects/coverband_demo/config/initializers/assets.rb' => old_data,
+      '/projects/coverband_demo/config/initializers/cookies_serializer.rb' => old_data,
+      '/projects/coverband_demo/config/initializers/filter_logging.rb' => new_data,
+      '/projects/coverband_demo/config/initializers/wrap_parameters.rb' => new_data
     }
     assert_equal expected_result, @store.send(:merge_reports, new_report, old_report)
   end

--- a/test/unit/adapters_file_store_test.rb
+++ b/test/unit/adapters_file_store_test.rb
@@ -10,8 +10,8 @@ class AdaptersFileStoreTest < Test::Unit::TestCase
   end
 
   def test_covered_lines_for_file
-    assert_equal @store.covered_lines_for_file('dog.rb')['1'],  1
-    assert_equal @store.covered_lines_for_file('dog.rb')['2'],  2
+    assert_equal @store.covered_lines_for_file('dog.rb')[0],  1
+    assert_equal @store.covered_lines_for_file('dog.rb')[1],  2
   end
 
   def test_covered_lines_when_null
@@ -28,7 +28,8 @@ class AdaptersFileStoreTest < Test::Unit::TestCase
   end
 
   def test_save_report
-    @store.send(:save_report, 'cat.rb' => [0,1])
+    mock_file_hash
+    @store.send(:save_report, 'cat.rb' => [0, 1])
     assert_equal @store.covered_lines_for_file('cat.rb')[1], 1
   end
 
@@ -36,7 +37,10 @@ class AdaptersFileStoreTest < Test::Unit::TestCase
 
   def test_data
     {
-      'dog.rb' => { 1 => 1, 2 => 2 }
+      'dog.rb' => { 'data' => [1, 2, nil],
+                    'file_hash' => 'abcd',
+                    'first_updated_at' => 1541968729,
+                    'last_updated_at' => 1541968729 }
     }
   end
 end

--- a/test/unit/adapters_redis_store_test.rb
+++ b/test/unit/adapters_redis_store_test.rb
@@ -12,27 +12,30 @@ class RedisTest < Test::Unit::TestCase
   end
 
   def test_coverage
+    mock_file_hash
     expected = basic_coverage
     @store.save_report(expected)
     assert_equal expected, @store.coverage
   end
 
   def test_coverage_increments
-    expected = basic_coverage
-    @store.save_report(expected)
+    mock_file_hash
+    expected = basic_coverage.dup
+    @store.save_report(basic_coverage.dup)
     assert_equal expected, @store.coverage
-    @store.save_report(expected)
+    @store.save_report(basic_coverage.dup)
     assert_equal [0, 2, 4], @store.coverage['app_path/dog.rb']
   end
 
   def test_covered_lines_for_file
+    mock_file_hash
     expected = basic_coverage
     @store.save_report(expected)
     assert_equal example_line, @store.covered_lines_for_file('app_path/dog.rb')
   end
 
   def test_covered_lines_when_null
-    assert_equal nil, @store.covered_lines_for_file('app_path/dog.rb')
+    assert_equal [], @store.covered_lines_for_file('app_path/dog.rb')
   end
 
   def test_clear
@@ -41,15 +44,6 @@ class RedisTest < Test::Unit::TestCase
   end
 
   private
-
-  def combined_report
-    {
-      "#{BASE_KEY}.dog.rb" => {
-        new: example_hash,
-        existing: {}
-      }
-    }
-  end
 
   def test_data
     {

--- a/test/unit/reports_console_test.rb
+++ b/test/unit/reports_console_test.rb
@@ -18,6 +18,7 @@ class SimpleCovReportTest < Test::Unit::TestCase
       config.reporting_frequency = 100.0
     end
     Coverband.configuration.logger.stubs('info')
+    mock_file_hash
     Coverband::Reporters::ConsoleReport
       .expects(:current_root)
       .returns('app_path')

--- a/test/unit/reports_simple_cov_test.rb
+++ b/test/unit/reports_simple_cov_test.rb
@@ -11,15 +11,6 @@ class ReportsSimpleCovTest < Test::Unit::TestCase
     @store.clear!
   end
 
-  def combined_report
-    {
-      "#{BASE_KEY}.test/unit/dog.rb" => {
-        new: example_hash,
-        existing: {}
-      }
-    }
-  end
-
   test 'generate scov report' do
     Coverband.configure do |config|
       config.reporter          = 'scov'
@@ -28,6 +19,7 @@ class ReportsSimpleCovTest < Test::Unit::TestCase
       config.ignore            = ['notsomething.rb']
     end
     Coverband.configuration.logger.stubs('info')
+    mock_file_hash
     @store.send(:save_report, basic_coverage)
 
     SimpleCov.expects(:track_files)


### PR DESCRIPTION
OK @dnasseri and @kbaum this takes the ideas from https://github.com/danmayer/coverband/pull/128 but pulls them into Coverband 3 and pushes as much of the logic to the adapter base class, as we don't want to have to do much specific to any given adapter.

I believe this should resolve the drift issue: https://github.com/danmayer/coverband/issues/118

* I need to do a bit more work and review of the benchmarks as I think this does slow things down.
* The report doesn't yet show the additional time information, about the timerange valid for a given file, that will take a bit more work and another PR, but I think we could likely get this in without that. 
     * I am thinking to do that I will need to drop direct dependencies on Simplecov / Simplecov-html
