### PR TITLE
Remove unneccessary eager_loading! in railtie

### DIFF
--- a/lib/coverband/utils/railtie.rb
+++ b/lib/coverband/utils/railtie.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-Coverband.eager_loading_coverage!
 module Coverband
   module RailsEagerLoad
     def eager_load!


### PR DESCRIPTION
Noticed that in development when eager_loading! was never invoked, we were stuck inside eager_loading! because of this unneccessary method call.

It's difficult to test for this since, we can only startup rails one time per process. I think for our integration tests, we will need to come up with a way to fork. This way we can test rails with multiple different configurations.