### PR TITLE
Reset collector on configure

### DIFF
--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -47,6 +47,7 @@ module Coverband
     else
       configuration.logger&.debug('using default configuration')
     end
+    coverage.reset_instance
   end
 
   def self.report_coverage(force_report = false)

--- a/lib/coverband/utils/railtie.rb
+++ b/lib/coverband/utils/railtie.rb
@@ -12,6 +12,10 @@ module Coverband
       Coverband.runtime_coverage!
     end
 
+    config.before_initialize do
+      Coverband.eager_loading_coverage!
+    end
+
     rake_tasks do
       load 'coverband/utils/tasks.rb'
     end

--- a/test/rails4_dummy/config/coverband.rb
+++ b/test/rails4_dummy/config/coverband.rb
@@ -4,5 +4,8 @@ Coverband.configure do |config|
   config.ignore            = %w[vendor .erb$ .slim$]
   config.root_paths        = []
   config.logger              = Rails.logger
-  config.background_reporting_sleep_seconds = 0.1
+  config.verbose           = true
+  config.background_reporting_enabled = false
+  config.track_gems = true
+  config.gem_details = true
 end

--- a/test/rails5_dummy/config/coverband.rb
+++ b/test/rails5_dummy/config/coverband.rb
@@ -5,5 +5,7 @@ Coverband.configure do |config|
   config.root_paths        = []
   config.logger            = Rails.logger
   config.verbose           = true
-  config.background_reporting_sleep_seconds = 0.1
+  config.background_reporting_enabled = false
+  config.track_gems = true
+  config.gem_details = true
 end

--- a/test/rails_test_helper.rb
+++ b/test/rails_test_helper.rb
@@ -7,9 +7,6 @@ def rails_setup
   #coverband must be required after rails
   load 'coverband/utils/railtie.rb'
   Coverband.configure("./test/rails#{Rails::VERSION::MAJOR}_dummy/config/coverband.rb")
-  Coverband.configuration.background_reporting_enabled = false
-  Coverband.configuration.track_gems = true
-  Coverband.configuration.gem_details = true
   require_relative "../test/rails#{Rails::VERSION::MAJOR}_dummy/config/environment"
   require 'capybara/rails'
   #Our coverage report is wrapped in display:none as of now


### PR DESCRIPTION
On master the following was failing:

```
bundle exec m test/integration/rails_full_stack_test.rb
```

The problem was that even though we were calling Coverband#configure with track_gems set to true within the test setup, Collectors::Coverage @track_gems had already been set to false. This is most likely only a problem in tests as Coverband#configure is invoked more than once.