### PR TITLE
Update base key for redis to 4_0

### DIFF
--- a/lib/coverband/adapters/redis_store.rb
+++ b/lib/coverband/adapters/redis_store.rb
@@ -6,7 +6,7 @@ module Coverband
     # RedisStore store a merged coverage file to redis
     ###
     class RedisStore < Base
-      BASE_KEY = 'coverband3_1'
+      BASE_KEY = 'coverband4_0'
 
       def initialize(redis, opts = {})
         super()


### PR DESCRIPTION
* Just noticed this when playing around with coverband and inspecting
  redis keys that mismatched my coverband version
* not sure if this is intentional, or what impacts it has on upgrading coverband
  and "losing" the data (although I suspect the data is typically quite short-lived?)