### PR TITLE
Remove previous_coverage code

### DIFF
--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -39,7 +39,6 @@ module Coverband
         return if !ready_to_report? && !force_report
         raise 'no Coverband store set' unless @store
 
-        Delta.previous_results
         files_with_line_usage = filtered_files(Delta.results)
 
         @store.save_report(files_with_line_usage)

--- a/lib/coverband/collectors/delta.rb
+++ b/lib/coverband/collectors/delta.rb
@@ -4,7 +4,7 @@ module Coverband
   module Collectors
     class Delta
       @semaphore = Mutex.new
-      @@previous_coverage = nil
+      @@previous_coverage = {}
       attr_reader :current_coverage
 
       def initialize(current_coverage)
@@ -19,17 +19,8 @@ module Coverband
 
       def self.results(process_coverage = RubyCoverage)
         @semaphore.synchronize do
-          set_default_results
           new(process_coverage.results).results
         end
-      end
-
-      def self.previous_results
-        @@previous_coverage
-      end
-
-      def self.set_default_results
-        @@previous_coverage ||= {}
       end
 
       def results
@@ -39,7 +30,7 @@ module Coverband
       end
 
       def self.reset
-        @@previous_coverage = nil
+        @@previous_coverage = {}
       end
 
       private

--- a/lib/coverband/integrations/resque.rb
+++ b/lib/coverband/integrations/resque.rb
@@ -3,8 +3,6 @@
 Resque.after_fork do |_job|
   Coverband.start
   Coverband.runtime_coverage!
-  # no reason to miss coverage on a first resque job
-  Coverband::Collectors::Delta.set_default_results
 end
 
 Resque.before_first_fork do


### PR DESCRIPTION
Since we now explicitly capture eager_loading coverage within `Rails::Engine#eager_load!`, we no longer need this logic.

This is a continuation of #238 