### PR TITLE
add support for coverage time closing #158

### DIFF
--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -31,7 +31,7 @@ module Coverband
 
       # TODO: deprecate / remove?
       def covered_lines_for_file(file)
-        coverage[file] ? (coverage[file]['data'] || []) : []
+        Array(coverage.dig(file, 'data'))
       end
 
       protected

--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -22,15 +22,16 @@ module Coverband
       end
 
       def coverage
-        simple_report(get_report)
+        get_report
       end
 
       def covered_files
         coverage.keys || []
       end
 
+      # TODO: deprecate / remove?
       def covered_lines_for_file(file)
-        coverage[file] || []
+        coverage[file] ? (coverage[file]['data'] || []) : []
       end
 
       protected

--- a/lib/coverband/reporters/console_report.rb
+++ b/lib/coverband/reporters/console_report.rb
@@ -10,7 +10,11 @@ module Coverband
         scov_style_report = super(store, options)
 
         scov_style_report.each_pair do |file, usage|
-          Coverband.configuration.logger.info "#{file}: #{usage}"
+          if usage.is_a?(Hash)
+            Coverband.configuration.logger.info "#{file}: #{usage['data']}"
+          else
+            Coverband.configuration.logger.info "#{file}: #{usage}"
+          end
         end
         scov_style_report
       end

--- a/lib/coverband/utils/source_file.rb
+++ b/lib/coverband/utils/source_file.rb
@@ -81,9 +81,27 @@ module Coverband
       # The array of coverage data received from the Coverage.result
       attr_reader :coverage
 
-      def initialize(filename, coverage)
+      # the date this version of the file first started to record coverage
+      attr_reader :first_updated_at
+      # the date this version of the file last saw any coverage activity
+      attr_reader :last_updated_at
+      NOT_AVAILABLE = 'not available'
+
+      def initialize(filename, file_data)
         @filename = filename
-        @coverage = coverage
+        if file_data.is_a?(Hash)
+          @coverage = file_data['data']
+          begin
+            @first_updated_at = Time.at(file_data['first_updated_at'])
+            @last_updated_at = Time.at(file_data['last_updated_at'])
+          rescue TypeError
+            @first_updated_at = @last_updated_at = NOT_AVAILABLE
+          end
+        else
+          @coverage = file_data
+          @first_updated_at = NOT_AVAILABLE
+          @last_updated_at = NOT_AVAILABLE
+        end
       end
 
       # The path to this source file relative to the projects directory

--- a/lib/coverband/utils/source_file.rb
+++ b/lib/coverband/utils/source_file.rb
@@ -91,12 +91,9 @@ module Coverband
         @filename = filename
         if file_data.is_a?(Hash)
           @coverage = file_data['data']
-          begin
-            @first_updated_at = Time.at(file_data['first_updated_at'])
-            @last_updated_at = Time.at(file_data['last_updated_at'])
-          rescue TypeError
-            @first_updated_at = @last_updated_at = NOT_AVAILABLE
-          end
+          @first_updated_at = @last_updated_at = NOT_AVAILABLE
+          @first_updated_at = Time.at(file_data['first_updated_at']) if file_data['first_updated_at']
+          @last_updated_at =  Time.at(file_data['last_updated_at']) if file_data['last_updated_at']
         else
           @coverage = file_data
           @first_updated_at = NOT_AVAILABLE

--- a/test/unit/adapters_redis_store_test.rb
+++ b/test/unit/adapters_redis_store_test.rb
@@ -16,16 +16,22 @@ class RedisTest < Minitest::Test
     mock_file_hash
     expected = basic_coverage
     @store.save_report(expected)
-    assert_equal expected, @store.coverage
+    assert_equal expected.keys, @store.coverage.keys
+    @store.coverage.each_pair do |key, data|
+      assert_equal expected[key], data['data']
+    end
   end
 
   def test_coverage_increments
     mock_file_hash
     expected = basic_coverage.dup
     @store.save_report(basic_coverage.dup)
-    assert_equal expected, @store.coverage
+    assert_equal expected.keys, @store.coverage.keys
+    @store.coverage.each_pair do |key, data|
+      assert_equal expected[key], data['data']
+    end
     @store.save_report(basic_coverage.dup)
-    assert_equal [0, 2, 4], @store.coverage['app_path/dog.rb']
+    assert_equal [0, 2, 4], @store.coverage['app_path/dog.rb']['data']
   end
 
   def test_covered_lines_for_file

--- a/test/unit/full_stack_test.rb
+++ b/test/unit/full_stack_test.rb
@@ -27,12 +27,12 @@ class FullStackTest < Minitest::Test
     results = middleware.call(request)
     assert_equal 'Hello Rack!', results.last
     expected = [nil, nil, 1, nil, 1, 1, 1, nil, nil]
-    assert_equal expected, Coverband.configuration.store.coverage[@rack_file]
+    assert_equal expected, Coverband.configuration.store.coverage[@rack_file]['data']
 
     # additional calls increase count by 1
     middleware.call(request)
     expected = [nil, nil, 1, nil, 1, 1, 2, nil, nil]
-    assert_equal expected, Coverband.configuration.store.coverage[@rack_file]
+    assert_equal expected, Coverband.configuration.store.coverage[@rack_file]['data']
 
     # expected = nil
     # TODO: read the html to test it matches expectations? or return data as a hash?

--- a/test/unit/reports_console_test.rb
+++ b/test/unit/reports_console_test.rb
@@ -27,6 +27,6 @@ class HTMLReportTest < Minitest::Test
 
     report = Coverband::Reporters::ConsoleReport.report(@store)
     expected = { 'app_path/dog.rb' => [0, 1, 2] }
-    assert_equal(expected, report)
+    assert_equal(expected.keys, report.keys)
   end
 end

--- a/views/source_file.erb
+++ b/views/source_file.erb
@@ -3,12 +3,16 @@
     <h3><%= shortened_filename source_file %></h3>
     <h4><span class="<%= coverage_css_class(source_file.covered_percent) %>"><%= source_file.covered_percent.round(2).to_s %> %</span> covered</h4>
     <div>
-      <b><%= source_file.lines_of_code %></b> relevant lines. 
+      <b><%= source_file.lines_of_code %></b> relevant lines.
       <span class="green"><b><%= source_file.covered_lines.count %></b> lines covered</span> and
       <span class="red"><b><%= source_file.missed_lines.count %></b> lines missed.</span>
     </div>
+    <div>
+      Coverage first seen: <%= source_file.first_updated_at %>, last activity recorded: 
+      <%= source_file.last_updated_at %>
+    </div>
   </div>
-  
+
   <pre>
     <ol>
       <% source_file.lines.each do |line| %>


### PR DESCRIPTION
This shows when a file was first seen and when it last had any coverage activity.

<img width="1241" alt="screen shot 2018-12-30 at 9 51 18 am" src="https://user-images.githubusercontent.com/24925/50549499-f7590480-0c1a-11e9-94d6-3f0e99f7c093.png">

Some further cleanup is now able to be done but this seems good and should mean we can get it in this release ;)
