### PR TITLE
Stop parent resque background reporting thread

### DIFF
--- a/lib/coverband/integrations/background.rb
+++ b/lib/coverband/integrations/background.rb
@@ -5,12 +5,17 @@ module Coverband
     @semaphore = Mutex.new
 
     def self.stop
+      return unless @thread
       @semaphore.synchronize do
         if @thread
           @thread.exit
           @thread = nil
         end
       end
+    end
+
+    def self.running?
+      !!@thread
     end
 
     def self.start

--- a/lib/coverband/integrations/resque.rb
+++ b/lib/coverband/integrations/resque.rb
@@ -5,6 +5,7 @@ Resque.after_fork do |job|
 end
 
 Resque.before_first_fork do
+  Coverband.configuration.background_reporting_enabled = false
   Coverband::Background.stop
   Coverband::Collectors::Coverage.instance.report_coverage(true)
 end

--- a/lib/coverband/integrations/resque.rb
+++ b/lib/coverband/integrations/resque.rb
@@ -4,6 +4,11 @@ Resque.after_fork do |job|
   Coverband.start
 end
 
+Resque.before_first_fork do
+  Coverband::Background.stop
+  Coverband::Collectors::Coverage.instance.report_coverage(true)
+end
+
 module Coverband
   module ResqueWorker
     def perform

--- a/test/unit/resque_worker_test.rb
+++ b/test/unit/resque_worker_test.rb
@@ -25,14 +25,10 @@ class ResqueWorkerTest < Minitest::Test
     resque_job_file = File.expand_path('./test_resque_job.rb', File.dirname(__FILE__))
     require resque_job_file
 
-    #report after loading the file in parent process
-    Coverband::Collectors::Coverage.instance.report_coverage(true)
-    
     enqueue_and_run_job
 
     assert !Coverband::Background.running?
 
-    puts "assert_equal 1, Coverband.configuration.store.coverage['#{resque_job_file}']['data'][4]"
     assert_equal 1, Coverband.configuration.store.coverage[resque_job_file]['data'][4]
   end
 end


### PR DESCRIPTION
No need for the background thread to be running in the parent resque process. This stops the background thread before the first fork.