### PR TITLE
Fix test race condition

### DIFF
--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -29,8 +29,7 @@ module Coverband
   end
 
   def self.configure(file = nil)
-    configuration_file = file || CONFIG_FILE
-
+    configuration_file = file || ENV.fetch('COVERBAND_CONFIG', CONFIG_FILE)
     configuration
     if block_given?
       yield(configuration)

--- a/lib/coverband/integrations/background.rb
+++ b/lib/coverband/integrations/background.rb
@@ -4,6 +4,15 @@ module Coverband
   class Background
     @semaphore = Mutex.new
 
+    def self.stop
+      @semaphore.synchronize do
+        if @thread
+          @thread.exit
+          @background_reporting_running = false
+        end
+      end
+    end
+
     def self.start
       return if @background_reporting_running
 
@@ -14,7 +23,7 @@ module Coverband
 
         @background_reporting_running = true
         sleep_seconds = Coverband.configuration.background_reporting_sleep_seconds
-        Thread.new do
+        @thread = Thread.new do
           loop do
             Coverband::Collectors::Coverage.instance.report_coverage(true)
             logger&.debug("Coverband: Reported coverage via thread. Sleeping #{sleep_seconds}s") if Coverband.configuration.verbose

--- a/test/rails4_dummy/config/coverband.rb
+++ b/test/rails4_dummy/config/coverband.rb
@@ -3,6 +3,6 @@ Coverband.configure do |config|
   config.store             = Coverband::Adapters::RedisStore.new(Redis.new(url: ENV['REDIS_URL'])) if defined? Redis
   config.ignore            = %w[vendor .erb$ .slim$]
   config.root_paths        = []
-  config.reporting_frequency = 100.0
   config.logger              = Rails.logger
+  config.background_reporting_sleep_seconds = 0.1
 end

--- a/test/rails5_dummy/config/coverband.rb
+++ b/test/rails5_dummy/config/coverband.rb
@@ -3,6 +3,7 @@ Coverband.configure do |config|
   config.store             = Coverband::Adapters::RedisStore.new(Redis.new(url: ENV['REDIS_URL'])) if defined? Redis
   config.ignore            = %w[vendor .erb$ .slim$]
   config.root_paths        = []
-  config.reporting_frequency = 100.0
-  config.logger              = Rails.logger
+  config.logger            = Rails.logger
+  config.verbose           = true
+  config.background_reporting_sleep_seconds = 0.1
 end

--- a/test/rails_test_helper.rb
+++ b/test/rails_test_helper.rb
@@ -1,11 +1,6 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 require 'rails'
+ENV['COVERBAND_CONFIG'] = "./test/rails#{Rails::VERSION::MAJOR}_dummy/config/coverband.rb"
 require File.expand_path('./test_helper', File.dirname(__FILE__))
-
-if Rails::VERSION::MAJOR >= 5
-  require_relative "../test/rails5_dummy/config/environment"
-else
-  require_relative "../test/rails4_dummy/config/environment"
-end
-
+require_relative "../test/rails#{Rails::VERSION::MAJOR}_dummy/config/environment"

--- a/test/unit/background_test.rb
+++ b/test/unit/background_test.rb
@@ -8,6 +8,7 @@ class BackgroundTest < Test::Unit::TestCase
     Coverband.configure do |config|
       config.store = Coverband::Adapters::RedisStore.new(Redis.new)
       config.background_reporting_enabled = true
+      config.background_reporting_sleep_seconds = 30
     end
     Coverband::Background.instance_variable_set(:@background_reporting_running, nil)
   end

--- a/test/unit/rails_full_stack_test.rb
+++ b/test/unit/rails_full_stack_test.rb
@@ -7,10 +7,16 @@ class RailsFullStackTest < ActionDispatch::IntegrationTest
     Coverband.configuration.store.clear!
   end
 
+  def teardown
+    Coverband::Background.stop
+    ENV['COVERBAND_CONFIG'] = nil
+  end
+
   test 'this is how we do it' do
     get '/dummy/show'
     assert_response :success
     assert_equal 'I am no dummy', response.body
+    sleep 0.2
     assert_equal [1, 1, 1, nil, nil], Coverband.configuration.store.coverage["#{Rails.root}/app/controllers/dummy_controller.rb"]
   end
 


### PR DESCRIPTION
When running this test alone, it would fail. 

```
➜  coverband git:(master) bundle exec m test/unit/rails_full_stack_test.rb
Run options: -n "/^(test_this_is_how_we_do_it|test_memory_usage)$/" --seed 28906

# Running:

.F

Failure:
RailsFullStackTest#test_this_is_how_we_do_it [/Users/karlbaum/workspace/coverband/test/unit/rails_full_stack_test.rb:14]:
Expected: [1, 1, 1, nil, nil]
  Actual: nil
```

When running with rake test it would pass. I am not sure why it ever passed honestly as it was
depending on a background thread reporting to redis every 30 seconds.