### PR TITLE
Reset coverband config, instance, and background thread

### DIFF
--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -12,6 +12,10 @@ module Coverband
     attr_writer :logger, :s3_region, :s3_bucket, :s3_access_key_id, :s3_secret_access_key
 
     def initialize
+      reset
+    end
+
+    def reset
       @root = Dir.pwd
       @root_paths = []
       @ignore = %w(vendor .erb$ .slim$)

--- a/lib/coverband/integrations/background.rb
+++ b/lib/coverband/integrations/background.rb
@@ -4,6 +4,15 @@ module Coverband
   class Background
     @semaphore = Mutex.new
 
+    def self.stop
+      @semaphore.synchronize do
+        if @thread
+          @thread.exit
+          @background_reporting_running = false
+        end
+      end
+    end
+
     def self.start
       return if @background_reporting_running
 
@@ -14,7 +23,7 @@ module Coverband
 
         @background_reporting_running = true
         sleep_seconds = Coverband.configuration.background_reporting_sleep_seconds
-        Thread.new do
+        @thread = Thread.new do
           loop do
             Coverband::Collectors::Coverage.instance.report_coverage(true)
             logger&.debug("Coverband: Reported coverage via thread. Sleeping #{sleep_seconds}s") if Coverband.configuration.verbose

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,7 @@ end
 
 class Test::Unit::TestCase
   def teardown
+    Coverband.configuration.store.clear!
     Coverband.configuration.reset
     Coverband::Collectors::Coverage.instance.reset_instance
     Coverband::Background.stop

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,13 @@ SimpleCov.start do
   add_filter '/config/'
 end
 
+class Test::Unit::TestCase
+  def teardown
+    Coverband.configuration.reset
+    Coverband::Collectors::Coverage.instance.reset_instance
+  end
+end
+
 TEST_COVERAGE_FILE = '/tmp/fake_file.json'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,7 @@ class Test::Unit::TestCase
   def teardown
     Coverband.configuration.reset
     Coverband::Collectors::Coverage.instance.reset_instance
+    Coverband::Background.stop
   end
 end
 


### PR DESCRIPTION
After each test, clean up reset coverband global state to avoid test pollution.