### PR TITLE
Reset coverage before each test

### DIFF
--- a/test/coverband/collectors/coverage_test.rb
+++ b/test/coverband/collectors/coverage_test.rb
@@ -1,53 +1,72 @@
 # frozen_string_literal: true
 
 require File.expand_path('../../test_helper', File.dirname(__FILE__))
-require File.expand_path('../../dog', File.dirname(__FILE__))
 
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
-  class CollectorsCoverageTest < Minitest::Test
-    attr_accessor :coverband
+class CollectorsCoverageTest < Minitest::Test
+  attr_accessor :coverband
 
-    def setup
-      super
-      Coverband.configure do |config|
-        config.store = Coverband::Adapters::RedisStore.new(Redis.new)
-      end
-      @coverband = Coverband::Collectors::Coverage.instance.reset_instance
+  def setup
+    super
+    Coverband.configure do |config|
+      config.store = Coverband::Adapters::RedisStore.new(Redis.new)
     end
+    @coverband = Coverband::Collectors::Coverage.instance.reset_instance
+  end
 
-    def teardown
-      Thread.current[:coverband_instance] = nil
-      Coverband.configure do |config|
-      end
-      @coverband = Coverband::Collectors::Coverage.instance.reset_instance
+  def teardown
+    Thread.current[:coverband_instance] = nil
+    Coverband.configure do |config|
     end
+    @coverband = Coverband::Collectors::Coverage.instance.reset_instance
+  end
 
-    test 'gets coverage instance' do
-      assert_equal Coverband::Collectors::Coverage, coverband.class
-    end
+  test 'Empty coverage' do
+    coverband.report_coverage(true)
+    assert_equal({}, Coverband.configuration.store.coverage)
+  end
 
-    test 'defaults to a redis store' do
-      assert_equal Coverband::Adapters::RedisStore, coverband.instance_variable_get('@store').class
-    end
+  test 'Dog class coverage' do
+    load File.expand_path('../../dog.rb', File.dirname(__FILE__))
+    coverband.report_coverage(true)
+    coverage = Coverband.configuration.store.coverage
+    assert_equal(["./test/dog.rb"], coverage.keys)
+    assert_equal(coverage["./test/dog.rb"]["data"], [nil, nil, 1, 1, 0, nil, nil])
+  end
 
-    test 'report_coverage raises errors in tests' do
-      @coverband.reset_instance
-      @coverband.expects(:ready_to_report?).raises('Oh no')
-      assert_raises RuntimeError do
-        @coverband.report_coverage
-      end
-    end
+  test 'Dog method and class coverage' do
+    load File.expand_path('../../dog.rb', File.dirname(__FILE__))
+    Dog.new.bark
+    coverband.report_coverage(true)
+    coverage = Coverband.configuration.store.coverage
+    assert_equal(["./test/dog.rb"], coverage.keys)
+    assert_equal(coverage["./test/dog.rb"]["data"], [nil, nil, 1, 1, 1, nil, nil])
+  end
 
-    test 'report_coverage does not raise errors in non-test mode' do
-      Coverband.configuration.stubs(:test_env).returns(false)
-      @coverband.expects(:ready_to_report?).raises('Oh no')
-      @coverband.reset_instance
+  test 'gets coverage instance' do
+    assert_equal Coverband::Collectors::Coverage, coverband.class
+  end
+
+  test 'defaults to a redis store' do
+    assert_equal Coverband::Adapters::RedisStore, coverband.instance_variable_get('@store').class
+  end
+
+  test 'report_coverage raises errors in tests' do
+    @coverband.reset_instance
+    @coverband.expects(:ready_to_report?).raises('Oh no')
+    assert_raises RuntimeError do
       @coverband.report_coverage
     end
+  end
 
-    test 'default tmp ignores' do
-      heroku_build_file = '/tmp/build_81feca8c72366e4edf020dc6f1937485/config/initializers/assets.rb'
-      assert_equal false, @coverband.send(:track_file?, heroku_build_file)
-    end
+  test 'report_coverage does not raise errors in non-test mode' do
+    Coverband.configuration.stubs(:test_env).returns(false)
+    @coverband.expects(:ready_to_report?).raises('Oh no')
+    @coverband.reset_instance
+    @coverband.report_coverage
+  end
+
+  test 'default tmp ignores' do
+    heroku_build_file = '/tmp/build_81feca8c72366e4edf020dc6f1937485/config/initializers/assets.rb'
+    assert_equal false, @coverband.send(:track_file?, heroku_build_file)
   end
 end

--- a/test/integration/full_stack_test.rb
+++ b/test/integration/full_stack_test.rb
@@ -44,6 +44,7 @@ class FullStackTest < Minitest::Test
     Coverband.configuration.track_gems = true
     Coverband::Collectors::Coverage.instance.reset_instance
     require 'rainbow'
+    load 'rainbow/null_presenter.rb'
     Rainbow('this text is red').red
     request = Rack::MockRequest.env_for('/anything.json')
     middleware = Coverband::Middleware.new(fake_app_with_lines)

--- a/test/integration/rails_full_stack_test.rb
+++ b/test/integration/rails_full_stack_test.rb
@@ -12,6 +12,7 @@ class RailsFullStackTest < Minitest::Test
     Coverband.configure("./test/rails#{Rails::VERSION::MAJOR}_dummy/config/coverband.rb")
     Coverband.configuration.background_reporting_enabled = false
     Coverband.start
+    load "./test/rails#{Rails::VERSION::MAJOR}_dummy/app/controllers/dummy_controller.rb"
   end
 
   def teardown

--- a/test/integration/rails_gems_full_stack_test.rb
+++ b/test/integration/rails_gems_full_stack_test.rb
@@ -11,10 +11,11 @@ class RailsGemsFullStackTest < Minitest::Test
     # The normal relative directory lookup of coverband won't work for our dummy rails project
     Coverband.configure("./test/rails#{Rails::VERSION::MAJOR}_dummy/config/coverband.rb")
     Coverband.configuration.track_gems = true
-    Coverband.configuration.gem_details = false
+    Coverband.configuration.gem_details = true
     Coverband.configuration.background_reporting_enabled = false
     Coverband.start
     require 'rainbow'
+    load('rainbow/wrapper.rb')
     Rainbow('this text is red').red
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,11 @@ Coveralls.wear!
 module Coverband
   module Test
     def self.reset
+      if defined?(::Coverage.running?)
+        ::Coverage.result if ::Coverage.running?
+      else
+        ::Coverage.result rescue nil
+      end
       Coverband.configuration.store.clear!
       Coverband.configuration.reset
       Coverband::Collectors::Coverage.instance.reset_instance

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -84,18 +84,6 @@ def basic_coverage
   { 'app_path/dog.rb' => example_line }
 end
 
-def fake_redis
-  @redis ||= begin
-    redis = OpenStruct.new
-    redis
-  end
-end
-
-def fake_coverage_report
-  file_name = '/Users/danmayer/projects/hearno/script/tester.rb'
-  { file_name => [1, nil, 1, 1, nil, nil, nil] }
-end
-
 def source_fixture(filename)
   File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', filename))
 end


### PR DESCRIPTION
Depending on which order the tests are run in the current coverage could be different. This PR introduces a call to Coverband#result which should clear what is in ::Coverage::peek_result