### PR TITLE
Prepend eager load

### DIFF
--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -46,10 +46,7 @@ module Coverband
         # when we are in runtime collection mode, which do not have a cache of previous
         # coverage to remove the initial stdlib Coverage loading data
         ###
-        if ((original_previous_set.nil? && @store.type == Coverband::EAGER_TYPE) ||
-           (original_previous_set && @store.type != Coverband::EAGER_TYPE))
-          @store.save_report(files_with_line_usage)
-        end
+        @store.save_report(files_with_line_usage)
       rescue StandardError => err
         if @verbose
           @logger&.error 'coverage failed to store'

--- a/lib/coverband/utils/file_path_helper.rb
+++ b/lib/coverband/utils/file_path_helper.rb
@@ -6,6 +6,7 @@
 module Coverband
   module Utils
     module FilePathHelper
+      extend self
       ###
       # Takes a full path and converts to a relative path
       ###

--- a/lib/coverband/utils/railtie.rb
+++ b/lib/coverband/utils/railtie.rb
@@ -19,17 +19,6 @@ module Coverband
       app.middleware.use Coverband::Middleware
     end
 
-    config.after_initialize do
-      Coverband.report_coverage(true)
-      Coverband.configuration.logger&.debug('Coverband: reported after_initialize')
-      Coverband.runtime_coverage!
-    end
-
-    config.before_initialize do
-      Coverband.configuration.logger&.debug('Coverband: set to eager_loading')
-      Coverband.eager_loading_coverage!
-    end
-
     rake_tasks do
       load 'coverband/utils/tasks.rb'
     end

--- a/lib/coverband/utils/railtie.rb
+++ b/lib/coverband/utils/railtie.rb
@@ -2,6 +2,18 @@
 
 Coverband.eager_loading_coverage!
 module Coverband
+  module RailsEagerLoad
+    def eager_load!
+      Coverband.configuration.logger&.debug('Coverband: set to eager_loading')
+      Coverband.eager_loading_coverage!
+      super
+    ensure
+      Coverband.report_coverage(true)
+      Coverband.runtime_coverage!
+    end
+  end
+  Rails::Engine.prepend(RailsEagerLoad)
+
   class Railtie < Rails::Railtie
     initializer 'coverband.configure' do |app|
       app.middleware.use Coverband::Middleware

--- a/test/integration/full_stack_test.rb
+++ b/test/integration/full_stack_test.rb
@@ -6,7 +6,6 @@ require 'rack'
 class FullStackTest < Minitest::Test
   REDIS_STORAGE_FORMAT_VERSION = Coverband::Adapters::RedisStore::REDIS_STORAGE_FORMAT_VERSION
   TEST_RACK_APP = '../fake_app/basic_rack.rb'
-  RELATIVE_FILE = './fake_app/basic_rack.rb'
 
   def setup
     super
@@ -22,8 +21,7 @@ class FullStackTest < Minitest::Test
     Coverband.configuration.store.clear!
     Coverband.start
     Coverband::Collectors::Coverage.instance.runtime!
-    @rack_file = File.expand_path(TEST_RACK_APP, File.dirname(__FILE__))
-    require @rack_file
+    @rack_file = require_unique_file 'fake_app/basic_rack.rb'
     # preload first coverage hit
     Coverband::Collectors::Coverage.instance.report_coverage(true)
   end
@@ -34,14 +32,14 @@ class FullStackTest < Minitest::Test
     results = middleware.call(request)
     assert_equal 'Hello Rack!', results.last
     sleep(0.2)
-    expected = [nil, nil, 0, nil, 0, 0, 1, nil, nil]
-    assert_equal expected, Coverband.configuration.store.coverage[RELATIVE_FILE]['data']
+    expected = [nil, nil, 1, nil, 1, 1, 1, nil, nil]
+    assert_equal expected, Coverband.configuration.store.coverage[@rack_file]['data']
 
     # additional calls increase count by 1
     middleware.call(request)
     sleep(0.2)
-    expected = [nil, nil, 0, nil, 0, 0, 2, nil, nil]
-    assert_equal expected, Coverband.configuration.store.coverage[RELATIVE_FILE]['data']
+    expected = [nil, nil, 1, nil, 1, 1, 2, nil, nil]
+    assert_equal expected, Coverband.configuration.store.coverage[@rack_file]['data']
   end
 
   test 'call app with gem tracking' do

--- a/test/integration/rails_full_stack_test.rb
+++ b/test/integration/rails_full_stack_test.rb
@@ -54,42 +54,44 @@ class RailsFullStackTest < Minitest::Test
   # as we run it in single test mode via the benchmarks.
   # Add new tests below this test
   ###
-  test 'memory usage' do
-    return unless ENV['COVERBAND_MEMORY_TEST']
-    # we don't want this to run during our standard test suite
-    # as the below profiler changes the runtime
-    # and shold only be included for isolated processes
-    begin
-      require 'memory_profiler'
+  if ENV['COVERBAND_MEMORY_TEST']
+    test 'memory usage' do
+      return unless ENV['COVERBAND_MEMORY_TEST']
+      # we don't want this to run during our standard test suite
+      # as the below profiler changes the runtime
+      # and shold only be included for isolated processes
+      begin
+        require 'memory_profiler'
 
-      # warmup
-      3.times do
-        visit '/dummy/show'
-        assert_content('I am no dummy')
-        Coverband.report_coverage(true)
-      end
-
-      previous_out = $stdout
-      capture = StringIO.new
-      $stdout = capture
-
-      MemoryProfiler.report do
-        15.times do
+        # warmup
+        3.times do
           visit '/dummy/show'
           assert_content('I am no dummy')
           Coverband.report_coverage(true)
-          # this is expected to retain memory across requests
-          # clear it to remove the false positive from test
-          Coverband::Collectors::Coverage.instance.send(:add_previous_results, nil)
         end
-      end.pretty_print
-      data = $stdout.string
-      $stdout = previous_out
-      if data.match(/retained objects by gem(.*)retained objects by file/m)[0]&.match(/coverband/)
-        raise 'leaking memory!!!'
+
+        previous_out = $stdout
+        capture = StringIO.new
+        $stdout = capture
+
+        MemoryProfiler.report do
+          15.times do
+            visit '/dummy/show'
+            assert_content('I am no dummy')
+            Coverband.report_coverage(true)
+            # this is expected to retain memory across requests
+            # clear it to remove the false positive from test
+            Coverband::Collectors::Coverage.instance.send(:add_previous_results, nil)
+          end
+        end.pretty_print
+        data = $stdout.string
+        $stdout = previous_out
+        if data.match(/retained objects by gem(.*)retained objects by file/m)[0]&.match(/coverband/)
+          raise 'leaking memory!!!'
+        end
+      ensure
+        $stdout = previous_out
       end
-    ensure
-      $stdout = previous_out
     end
   end
 end

--- a/test/unique_files.rb
+++ b/test/unique_files.rb
@@ -6,12 +6,13 @@ require 'fileutils'
 UNIQUE_FILES_DIR = "./test/unique_files"
 
 def require_unique_file(file = 'dog.rb')
-  dir = "#{UNIQUE_FILES_DIR}/#{SecureRandom.uuid}"
-  FileUtils.mkdir_p(dir)
+  uuid = SecureRandom.uuid
+  dir = "#{UNIQUE_FILES_DIR}/#{uuid}"
   temp_file = "#{dir}/#{file}"
+  FileUtils.mkdir_p(Pathname.new(temp_file).dirname.to_s)
   File.open(temp_file, 'w'){ |w| w.write(File.read("./test/#{file}")) }
   require temp_file
-  temp_file
+  Coverband::Utils::FilePathHelper.full_path_to_relative(File.expand_path(temp_file))
 end
 
 def remove_unique_files


### PR DESCRIPTION
This approach prepends to the `Rails::Engine#eager_load!` method. The reason I went down this path is because in a project that uses sneakers, the eager_load! was explicitly being called.

https://github.com/jondot/sneakers/wiki/Eager-loading

I believe using this approach will avoid the issues we were running into with rails rake tasks disabling eager_load: 

https://github.com/rails/rails/commit/9cac69c602f57e397fe01d866cb24ce1781606d4#diff-580e183141be706162224ef696bdb6c7R294

Using this approach, the eager loading logic only comes into play when eager_load is actually being used. We should not need #233 anymore.