### PR TITLE
Manually report coverage in test

### DIFF
--- a/test/unit/rails_full_stack_test.rb
+++ b/test/unit/rails_full_stack_test.rb
@@ -10,6 +10,7 @@ class RailsFullStackTest < Minitest::Test
     super
     # The normal relative directory lookup of coverband won't work for our dummy rails project
     Coverband.configure("./test/rails#{Rails::VERSION::MAJOR}_dummy/config/coverband.rb")
+    Coverband.configuration.background_reporting_enabled = false
     Coverband.start
   end
 
@@ -21,8 +22,8 @@ class RailsFullStackTest < Minitest::Test
 
   test 'this is how we do it' do
     visit '/dummy/show'
+    Coverband::Collectors::Coverage.instance.report_coverage(true)
     assert_content('I am no dummy')
-    sleep 0.2
     visit '/coverage'
     within page.find('a', text: /dummy_controller.rb/).find(:xpath, '../..') do
       assert_selector('td', text: '100.0 %')

--- a/test/unit/rails_gems_full_stack_test.rb
+++ b/test/unit/rails_gems_full_stack_test.rb
@@ -12,6 +12,7 @@ class RailsGemsFullStackTest < Minitest::Test
     Coverband.configure("./test/rails#{Rails::VERSION::MAJOR}_dummy/config/coverband.rb")
     Coverband.configuration.track_gems = true
     Coverband.configuration.gem_details = true
+    Coverband.configuration.background_reporting_enabled = false
     Coverband.start
     require 'rainbow'
     Rainbow('this text is red').red
@@ -26,7 +27,7 @@ class RailsGemsFullStackTest < Minitest::Test
   test 'this is how gem it' do
     visit '/dummy/show'
     assert_content('I am no dummy')
-    sleep 0.2
+    Coverband::Collectors::Coverage.instance.report_coverage(true)
     visit '/coverage'
     assert_content('Coverband Admin')
     assert_content('Gems')


### PR DESCRIPTION
Modified these two tests to not use the background reporting thread and it seems to fix the sporadic failures. Working theory which i haven't had time to verify. The current minitest thread has a background thread running. Then this test spins up a puma server which might fork and start another background thread. These threads compete with each other and cause occasional overwrites of data.

We could merge this in and I believe it will solve sporadic failures for these tests. The other alternative is to dig in some more here and:

1. See if my theory is actually correct
2. Fix by stopping the thread in the minitest process?

This pull request takes a little bit of "end to end" away in that it does not test the background thread so i am on the fence.