### PR TITLE
Speed up test by setting gem_details to false

### DIFF
--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -42,6 +42,8 @@ Gem::Specification.new do |spec|
   # require 'byebug'; byebug
   spec.add_development_dependency 'pry-byebug'
 
+  spec.add_development_dependency 'minitest-profile'
+
   # TODO: Remove when other production adapters exist
   # because the default configuration of redis store, we really do require
   # redis now. I was reluctant to add this, but until we offer another production

--- a/test/integration/rails_gems_full_stack_test.rb
+++ b/test/integration/rails_gems_full_stack_test.rb
@@ -11,7 +11,7 @@ class RailsGemsFullStackTest < Minitest::Test
     # The normal relative directory lookup of coverband won't work for our dummy rails project
     Coverband.configure("./test/rails#{Rails::VERSION::MAJOR}_dummy/config/coverband.rb")
     Coverband.configuration.track_gems = true
-    Coverband.configuration.gem_details = true
+    Coverband.configuration.gem_details = false
     Coverband.configuration.background_reporting_enabled = false
     Coverband.start
     require 'rainbow'


### PR DESCRIPTION
Noticed this test was taking up to 6 seconds so I added mini_test_profile and set gem_details to false.

Before:

```
TESTOPTS='--profile' bundle exec rake test
================================================================================
Your 10 Slowest Tests
================================================================================

 5.3751ms - RailsGemsFullStackTest#test_this_is_how_gem_it
 0.2883ms - FullStackTest#test_call_app_with_gem_tracking
 0.2372ms - FullStackTest#test_call_app
 0.1316ms - RailsFullStackTest#test_this_is_how_we_do_it
 0.0565ms - ResqueWorkerTest#test_resque_job_coverage
 0.0292ms - Coverband::WebTest#test_renders_index_content
 0.0241ms - ReportHTMLTest#test_generate_scov_html_report
 0.0108ms - Coverband::WebTest#test_collect_coverage
 0.0097ms - AtExitTest#test_only_registers_once
 0.0086ms - MiddlewareTest#test_always_be_enabled_with_sample_percentage_of_100
```

After:
```
TESTOPTS='--profile' bundle exec rake test
 0.8140ms - RailsGemsFullStackTest#test_this_is_how_gem_it
 0.3263ms - FullStackTest#test_call_app_with_gem_tracking
 0.2484ms - FullStackTest#test_call_app
 0.1244ms - RailsFullStackTest#test_this_is_how_we_do_it
 0.0883ms - ResqueWorkerTest#test_resque_job_coverage
 0.0321ms - ReportHTMLTest#test_generate_scov_html_report
 0.0307ms - Coverband::WebTest#test_renders_index_content
 0.0097ms - AtExitTest#test_only_registers_once
 0.0096ms - Coverband::WebTest#test_collect_coverage
 0.0076ms - ReportHTMLTest#test_generate_scov_report_file
```