### PR TITLE
Use rack for coverband:coverage

### DIFF
--- a/lib/coverband/utils/tasks.rb
+++ b/lib/coverband/utils/tasks.rb
@@ -17,6 +17,12 @@ namespace :coverband do
     end
   end
 
+  desc 'report runtime Coverband code coverage'
+  task :coverage_server do
+    environment
+    Rack::Server.start app: Coverband::Reporters::Web.new, Port: ENV.fetch('COVERBAND_COVERAGE_PORT', 1022).to_i
+  end
+
   ###
   # clear data helpful for development or after configuration issues
   ###


### PR DESCRIPTION
This was easier than I thought. We could also just include this as a separate rake task to make everything backwards compatible but it feels tempting to just support the coverage report through rack. As the report gets more advanced it will be difficult to support both.