### PR TITLE
Skip first runtime report when eager load false

### DIFF
--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -22,6 +22,7 @@ module Coverband
         @logger   = Coverband.configuration.logger
         @test_env = Coverband.configuration.test_env
         @track_gems = Coverband.configuration.track_gems
+        @skip_next_report = false
         Delta.reset
         self
       end
@@ -36,6 +37,10 @@ module Coverband
 
       def skip_next_report!
         @skip_next_report = true
+      end
+
+      def disable_skip_next_report!
+        @skip_next_report = false
       end
 
       def report_coverage(force_report = false)

--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -34,6 +34,10 @@ module Coverband
         @store.type = Coverband::EAGER_TYPE
       end
 
+      def skip_next_report!
+        @skip_next_report = true
+      end
+
       def report_coverage(force_report = false)
         return if !ready_to_report? && !force_report
         raise 'no Coverband store set' unless @store
@@ -46,8 +50,10 @@ module Coverband
         # when we are in runtime collection mode, which do not have a cache of previous
         # coverage to remove the initial stdlib Coverage loading data
         ###
-        if ((original_previous_set.nil? && @store.type == Coverband::EAGER_TYPE) ||
-           (original_previous_set && @store.type != Coverband::EAGER_TYPE))
+        if @skip_next_report
+          @logger&.info('skipping report of coverage') if @verbose
+          @skip_next_report = false
+        else
           @store.save_report(files_with_line_usage)
         end
       rescue StandardError => err

--- a/lib/coverband/collectors/delta.rb
+++ b/lib/coverband/collectors/delta.rb
@@ -18,17 +18,13 @@ module Coverband
 
       def self.results(process_coverage = RubyCoverage)
         @semaphore.synchronize do
-          set_default_results
+          @@previous_coverage ||= {}
           new(process_coverage.results).results
         end
       end
 
       def self.previous_results
         @@previous_coverage
-      end
-
-      def self.set_default_results
-        @@previous_coverage ||= {}
       end
 
       def results

--- a/lib/coverband/integrations/resque.rb
+++ b/lib/coverband/integrations/resque.rb
@@ -4,7 +4,7 @@ Resque.after_fork do |job|
   Coverband.start
   Coverband.runtime_coverage!
   # no reason to miss coverage on a first resque job
-  Coverband::Collectors::Delta.set_default_results
+  Coverband.coverage.disable_skip_next_report!
 end
 
 Resque.before_first_fork do

--- a/lib/coverband/utils/file_path_helper.rb
+++ b/lib/coverband/utils/file_path_helper.rb
@@ -6,6 +6,7 @@
 module Coverband
   module Utils
     module FilePathHelper
+      extend self
       ###
       # Takes a full path and converts to a relative path
       ###

--- a/lib/coverband/utils/railtie.rb
+++ b/lib/coverband/utils/railtie.rb
@@ -10,6 +10,10 @@ module Coverband
     config.after_initialize do
       Coverband.report_coverage(true)
       Coverband.configuration.logger&.debug('Coverband: reported after_initialize')
+      unless Rails.configuration.eager_load
+        Coverband.configuration.logger&.debug('Coverband: setting to skip next report')
+        Coverband.coverage.skip_next_report!
+      end
       Coverband.runtime_coverage!
     end
 

--- a/test/coverband/collectors/coverage_test.rb
+++ b/test/coverband/collectors/coverage_test.rb
@@ -67,9 +67,9 @@ class CollectorsCoverageTest < Minitest::Test
   end
 
   test '#skip_next_report!' do
-    @coverband.skip_next_report!
     store = Coverband.configuration.store
     @coverband.reset_instance
+    @coverband.skip_next_report!
     store.expects(:save_report).once
     @coverband.report_coverage(true)
     @coverband.report_coverage(true)

--- a/test/coverband/collectors/coverage_test.rb
+++ b/test/coverband/collectors/coverage_test.rb
@@ -66,6 +66,15 @@ class CollectorsCoverageTest < Minitest::Test
     assert_match /Oh no/, error.message
   end
 
+  test '#skip_next_report!' do
+    @coverband.skip_next_report!
+    store = Coverband.configuration.store
+    @coverband.reset_instance
+    store.expects(:save_report).once
+    @coverband.report_coverage(true)
+    @coverband.report_coverage(true)
+  end
+
   test 'default tmp ignores' do
     heroku_build_file = '/tmp/build_81feca8c72366e4edf020dc6f1937485/config/initializers/assets.rb'
     assert_equal false, @coverband.send(:track_file?, heroku_build_file)

--- a/test/integration/full_stack_test.rb
+++ b/test/integration/full_stack_test.rb
@@ -34,13 +34,13 @@ class FullStackTest < Minitest::Test
     results = middleware.call(request)
     assert_equal 'Hello Rack!', results.last
     sleep(0.2)
-    expected = [nil, nil, 0, nil, 0, 0, 1, nil, nil]
+    expected = [nil, nil, 1, nil, 1, 1, 1, nil, nil]
     assert_equal expected, Coverband.configuration.store.coverage[RELATIVE_FILE]['data']
 
     # additional calls increase count by 1
     middleware.call(request)
     sleep(0.2)
-    expected = [nil, nil, 0, nil, 0, 0, 2, nil, nil]
+    expected = [nil, nil, 1, nil, 1, 1, 2, nil, nil]
     assert_equal expected, Coverband.configuration.store.coverage[RELATIVE_FILE]['data']
   end
 

--- a/test/unique_files.rb
+++ b/test/unique_files.rb
@@ -6,12 +6,13 @@ require 'fileutils'
 UNIQUE_FILES_DIR = "./test/unique_files"
 
 def require_unique_file(file = 'dog.rb')
-  dir = "#{UNIQUE_FILES_DIR}/#{SecureRandom.uuid}"
-  FileUtils.mkdir_p(dir)
+  uuid = SecureRandom.uuid
+  dir = "#{UNIQUE_FILES_DIR}/#{uuid}"
   temp_file = "#{dir}/#{file}"
+  FileUtils.mkdir_p(Pathname.new(temp_file).dirname.to_s)
   File.open(temp_file, 'w'){ |w| w.write(File.read("./test/#{file}")) }
   require temp_file
-  temp_file
+  Coverband::Utils::FilePathHelper.full_path_to_relative(File.expand_path(temp_file))
 end
 
 def remove_unique_files


### PR DESCRIPTION
What you uncovered [here](https://github.com/danmayer/coverband/pull/232#discussion_r277527218), gave me an idea for skipping first coverage report in rails when eager load is false. Let me know what you think.