### PR TITLE
Check if thread is still alive

### DIFF
--- a/lib/coverband/integrations/background.rb
+++ b/lib/coverband/integrations/background.rb
@@ -15,19 +15,20 @@ module Coverband
     end
 
     def self.running?
-      !!@thread
+      @thread && @thread.alive?
     end
 
     def self.start
-      return if @thread
+      return if running?
 
       logger = Coverband.configuration.logger
       @semaphore.synchronize do
-        return if @thread
+        return if running?
         logger&.debug('Coverband: Starting background reporting')
         sleep_seconds = Coverband.configuration.background_reporting_sleep_seconds
         @thread = Thread.new do
           loop do
+            puts "Background thread reporting pid: #{Process.pid}"
             Coverband.report_coverage(true)
             logger&.debug("Coverband: Reported coverage via thread. Sleeping #{sleep_seconds}s") if Coverband.configuration.verbose
             sleep(sleep_seconds)

--- a/test/coverband/integrations/background_test.rb
+++ b/test/coverband/integrations/background_test.rb
@@ -3,26 +3,29 @@
 require File.expand_path('../../test_helper', File.dirname(__FILE__))
 
 class BackgroundTest < Minitest::Test
-  def setup
-    super
-    Coverband.configure do |config|
-      config.store = Coverband::Adapters::RedisStore.new(Redis.new)
-      config.background_reporting_enabled = true
-      config.background_reporting_sleep_seconds = 30
-    end
-    Coverband::Background.stop
-  end
-
-  class ThreadDouble
+  class ThreadDouble < Struct.new(:alive)
     def exit
+    end
+
+    def alive?
+      alive
     end
   end
 
   def test_start
-    Thread.expects(:new).yields.returns(ThreadDouble.new)
+    Thread.expects(:new).yields.returns(ThreadDouble.new(true))
     Coverband::Background.expects(:loop).yields
     Coverband::Background.expects(:sleep).with(30)
     Coverband::Collectors::Coverage.instance.expects(:report_coverage).once
     2.times { Coverband::Background.start }
   end
+
+  def test_start_dead_thread
+    Thread.expects(:new).yields.returns(ThreadDouble.new(false)).twice
+    Coverband::Background.expects(:loop).yields.twice
+    Coverband::Background.expects(:sleep).with(30).twice
+    Coverband::Collectors::Coverage.instance.expects(:report_coverage).twice
+    2.times { Coverband::Background.start }
+  end
+
 end


### PR DESCRIPTION
When a process forks, the thread instance variable will be copied to the new process but the thread will not be running. This checks the thread to see if if it is alive. If it is not, a new thread is started.

Noticed this issue when trying to get coverband to work with https://github.com/jondot/sneakers. Tried to start the background thread after_fork:

```ruby
  after_fork: lambda do
    Coverband::Background.start
  end
```
This did not work since the `@thread` instance was not null but the thread itself was no longer running.

