### PR TITLE
fix for issue #188 broken file merge over deploy names...

### DIFF
--- a/lib/coverband/reporters/base.rb
+++ b/lib/coverband/reporters/base.rb
@@ -38,8 +38,10 @@ module Coverband
           # normalize names across servers
           report_hash.each_with_object({}) do |(key, vals), fixed_report|
             filename = filename_from_key(key, roots)
-            fixed_report[filename] = if fixed_report.key?(filename)
-                                       merge_arrays(fixed_report[filename], vals)
+            fixed_report[filename] = if fixed_report.key?(filename) && fixed_report[filename]['data'] && vals['data']
+                                       merged_data = merge_arrays(fixed_report[filename]['data'], vals['data'])
+                                       vals['data'] = merged_data
+                                       vals
                                      else
                                        vals
                                      end
@@ -94,7 +96,6 @@ module Coverband
         # why do we need to merge covered files data?
         # basically because paths on machines or deployed hosts could be different, so
         # two different keys could point to the same filename or `line_key`
-        # this logic should be pushed to base report
         # TODO: think we are filtering based on ignore while sending to the store
         # and as we also pull it out here
         ###

--- a/test/unit/reports_base_test.rb
+++ b/test/unit/reports_base_test.rb
@@ -93,7 +93,6 @@ class ReportsBaseTest < Minitest::Test
 
     Coverband.configure do |config|
       config.reporter          = 'std_out'
-      config.ignore            = %w(vendor .erb$ .slim$)
       config.root              = '/full/remote_app/path'
       config.store             = store
     end
@@ -106,5 +105,50 @@ class ReportsBaseTest < Minitest::Test
     expected = { key => [1, 3, 6] }
 
     assert_equal expected, Coverband::Reporters::Base.send(:get_current_scov_data_imp, store, roots)
+  end
+
+  ###
+  # This test uses real world example data which helped uncover a bug
+  # The copied data doesn't format easily and isn't worth the effort to meet
+  # string style
+  # rubocop:disable all
+  ###
+  test '#get_current_scov_data_imp merges multiples of file data' do
+    coverage = {'/base/66/app/controllers/dashboard_controller.rb' =>
+       {"first_updated_at"=>1549610119,
+        "last_updated_at"=>1549610200,
+        "file_hash"=>"14dc84e940e26cbfb9ac79b43862e762",
+        "data"=>[1, 1, 1, nil, 1, 1, nil, nil, 1, nil, 1, 26, 26, nil, 26, 26, 26, 26, 26, 26, 26, nil, nil, 1, nil, 1, 26, 19, 0, 0, 0, 0, nil, nil, nil, nil, 0, 0, nil, nil, 1, 26, 26, 26, nil, nil, nil, nil, nil, 1, 26, nil, nil, 1, 26, nil, nil]},
+     '/base/78/app/controllers/dashboard_controller.rb' =>
+       {"first_updated_at"=>1549658574,
+        "last_updated_at"=>1549729830,
+        "file_hash"=>"14dc84e940e26cbfb9ac79b43862e762",
+        "data"=>[21, 21, 21, nil, 21, 21, nil, nil, 21, nil, 21, 22, 22, nil, 22, 22, 22, 22, 22, 22, 22, nil, nil, 21, nil, 21, 22, 13, 0, 0, 0, 0, nil, nil, nil, nil, 0, 0, nil, nil, 21, 22, 22, 22, nil, nil, nil, nil, nil, 21, 22, nil, nil, 21, 22, nil, nil]},
+    '/base/70/app/controllers/dashboard_controller.rb' =>
+       {"first_updated_at"=>1549617873,
+        "last_updated_at"=>1549618094,
+        "file_hash"=>"14dc84e940e26cbfb9ac79b43862e762",
+        "data"=>[16, 16, 16, nil, 16, 16, nil, nil, 16, nil, 16, 32, 32, nil, 32, 32, 32, 32, 32, 32, 32, nil, nil, 16, nil, 16, 32, 23, 0, 0, 0, 0, nil, nil, nil, nil, 0, 0, nil, nil, 16, 32, 32, 32, nil, nil, nil, nil, nil, 16, 32, nil, nil, 16, 32, nil, nil]}
+      }
+    @redis = Redis.new
+    store = Coverband::Adapters::RedisStore.new(@redis)
+    store.clear!
+
+    Coverband.configure do |config|
+      config.reporter          = 'std_out'
+      config.root              = '/base/78/app/'
+      config.store             = store
+    end
+
+    key = '/base/78/app/app/controllers/dashboard_controller.rb'
+    roots = ['/base/[0-9]*/', '/base/78/app/']
+
+    lines_hit = [1, 3, 6]
+    store.stubs(:coverage).returns(coverage)
+    expected = {"first_updated_at"=>1549617873,
+                "last_updated_at"=>1549618094,
+                "file_hash"=>"14dc84e940e26cbfb9ac79b43862e762",
+                "data"=>[38, 38, 38, nil, 38, 38, nil, nil, 38, nil, 38, 80, 80, nil, 80, 80, 80, 80, 80, 80, 80, nil, nil, 38, nil, 38, 80, 55, 0, 0, 0, 0, nil, nil, nil, nil, 0, 0, nil, nil, 38, 80, 80, 80, nil, nil, nil, nil, nil, 38, 80, nil, nil, 38, 80, nil, nil]}
+    assert_equal expected, Coverband::Reporters::Base.send(:get_current_scov_data_imp, store, roots)[key]
   end
 end


### PR DESCRIPTION
The pervious merge functionality was tested at to low of a level and missed that with additional meta data. The merge was broken and regressed a few releases ago. This test scrubbed real world data captures and resolves the issue

Thanks to @gingerlime for the great bug report and data and support to figure this out.