### PR TITLE
Add require_unique_files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ temp_results
 .byebug_history
 .env
 log/
+test/unique_files
+test/rails5_dummy/tmp

--- a/test/coverband/collectors/coverage_test.rb
+++ b/test/coverband/collectors/coverage_test.rb
@@ -21,10 +21,10 @@ class CollectorsCoverageTest < Minitest::Test
   end
 
   test 'Dog class coverage' do
-    load File.expand_path('../../dog.rb', File.dirname(__FILE__))
+    file = require_unique_file
     coverband.report_coverage(true)
     coverage = Coverband.configuration.store.coverage
-    assert_equal(coverage["./test/dog.rb"]["data"], [nil, nil, 1, 1, 0, nil, nil])
+    assert_equal(coverage[file]["data"], [nil, nil, 1, 1, 0, nil, nil])
   end
 
   test 'Dog method and class coverage' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,7 @@ require 'json'
 require 'redis'
 require 'resque'
 require 'pry-byebug'
+require_relative 'unique_files'
 $VERBOSE = original_verbosity
 
 Coveralls.wear!

--- a/test/unique_files.rb
+++ b/test/unique_files.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'fileutils'
+
+UNIQUE_FILES_DIR = "./test/unique_files"
+
+def require_unique_file(file = 'dog.rb')
+  dir = "#{UNIQUE_FILES_DIR}/#{SecureRandom.uuid}"
+  FileUtils.mkdir_p(dir)
+  temp_file = "#{dir}/#{file}"
+  File.open(temp_file, 'w'){ |w| w.write(File.read("./test/#{file}")) }
+  require temp_file
+  temp_file
+end
+
+def remove_unique_files
+  FileUtils.rm_r(UNIQUE_FILES_DIR) if File.exist?(UNIQUE_FILES_DIR)
+end
+
+Minitest.after_run do
+  remove_unique_files
+end


### PR DESCRIPTION
Allow for requiring unique "dog.rb" files for testing isolation. Idea is that when calling require_unique_file, a unique file is generated using SecureRandom.uuid as part of the path. After all tests have run, the unique files are removed.