### PR TITLE
Oneshot coverage

### DIFF
--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -71,7 +71,7 @@ module Coverband
         raise 'abstract'
       end
 
-      def get_report(type = nil)
+      def get_report(_type = nil)
         raise 'abstract'
       end
 

--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -71,7 +71,7 @@ module Coverband
         raise 'abstract'
       end
 
-      def get_report
+      def get_report(type = nil)
         raise 'abstract'
       end
 

--- a/lib/coverband/adapters/file_store.rb
+++ b/lib/coverband/adapters/file_store.rb
@@ -36,7 +36,7 @@ module Coverband
         File.open(path, 'w') { |f| f.write(report.to_json) }
       end
 
-      def get_report
+      def get_report(_local_type = nil)
         if File.exist?(path)
           JSON.parse(File.read(path))
         else

--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -79,7 +79,9 @@ module Coverband
         raise NotImplementedError, 'Coverage needs Ruby > 2.3.0' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
 
         require 'coverage'
-        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
+        if Coverage.ruby_version_greater_than_or_equal_to?('2.6.0')
+          ::Coverage.start(oneshot_lines: Coverband.configuration.use_oneshot_lines_coverage) unless ::Coverage.running?
+        elsif Coverage.ruby_version_greater_than_or_equal_to?('2.5.0')
           ::Coverage.start unless ::Coverage.running?
         else
           ::Coverage.start
@@ -88,6 +90,10 @@ module Coverband
           load safe_file
         end
         reset_instance
+      end
+
+      def self.ruby_version_greater_than_or_equal_to?(version)
+        Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(version)
       end
     end
   end

--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -14,6 +14,10 @@ module Coverband
     class Coverage
       include Singleton
 
+      def self.ruby_version_greater_than_or_equal_to?(version)
+        Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(version)
+      end
+
       def reset_instance
         @project_directory = File.expand_path(Coverband.configuration.root)
         @ignore_patterns = Coverband.configuration.ignore
@@ -90,10 +94,6 @@ module Coverband
           load safe_file
         end
         reset_instance
-      end
-
-      def self.ruby_version_greater_than_or_equal_to?(version)
-        Gem::Version.new(RUBY_VERSION) >= Gem::Version.new(version)
       end
     end
   end

--- a/lib/coverband/collectors/delta.rb
+++ b/lib/coverband/collectors/delta.rb
@@ -12,7 +12,17 @@ module Coverband
 
       class RubyCoverage
         def self.results
-          ::Coverage.peek_result.dup
+          results = ::Coverage.peek_result.dup
+          Coverband.configuration.use_oneshot_lines_coverage ? transform_oneshot_lines_results(results) : results
+        end
+
+        def self.transform_oneshot_lines_results(results)
+          results.each_with_object({}) do |(file, coverage), new_results|
+            line_counts = coverage[:oneshot_lines].each_with_object(::Coverage.line_stub(file)) do |line_number, line_counts|
+              line_counts[line_number - 1] = 1
+            end
+            new_results[file] = line_counts
+          end
         end
       end
 

--- a/lib/coverband/collectors/delta.rb
+++ b/lib/coverband/collectors/delta.rb
@@ -50,12 +50,12 @@ module Coverband
         end
       end
 
-      def self.transform_oneshot_lines_results(results)
+      private_class_method def self.transform_oneshot_lines_results(results)
         results.each_with_object({}) do |(file, coverage), new_results|
-          line_counts = coverage[:oneshot_lines].each_with_object(::Coverage.line_stub(file)) do |line_number, line_counts|
+          transformed_line_counts = coverage[:oneshot_lines].each_with_object(::Coverage.line_stub(file)) do |line_number, line_counts|
             line_counts[line_number - 1] = 1
           end
-          new_results[file] = line_counts
+          new_results[file] = transformed_line_counts
         end
       end
     end

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -154,7 +154,8 @@ module Coverband
     end
 
     def use_oneshot_lines_coverage=(value)
-      raise Exception.new('One shot line coverage is only available in ruby >= 2.6') unless one_shot_coverage_implemented_in_ruby_version? || !value
+      raise(Exception, 'One shot line coverage is only available in ruby >= 2.6') unless one_shot_coverage_implemented_in_ruby_version? || !value
+
       @use_oneshot_lines_coverage = value
     end
 

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rubygems'
-
 module Coverband
   class Configuration
     attr_accessor :root_paths, :root,

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rubygems'
+
 module Coverband
   class Configuration
     attr_accessor :root_paths, :root,
@@ -10,7 +12,7 @@ module Coverband
                   :web_enable_clear, :gem_details, :web_debug, :report_on_exit
 
     attr_writer :logger, :s3_region, :s3_bucket, :s3_access_key_id, :s3_secret_access_key
-    attr_reader :track_gems, :ignore
+    attr_reader :track_gems, :ignore, :use_oneshot_lines_coverage
 
     # Heroku when building assets runs code from a dynamic directory
     # /tmp was added to avoid coverage from /tmp/build directories during
@@ -39,6 +41,7 @@ module Coverband
       @groups = {}
       @web_debug = false
       @report_on_exit = true
+      @use_oneshot_lines_coverage = false
 
       # TODO: should we push these to adapter configs
       @s3_region = nil
@@ -148,6 +151,15 @@ module Coverband
         .each_with_object('gem_paths': gem_paths) do |var, hash|
           hash[var.to_s.delete('@')] = instance_variable_get(var) unless SKIPPED_SETTINGS.include?(var.to_s)
         end
+    end
+
+    def use_oneshot_lines_coverage=(value)
+      raise Exception.new('One shot line coverage is only available in ruby >= 2.6') unless one_shot_coverage_implemented_in_ruby_version? || !value
+      @use_oneshot_lines_coverage = value
+    end
+
+    def one_shot_coverage_implemented_in_ruby_version?
+      Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6.0')
     end
 
     private

--- a/test/coverband/collectors/coverage_test.rb
+++ b/test/coverband/collectors/coverage_test.rb
@@ -70,4 +70,38 @@ class CollectorsCoverageTest < Minitest::Test
     heroku_build_file = '/tmp/build_81feca8c72366e4edf020dc6f1937485/config/initializers/assets.rb'
     assert_equal false, @coverband.send(:track_file?, heroku_build_file)
   end
+
+  test 'one shot line coverage disabled for ruby >= 2.6' do
+    return unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
+    Coverband::Collectors::Coverage.expects(:ruby_version_greater_than_or_equal_to?).with('2.6.0').returns(true)
+    ::Coverage.expects(:running?).returns(false)
+    ::Coverage.expects(:start).with(oneshot_lines: false)
+    Coverband::Collectors::Coverage.send(:new)
+  end
+
+  test 'one shot line coverage enabled for ruby >= 2.6' do
+    return unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
+    Coverband.configuration.expects(:use_oneshot_lines_coverage).returns(true)
+    Coverband::Collectors::Coverage.expects(:ruby_version_greater_than_or_equal_to?).with('2.6.0').returns(true)
+    ::Coverage.expects(:running?).returns(false)
+    ::Coverage.expects(:start).with(oneshot_lines: true)
+    Coverband::Collectors::Coverage.send(:new)
+  end
+
+  test 'one shot line coverage for ruby >= 2.6 when already running' do
+    return unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
+    Coverband::Collectors::Coverage.expects(:ruby_version_greater_than_or_equal_to?).with('2.6.0').returns(true)
+    ::Coverage.expects(:running?).returns(true)
+    ::Coverage.expects(:start).never
+    Coverband::Collectors::Coverage.send(:new)
+  end
+
+  test 'no one shot line coverage for ruby < 2.6' do
+    return unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
+    Coverband::Collectors::Coverage.expects(:ruby_version_greater_than_or_equal_to?).with('2.6.0').returns(false)
+    Coverband::Collectors::Coverage.expects(:ruby_version_greater_than_or_equal_to?).with('2.5.0').returns(true)
+    ::Coverage.expects(:running?).returns(false)
+    ::Coverage.expects(:start).with()
+    Coverband::Collectors::Coverage.send(:new)
+  end
 end

--- a/test/coverband/collectors/delta_test.rb
+++ b/test/coverband/collectors/delta_test.rb
@@ -49,29 +49,25 @@ class CollectorsDeltaTest < Minitest::Test
     assert_equal(current_coverage, results)
   end
 
-  test 'one shot lines results' do
-    unless Coverband.configuration.one_shot_coverage_implemented_in_ruby_version?
-      module ::Coverage
-        def self.line_stub(file)
-        end
-      end
-    end
+  if Coverband.configuration.one_shot_coverage_implemented_in_ruby_version?
+    test 'one shot lines results' do
 
-    Coverband.configuration.stubs(:use_oneshot_lines_coverage).returns(true)
-    current_coverage = {}
-    results = Coverband::Collectors::Delta.results(mock_coverage(current_coverage))
-    assert_equal(current_coverage, results)
+      Coverband.configuration.stubs(:use_oneshot_lines_coverage).returns(true)
+      current_coverage = {}
+      results = Coverband::Collectors::Delta.results(mock_coverage(current_coverage))
+      assert_equal(current_coverage, results)
 
-    current_coverage = {
-      'dealership.rb' => {
-        :oneshot_lines => [2,3]
+      current_coverage = {
+        'dealership.rb' => {
+          :oneshot_lines => [2,3]
+        }
       }
-    }
-    ::Coverage.expects(:line_stub).with('dealership.rb').returns([nil, 0, 0, nil])
-    results = Coverband::Collectors::Delta.results(mock_coverage(current_coverage))
-    expected = {
-      'dealership.rb' => [nil, 1, 1, nil]
-    }
-    assert_equal(expected, results)
+      ::Coverage.expects(:line_stub).with('dealership.rb').returns([nil, 0, 0, nil])
+      results = Coverband::Collectors::Delta.results(mock_coverage(current_coverage))
+      expected = {
+        'dealership.rb' => [nil, 1, 1, nil]
+      }
+      assert_equal(expected, results)
+    end
   end
 end

--- a/test/coverband/collectors/delta_test.rb
+++ b/test/coverband/collectors/delta_test.rb
@@ -59,8 +59,7 @@ class CollectorsDeltaTest < Minitest::Test
 
     Coverband.configuration.stubs(:use_oneshot_lines_coverage).returns(true)
     current_coverage = {}
-    ::Coverage.expects(:peek_result).returns(current_coverage)
-    results = Coverband::Collectors::Delta.results
+    results = Coverband::Collectors::Delta.results(mock_coverage(current_coverage))
     assert_equal(current_coverage, results)
 
     current_coverage = {
@@ -69,8 +68,7 @@ class CollectorsDeltaTest < Minitest::Test
       }
     }
     ::Coverage.expects(:line_stub).with('dealership.rb').returns([nil, 0, 0, nil])
-    ::Coverage.expects(:peek_result).returns(current_coverage)
-    results = Coverband::Collectors::Delta.results
+    results = Coverband::Collectors::Delta.results(mock_coverage(current_coverage))
     expected = {
       'dealership.rb' => [nil, 1, 1, nil]
     }

--- a/test/coverband/collectors/delta_test.rb
+++ b/test/coverband/collectors/delta_test.rb
@@ -48,4 +48,32 @@ class CollectorsDeltaTest < Minitest::Test
     results = Coverband::Collectors::Delta.results(mock_coverage(current_coverage))
     assert_equal(current_coverage, results)
   end
+
+  test 'one shot lines results' do
+    unless Coverband.configuration.one_shot_coverage_implemented_in_ruby_version?
+      module ::Coverage
+        def self.line_stub(file)
+        end
+      end
+    end
+
+    Coverband.configuration.stubs(:use_oneshot_lines_coverage).returns(true)
+    current_coverage = {}
+    ::Coverage.expects(:peek_result).returns(current_coverage)
+    results = Coverband::Collectors::Delta.results
+    assert_equal(current_coverage, results)
+
+    current_coverage = {
+      'dealership.rb' => {
+        :oneshot_lines => [2,3]
+      }
+    }
+    ::Coverage.expects(:line_stub).with('dealership.rb').returns([nil, 0, 0, nil])
+    ::Coverage.expects(:peek_result).returns(current_coverage)
+    results = Coverband::Collectors::Delta.results
+    expected = {
+      'dealership.rb' => [nil, 1, 1, nil]
+    }
+    assert_equal(expected, results)
+  end
 end

--- a/test/coverband/configuration_test.rb
+++ b/test/coverband/configuration_test.rb
@@ -86,4 +86,23 @@ class BaseTest < Minitest::Test
       end
     end
   end
+
+  test 'use_oneshot_lines_coverage' do
+    Coverband::Collectors::Coverage.instance.reset_instance
+    refute Coverband.configuration.use_oneshot_lines_coverage
+
+    Coverband.configuration.stubs(:one_shot_coverage_implemented_in_ruby_version?).returns(true)
+    Coverband.configuration.use_oneshot_lines_coverage = true
+    assert Coverband.configuration.use_oneshot_lines_coverage
+
+    Coverband.configuration.use_oneshot_lines_coverage = false
+    refute Coverband.configuration.use_oneshot_lines_coverage
+
+    Coverband.configuration.stubs(:one_shot_coverage_implemented_in_ruby_version?).returns(false)
+    exception = assert_raises Exception do
+      Coverband.configuration.use_oneshot_lines_coverage = true
+    end
+    assert_equal 'One shot line coverage is only available in ruby >= 2.6', exception.message
+    refute Coverband.configuration.use_oneshot_lines_coverage
+  end
 end

--- a/test/coverband/configuration_test.rb
+++ b/test/coverband/configuration_test.rb
@@ -88,7 +88,6 @@ class BaseTest < Minitest::Test
   end
 
   test 'use_oneshot_lines_coverage' do
-    Coverband::Collectors::Coverage.instance.reset_instance
     refute Coverband.configuration.use_oneshot_lines_coverage
 
     Coverband.configuration.stubs(:one_shot_coverage_implemented_in_ruby_version?).returns(true)


### PR DESCRIPTION
Adds a configuration option `use_oneshot_lines_coverage` which when true enables oneshot_lines coverage in ruby versions >= 2.6.