### PR TITLE
Check for rails server command

### DIFF
--- a/lib/coverband/integrations/rack_server_check.rb
+++ b/lib/coverband/integrations/rack_server_check.rb
@@ -3,7 +3,25 @@
 module Coverband
   class RackServerCheck
     def self.running?
-      Kernel.caller_locations.any? { |line| line.path.include?('lib/rack/') }
+      new(Kernel.caller_locations).running?
+    end
+
+    def initialize(stack)
+      @stack = stack
+    end
+
+    def running?
+      rack_server? || rails_server?
+    end
+
+    def rack_server?
+      @stack.any? { |line| line.path.include?('lib/rack/') }
+    end
+
+    def rails_server?
+      @stack.any? do |location|
+        location.path.include?('rails/commands/commands_tasks.rb') && location.label == 'server'
+      end
     end
   end
 end

--- a/test/unit/rack_server_checkout_test.rb
+++ b/test/unit/rack_server_checkout_test.rb
@@ -5,14 +5,20 @@ require File.expand_path('../test_helper', File.dirname(__FILE__))
 class RackServerCheckTest < Test::Unit::TestCase
 
   test 'returns true when running in rack server' do
-    caller_locations = ['blah/lib/rack/server.rb'].map{ |path| OpenStruct.new(path: path) }
+    caller_locations = ['blah/lib/rack/server.rb'].map{ |path| OpenStruct.new(path: path, label: 'foo') }
     Kernel.expects(:caller_locations).returns(caller_locations)
     assert_true(Coverband::RackServerCheck.running?)
   end
 
   test 'returns false when not running in rack server' do
-    caller_locations = ['blah/lib/sidekiq/worker.rb'].map{ |path| OpenStruct.new(path: path) }
+    caller_locations = ['blah/lib/sidekiq/worker.rb'].map{ |path| OpenStruct.new(path: path, label: 'foo') }
     Kernel.expects(:caller_locations).returns(caller_locations)
     assert_false(Coverband::RackServerCheck.running?)
+  end
+
+  test 'returns true if running within a rails server' do
+    caller_locations = [OpenStruct.new(path: '/lib/rails/commands/commands_tasks.rb', label: 'server')] 
+    Kernel.expects(:caller_locations).returns(caller_locations)
+    assert_true(Coverband::RackServerCheck.running?)
   end
 end


### PR DESCRIPTION
Noticed that when starting with rails s on a rails 4 project for some
reason rack was not in the stack. This pull request looks for the rails
commands/commands_tasks server method. If it finds this method it delays
early start and waits until the rack middleware kicks off the thread on
first request.