### PR TITLE
add support for first migration

### DIFF
--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -13,6 +13,10 @@ module Coverband
         raise 'abstract'
       end
 
+      def migrate!
+        raise 'abstract'
+      end
+
       def size
         raise 'abstract'
       end
@@ -73,8 +77,8 @@ module Coverband
         expanded
       end
 
-      def merge_reports(new_report, old_report)
-        new_report = expand_report(new_report)
+      def merge_reports(new_report, old_report, options = {})
+        new_report = expand_report(new_report) unless options[:skip_expansion]
         keys = (new_report.keys + old_report.keys).uniq
         keys.each do |file|
           new_report[file] = if new_report[file] &&

--- a/lib/coverband/adapters/file_store.rb
+++ b/lib/coverband/adapters/file_store.rb
@@ -24,6 +24,10 @@ module Coverband
         File.size?(path).to_i
       end
 
+      def migrate!
+        raise NotImplementedError, "FileStore doesn't support migrations"
+      end
+
       private
 
       attr_accessor :path

--- a/lib/coverband/adapters/redis_store.rb
+++ b/lib/coverband/adapters/redis_store.rb
@@ -18,6 +18,7 @@ module Coverband
         @redis           = redis
         @ttl             = opts[:ttl]
         @redis_namespace = opts[:redis_namespace]
+        @format_version  = REDIS_STORAGE_FORMAT_VERSION
       end
 
       def clear!
@@ -28,12 +29,38 @@ module Coverband
         @redis.get(REDIS_STORAGE_FORMAT_VERSION).bytesize
       end
 
+      ###
+      # Current implementation moves from coverband3_1 to coverband_3_2
+      # In the future this can be made more general and support a more specific
+      # version format.
+      ###
+      def migrate!
+        reset_base_key
+        @format_version = 'coverband3_1'
+        previous_data = get_report
+        if previous_data.empty?
+          puts 'no previous data to migrate found'
+          exit 0
+        end
+        relative_path_report = previous_data.each_with_object({}) do |(key, vals), fixed_report|
+          fixed_report[full_path_to_relative(key)] = vals
+        end
+        clear!
+        reset_base_key
+        @format_version = REDIS_STORAGE_FORMAT_VERSION
+        save_coverage(merge_reports(get_report, relative_path_report, skip_expansion: true))
+      end
+
       private
 
       attr_reader :redis
 
+      def reset_base_key
+        @base_key = nil
+      end
+
       def base_key
-        @base_key ||= [REDIS_STORAGE_FORMAT_VERSION, @redis_namespace].compact.join('.')
+        @base_key ||= [@format_version, @redis_namespace].compact.join('.')
       end
 
       def save_coverage(data)

--- a/lib/coverband/utils/tasks.rb
+++ b/lib/coverband/utils/tasks.rb
@@ -25,4 +25,13 @@ namespace :coverband do
     environment
     Coverband.configuration.store.clear!
   end
+
+  ###
+  # clear data helpful for development or after configuration issues
+  ###
+  desc 'upgrade previous Coverband datastore to latest format'
+  task :migrate do
+    environment
+    Coverband.configuration.store.migrate!
+  end
 end


### PR DESCRIPTION
OK, I think this shows the basic plan, as we add support for another migration in the future I think we will refactor out a migrator class and try to figure out a way / format to standardize versions / calculate them... and to archive/drop support for older migrations. I am thinking something like the schema table that rails uses but a redis key coverband_schema_versions or something to track previous keys and if migrations are supported for those keys.