### PR TITLE
Exclude benchmark tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ Rake::TestTask.new(:test) do |test|
   # exclude benchmark from the tests as the way it functions resets code coverage during executions
   # test.pattern = 'test/unit/*_test.rb'
   # using test files opposed to pattern as it outputs which files are run
-  test.test_files = FileList['test/**/*_test.rb']
+  test.test_files = FileList['test/integration/**/*_test.rb', 'test/coverband/**/*_test.rb']
   test.verbose = true
 end
 


### PR DESCRIPTION
Not sure why, but I just started getting the following error on my local machine:

```
➜  coverband git:(bb11a27) bundle exec rake test
/Users/karlbaum/.rubies/ruby-2.5.3/bin/ruby -w -I"lib:lib:test" -I"/Users/karlbaum/.gem/ruby/2.5.3/gems/rake-12.3.2/lib" "/Users/karlbaum/.gem/ruby/2.5.3/gems/rake-12.3.2/lib/rake/rake_test_loader.rb" "test/benchmarks/classifier-reborn/test/backends/backend_memory_test.rb" "test/benchmarks/classifier-reborn/test/backends/backend_redis_test.rb" "test/benchmarks/classifier-reborn/test/bayes/bayesian_integration_test.rb" "test/benchmarks/classifier-reborn/test/bayes/bayesian_memory_test.rb" "test/benchmarks/classifier-reborn/test/bayes/bayesian_redis_test.rb" "test/benchmarks/classifier-reborn/test/extensions/hasher_test.rb" "test/benchmarks/classifier-reborn/test/extensions/matrix_test.rb" "test/benchmarks/classifier-reborn/test/extensions/token_filter/stemmer_test.rb" "test/benchmarks/classifier-reborn/test/extensions/token_filter/stopword_test.rb" "test/benchmarks/classifier-reborn/test/extensions/token_filter/symbol_test.rb" "test/benchmarks/classifier-reborn/test/extensions/tokenizer/token_test.rb" "test/benchmarks/classifier-reborn/test/extensions/tokenizer/whitespace_test.rb" "test/benchmarks/classifier-reborn/test/extensions/zero_vector_test.rb" "test/benchmarks/classifier-reborn/test/lsi/lsi_test.rb" "test/benchmarks/classifier-reborn/test/lsi/word_list_test.rb" "test/coverband/adapters/base_test.rb" "test/coverband/adapters/file_store_test.rb" "test/coverband/adapters/redis_store_test.rb" "test/coverband/at_exit_test.rb" "test/coverband/collectors/coverage_test.rb" "test/coverband/configuration_test.rb" "test/coverband/coverband_test.rb" "test/coverband/integrations/background_test.rb" "test/coverband/integrations/middleware_test.rb" "test/coverband/integrations/rack_server_check_test.rb" "test/coverband/integrations/resque_worker_test.rb" "test/coverband/reporters/base_test.rb" "test/coverband/reporters/console_test.rb" "test/coverband/reporters/html_test.rb" "test/coverband/reporters/web_test.rb" "test/coverband/utils/file_groups_test.rb" "test/coverband/utils/file_list_test.rb" "test/coverband/utils/gem_list_test.rb" "test/coverband/utils/lines_classifier_test.rb" "test/coverband/utils/result_test.rb" "test/coverband/utils/s3_report_test.rb" "test/coverband/utils/source_file_line_test.rb" "test/coverband/utils/source_file_test.rb" "test/integration/full_stack_test.rb" "test/integration/rails_full_stack_test.rb" "test/integration/rails_gems_full_stack_test.rb"

File does not exist: minitest/reporters

rake aborted!
Command failed with status (1): [ruby -w -I"lib:lib:test" -I"/Users/karlbaum/.gem/ruby/2.5.3/gems/rake-12.3.2/lib" "/Users/karlbaum/.gem/ruby/2.5.3/gems/rake-12.3.2/lib/rake/rake_test_loader.rb" "test/benchmarks/classifier-reborn/test/backends/backend_memory_test.rb" "test/benchmarks/classifier-reborn/test/backends/backend_redis_test.rb" "test/benchmarks/classifier-reborn/test/bayes/bayesian_integration_test.rb" "test/benchmarks/classifier-reborn/test/bayes/bayesian_memory_test.rb" "test/benchmarks/classifier-reborn/test/bayes/bayesian_redis_test.rb" "test/benchmarks/classifier-reborn/test/extensions/hasher_test.rb" "test/benchmarks/classifier-reborn/test/extensions/matrix_test.rb" "test/benchmarks/classifier-reborn/test/extensions/token_filter/stemmer_test.rb" "test/benchmarks/classifier-reborn/test/extensions/token_filter/stopword_test.rb" "test/benchmarks/classifier-reborn/test/extensions/token_filter/symbol_test.rb" "test/benchmarks/classifier-reborn/test/extensions/tokenizer/token_test.rb" "test/benchmarks/classifier-reborn/test/extensions/tokenizer/whitespace_test.rb" "test/benchmarks/classifier-reborn/test/extensions/zero_vector_test.rb" "test/benchmarks/classifier-reborn/test/lsi/lsi_test.rb" "test/benchmarks/classifier-reborn/test/lsi/word_list_test.rb" "test/coverband/adapters/base_test.rb" "test/coverband/adapters/file_store_test.rb" "test/coverband/adapters/redis_store_test.rb" "test/coverband/at_exit_test.rb" "test/coverband/collectors/coverage_test.rb" "test/coverband/configuration_test.rb" "test/coverband/coverband_test.rb" "test/coverband/integrations/background_test.rb" "test/coverband/integrations/middleware_test.rb" "test/coverband/integrations/rack_server_check_test.rb" "test/coverband/integrations/resque_worker_test.rb" "test/coverband/reporters/base_test.rb" "test/coverband/reporters/console_test.rb" "test/coverband/reporters/html_test.rb" "test/coverband/reporters/web_test.rb" "test/coverband/utils/file_groups_test.rb" "test/coverband/utils/file_list_test.rb" "test/coverband/utils/gem_list_test.rb" "test/coverband/utils/lines_classifier_test.rb" "test/coverband/utils/result_test.rb" "test/coverband/utils/s3_report_test.rb" "test/coverband/utils/source_file_line_test.rb" "test/coverband/utils/source_file_test.rb" "test/integration/full_stack_test.rb" "test/integration/rails_full_stack_test.rb" "test/integration/rails_gems_full_stack_test.rb" ]
/Users/karlbaum/.gem/ruby/2.5.3/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/Users/karlbaum/.gem/ruby/2.5.3/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `load'
/Users/karlbaum/.gem/ruby/2.5.3/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:74:in `kernel_load'
/Users/karlbaum/.gem/ruby/2.5.3/gems/bundler-1.17.3/lib/bundler/cli/exec.rb:28:in `run'
/Users/karlbaum/.gem/ruby/2.5.3/gems/bundler-1.17.3/lib/bundler/cli.rb:463:in `exec'
/Users/karlbaum/.gem/ruby/2.5.3/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/karlbaum/.gem/ruby/2.5.3/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/Users/karlbaum/.gem/ruby/2.5.3/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/Users/karlbaum/.gem/ruby/2.5.3/gems/bundler-1.17.3/lib/bundler/cli.rb:27:in `dispatch'
/Users/karlbaum/.gem/ruby/2.5.3/gems/bundler-1.17.3/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/Users/karlbaum/.gem/ruby/2.5.3/gems/bundler-1.17.3/lib/bundler/cli.rb:18:in `start'
/Users/karlbaum/.gem/ruby/2.5.3/gems/bundler-1.17.3/exe/bundle:30:in `block in <top (required)>'
/Users/karlbaum/.gem/ruby/2.5.3/gems/bundler-1.17.3/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
/Users/karlbaum/.gem/ruby/2.5.3/gems/bundler-1.17.3/exe/bundle:22:in `<top (required)>'
/Users/karlbaum/.gem/ruby/2.5.3/bin/bundle:23:in `load'
/Users/karlbaum/.gem/ruby/2.5.3/bin/bundle:23:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

When I used git bisect, I traced it down to this change I made which accidentally was including benchmarks in default test task. I don't really understand why this started happening to me tonight as I made this change a while back. Either way, this fixes it and does what we want I believe.