### PR TITLE
Introduce Coverband#report_coverage

### DIFF
--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -49,6 +49,10 @@ module Coverband
     end
   end
 
+  def self.report_coverage(force_report = false)
+    Coverband::Collectors::Coverage.instance.report_coverage(force_report)
+  end
+
   def self.configuration
     self.configuration_data ||= Configuration.new
   end

--- a/lib/coverband/at_exit.rb
+++ b/lib/coverband/at_exit.rb
@@ -11,7 +11,7 @@ module Coverband
         @at_exit_registered = true
         at_exit do
           ::Coverband::Background.stop
-          Coverband::Collectors::Coverage.instance.report_coverage(true)
+          Coverband.report_coverage(true)
           Coverband.configuration.logger&.debug('Coverband: Reported coverage before exit')
         end
       end

--- a/lib/coverband/integrations/background.rb
+++ b/lib/coverband/integrations/background.rb
@@ -28,7 +28,7 @@ module Coverband
         sleep_seconds = Coverband.configuration.background_reporting_sleep_seconds
         @thread = Thread.new do
           loop do
-            Coverband::Collectors::Coverage.instance.report_coverage(true)
+            Coverband.report_coverage(true)
             logger&.debug("Coverband: Reported coverage via thread. Sleeping #{sleep_seconds}s") if Coverband.configuration.verbose
             sleep(sleep_seconds)
           end

--- a/lib/coverband/integrations/resque.rb
+++ b/lib/coverband/integrations/resque.rb
@@ -15,7 +15,7 @@ module Coverband
     def perform
       super
     ensure
-      Coverband::Collectors::Coverage.instance.report_coverage(true)
+      Coverband.report_coverage(true)
     end
   end
 end

--- a/lib/coverband/reporters/web.rb
+++ b/lib/coverband/reporters/web.rb
@@ -66,7 +66,7 @@ module Coverband
       end
 
       def collect_coverage
-        Coverband::Collectors::Coverage.instance.report_coverage(true)
+        Coverband.report_coverage(true)
         notice = 'coverband coverage collected'
         [301, { 'Location' => "#{base_path}?notice=#{notice}" }, []]
       end

--- a/lib/coverband/utils/railtie.rb
+++ b/lib/coverband/utils/railtie.rb
@@ -7,7 +7,7 @@ module Coverband
     end
 
     config.after_initialize do
-      Coverband::Collectors::Coverage.instance.report_coverage(true)
+      Coverband.report_coverage(true)
     end
 
     rake_tasks do

--- a/test/benchmarks/benchmark.rake
+++ b/test/benchmarks/benchmark.rake
@@ -134,7 +134,7 @@ namespace :benchmarks do
       x.config(time: 12, warmup: 5, suite: suite)
       x.report 'coverband' do
         work
-        Coverband::Collectors::Coverage.instance.report_coverage
+        Coverband.report_coverage(true)
       end
       x.report 'no coverband' do
         work

--- a/test/unit/rails_full_stack_test.rb
+++ b/test/unit/rails_full_stack_test.rb
@@ -22,7 +22,7 @@ class RailsFullStackTest < Minitest::Test
 
   test 'this is how we do it' do
     visit '/dummy/show'
-    Coverband::Collectors::Coverage.instance.report_coverage(true)
+    Coverband.report_coverage(true)
     assert_content('I am no dummy')
     visit '/coverage'
     within page.find('a', text: /dummy_controller.rb/).find(:xpath, '../..') do
@@ -47,7 +47,7 @@ class RailsFullStackTest < Minitest::Test
       3.times do
         visit '/dummy/show'
         assert_content('I am no dummy')
-        Coverband::Collectors::Coverage.instance.report_coverage(true)
+        Coverband.report_coverage(true)
       end
 
       previous_out = $stdout
@@ -58,7 +58,7 @@ class RailsFullStackTest < Minitest::Test
         15.times do
           visit '/dummy/show'
           assert_content('I am no dummy')
-          Coverband::Collectors::Coverage.instance.report_coverage(true)
+          Coverband.report_coverage(true)
           # this is expected to retain memory across requests
           # clear it to remove the false positive from test
           Coverband::Collectors::Coverage.instance.send(:add_previous_results, nil)

--- a/test/unit/rails_gems_full_stack_test.rb
+++ b/test/unit/rails_gems_full_stack_test.rb
@@ -27,7 +27,7 @@ class RailsGemsFullStackTest < Minitest::Test
   test 'this is how gem it' do
     visit '/dummy/show'
     assert_content('I am no dummy')
-    Coverband::Collectors::Coverage.instance.report_coverage(true)
+    Coverband.report_coverage(true)
     visit '/coverage'
     assert_content('Coverband Admin')
     assert_content('Gems')


### PR DESCRIPTION
Reduce coupling on implementation by hanging a method off of Coverband to report_coverage.