### PR TITLE
Fix sporadic failure of resque test

### DIFF
--- a/lib/coverband/integrations/resque.rb
+++ b/lib/coverband/integrations/resque.rb
@@ -9,7 +9,6 @@ module Coverband
     def perform
       super
     ensure
-      puts "Resque coverband integration reporting"
       Coverband::Collectors::Coverage.instance.report_coverage(true)
     end
   end

--- a/lib/coverband/integrations/resque.rb
+++ b/lib/coverband/integrations/resque.rb
@@ -9,6 +9,7 @@ module Coverband
     def perform
       super
     ensure
+      puts "Resque coverband integration reporting"
       Coverband::Collectors::Coverage.instance.report_coverage(true)
     end
   end

--- a/test/unit/resque_worker_test.rb
+++ b/test/unit/resque_worker_test.rb
@@ -6,23 +6,15 @@ class ResqueWorkerTest < Minitest::Test
   def enqueue_and_run_job
     Resque.enqueue(TestResqueJob)
     queue = ENV['QUEUE'] ='resque_coverband'
-    10.times do
-      break if Resque.size(queue) == 1
-      puts "sleeping until queue size is 1"
-    end
-    raise "Job not enqueued" if Resque.size(queue) != 1
-    25.times do
-      Resque::Worker.new.work_one_job
-      break if Resque.size(queue) == 0
-      puts "sleeping until queue size is 0"
-      sleep 0.25
-    end
-    raise "Job did not run" if Resque.size(queue) != 0
-    sleep 0.5
+    Resque::Worker.new.work_one_job
   end
 
   def setup
     super
+    Coverband.configure do |config|
+      config.background_reporting_enabled = false
+    end
+    Coverband.start
     redis = Coverband.configuration.store.send(:redis)
     Resque.redis = redis
   end

--- a/test/unit/resque_worker_test.rb
+++ b/test/unit/resque_worker_test.rb
@@ -5,8 +5,26 @@ require File.expand_path('../test_helper', File.dirname(__FILE__))
 class ResqueWorkerTest < Minitest::Test
   def enqueue_and_run_job
     Resque.enqueue(TestResqueJob)
-    ENV['QUEUE'] ='resque_coverband'
-    Resque::Worker.new.work_one_job
+    queue = ENV['QUEUE'] ='resque_coverband'
+    10.times do
+      break if Resque.size(queue) == 1
+      puts "sleeping until queue size is 1"
+    end
+    raise "Job not enqueued" if Resque.size(queue) != 1
+    25.times do
+      Resque::Worker.new.work_one_job
+      break if Resque.size(queue) == 0
+      puts "sleeping until queue size is 0"
+      sleep 0.25
+    end
+    raise "Job did not run" if Resque.size(queue) != 0
+    sleep 0.5
+  end
+
+  def setup
+    super
+    redis = Coverband.configuration.store.send(:redis)
+    Resque.redis = redis
   end
 
   test 'resque job coverage' do
@@ -18,8 +36,8 @@ class ResqueWorkerTest < Minitest::Test
 
     enqueue_and_run_job
 
-    expected = [1, 1, nil, 1, 1, nil, nil]
-    assert_equal expected, Coverband.configuration.store.coverage[resque_job_file]['data']
+    puts "assert_equal 1, Coverband.configuration.store.coverage['#{resque_job_file}']['data'][4]"
+    assert_equal 1, Coverband.configuration.store.coverage[resque_job_file]['data'][4]
   end
 end
 

--- a/test/unit/test_resque_job.rb
+++ b/test/unit/test_resque_job.rb
@@ -2,6 +2,6 @@ class TestResqueJob
   @queue = :resque_coverband
 
   def self.perform
-    puts "perform"
+    puts "resque job perform"
   end
 end

--- a/test/unit/test_resque_job.rb
+++ b/test/unit/test_resque_job.rb
@@ -2,6 +2,6 @@ class TestResqueJob
   @queue = :resque_coverband
 
   def self.perform
-    puts "resque job perform"
+    "resque job perform"
   end
 end


### PR DESCRIPTION
Was difficult to figure this out as I was only able to reproduce the problem sporadically on travis. Theory is that the background job thread running on parent process was overwriting what the child process was writing to redis. This is kind of a known race condition in coverband that two different processes can compete with each other.

Have run the tests over and over again on travis and haven't had an error so i think we got it.