### PR TITLE
Add resque support

### DIFF
--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'resque'
 
   # TODO: used for benchmarking and tests I think we have other better benchmarking
   # perhaps time to drop this and refactor.

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -25,6 +25,7 @@ require 'coverband/integrations/rack_server_check'
 require 'coverband/reporters/web'
 require 'coverband/integrations/middleware'
 require 'coverband/integrations/background'
+require 'coverband/integrations/resque' if defined? Resque
 
 module Coverband
   CONFIG_FILE = './config/coverband.rb'

--- a/lib/coverband/integrations/resque.rb
+++ b/lib/coverband/integrations/resque.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+Resque.after_fork do |job|
+  Coverband.start
+end
+
+module Coverband
+  module ResqueWorker
+    def perform
+      super
+    ensure
+      Coverband::Collectors::Coverage.instance.report_coverage(true)
+    end
+  end
+end
+
+Resque::Job.prepend(Coverband::ResqueWorker)
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@ require 'mocha/minitest'
 require 'ostruct'
 require 'json'
 require 'redis'
+require 'resque'
 require 'pry-byebug'
 $VERBOSE = original_verbosity
 

--- a/test/unit/resque_worker_test.rb
+++ b/test/unit/resque_worker_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require File.expand_path('../test_helper', File.dirname(__FILE__))
+
+class ResqueWorkerTest < Minitest::Test
+  def enqueue_and_run_job
+    Resque.enqueue(TestResqueJob)
+    ENV['QUEUE'] ='resque_coverband'
+    Resque::Worker.new.work_one_job
+  end
+
+  test 'resque job coverage' do
+    resque_job_file = File.expand_path('./test_resque_job.rb', File.dirname(__FILE__))
+    require resque_job_file
+
+    #report after loading the file in parent process
+    Coverband::Collectors::Coverage.instance.report_coverage(true)
+
+    enqueue_and_run_job
+
+    expected = [1, 1, nil, 1, 1, nil, nil]
+    assert_equal expected, Coverband.configuration.store.coverage[resque_job_file]['data']
+  end
+end
+

--- a/test/unit/test_resque_job.rb
+++ b/test/unit/test_resque_job.rb
@@ -1,0 +1,7 @@
+class TestResqueJob
+  @queue = :resque_coverband
+
+  def self.perform
+    puts "perform"
+  end
+end


### PR DESCRIPTION
Out of box support for resque. Current implementation will report to redis for every job execution. 