### PR TITLE
fix for resque boot storing runtime coverage

### DIFF
--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -5,7 +5,6 @@ require_relative 'delta'
 module Coverband
   module Collectors
     ###
-    # TODO: look at alternatives to semaphore
     # StandardError seems like be better option
     # coverband previously had RuntimeError here
     # but runtime error can let a large number of error crash this method
@@ -13,7 +12,6 @@ module Coverband
     ###
     class Coverage
       include Singleton
-      extend Forwardable
 
       def reset_instance
         @project_directory = File.expand_path(Coverband.configuration.root)

--- a/lib/coverband/collectors/delta.rb
+++ b/lib/coverband/collectors/delta.rb
@@ -18,13 +18,17 @@ module Coverband
 
       def self.results(process_coverage = RubyCoverage)
         @semaphore.synchronize do
-          @@previous_coverage ||= {}
+          set_default_results
           new(process_coverage.results).results
         end
       end
 
       def self.previous_results
         @@previous_coverage
+      end
+
+      def self.set_default_results
+        @@previous_coverage ||= {}
       end
 
       def results

--- a/lib/coverband/integrations/resque.rb
+++ b/lib/coverband/integrations/resque.rb
@@ -2,9 +2,11 @@
 
 Resque.after_fork do |job|
   Coverband.start
+  Coverband.runtime_coverage!
 end
 
 Resque.before_first_fork do
+  Coverband.eager_loading_coverage!
   Coverband.configuration.background_reporting_enabled = false
   Coverband::Background.stop
   Coverband::Collectors::Coverage.instance.report_coverage(true)

--- a/lib/coverband/integrations/resque.rb
+++ b/lib/coverband/integrations/resque.rb
@@ -3,6 +3,8 @@
 Resque.after_fork do |job|
   Coverband.start
   Coverband.runtime_coverage!
+  # no reason to miss coverage on a first resque job
+  Coverband::Collectors::Delta.set_default_results
 end
 
 Resque.before_first_fork do

--- a/test/coverband/integrations/resque_worker_test.rb
+++ b/test/coverband/integrations/resque_worker_test.rb
@@ -31,6 +31,12 @@ class ResqueWorkerTest < Minitest::Test
 
     assert !Coverband::Background.running?
 
-    assert_equal 1, Coverband.configuration.store.coverage[relative_job_file]['data'][4]
+    # TODO: There is a test only type issue where the test is looking at eager data
+    # it merged eager and eager for merged and runtime is eager
+    Coverband.runtime_coverage!
+    report = Coverband.configuration.store.get_coverage_report
+
+    assert_equal 0, report[Coverband::EAGER_TYPE][relative_job_file]['data'][4]
+    assert_equal 1, report[Coverband::RUNTIME_TYPE][relative_job_file]['data'][4]
   end
 end


### PR DESCRIPTION
OK, this resolves issues where resque booting would store boot time coverage as runtime coverage.

I think this brings up if this would be an issue with other integrations, or if we need to better document how to integrate this for things like default Rack apps.

take a look @kbaum and I will look at doing a bit more testing and try to see if this is the only issue
