### PR TITLE
Add Bundle.require eager_loading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in coverband.gemspec
 gemspec
 gem 'rails', '~>5'
-# this is used for testing gem tracking
+# these gems are used for testing gem tracking
+gem 'pundit'
 gem 'rainbow', require: false

--- a/Gemfile.rails4
+++ b/Gemfile.rails4
@@ -7,3 +7,4 @@ gemspec
 gem 'rails', '~>4'
 # this is used for testing gem tracking
 gem 'rainbow', require: false
+gem 'pundit'

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -93,14 +93,7 @@ module Coverband
     configure
     start
     require 'coverband/utils/railtie' if defined? ::Rails::Railtie
-    require 'coverband/integrations/resque' if defined? Resque
-    if defined?(Bundler)
-      module BundlerEagerLoad
-        def require(*groups)
-          Coverband.eager_loading_coverage { super }
-        end
-      end
-      Bundler.singleton_class.prepend BundlerEagerLoad
-    end
+    require 'coverband/integrations/resque' if defined? ::Resque
+    require 'coverband/integrations/bundler' if defined? ::Bundler
   end
 end

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -76,6 +76,10 @@ module Coverband
     coverage_instance.eager_loading!
   end
 
+  def self.eager_loading_coverage(&block)
+    coverage_instance.eager_loading(&block)
+  end
+
   def self.runtime_coverage!
     coverage_instance.runtime!
   end

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -94,5 +94,13 @@ module Coverband
     start
     require 'coverband/utils/railtie' if defined? ::Rails::Railtie
     require 'coverband/integrations/resque' if defined? Resque
+    if defined?(Bundler)
+      module BundlerEagerLoad
+        def require(*groups)
+          Coverband.eager_loading_coverage { super }
+        end
+      end
+      Bundler.singleton_class.prepend BundlerEagerLoad
+    end
   end
 end

--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -38,6 +38,15 @@ module Coverband
         @store.type = Coverband::EAGER_TYPE
       end
 
+      def eager_loading(&block)
+        old_coverage_type = @store.type
+        eager_loading!
+        block.call
+      ensure
+        report_coverage
+        @store.type = old_coverage_type
+      end
+
       def report_coverage
         @semaphore.synchronize do
           raise 'no Coverband store set' unless @store

--- a/lib/coverband/integrations/bundler.rb
+++ b/lib/coverband/integrations/bundler.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module BundlerEagerLoad
+  def require(*groups)
+    Coverband.eager_loading_coverage { super }
+  end
+end
+Bundler.singleton_class.prepend BundlerEagerLoad

--- a/test/coverband/adapters/file_store_test.rb
+++ b/test/coverband/adapters/file_store_test.rb
@@ -16,7 +16,7 @@ class AdaptersFileStoreTest < Minitest::Test
   end
 
   def test_covered_lines_when_null
-    assert_equal @store.coverage['none.rb'], nil
+    assert_nil @store.coverage['none.rb']
   end
 
   def test_covered_files

--- a/test/coverband/adapters/redis_store_test.rb
+++ b/test/coverband/adapters/redis_store_test.rb
@@ -66,7 +66,7 @@ class RedisTest < Minitest::Test
   end
 
   def test_coverage_when_null
-    assert_equal nil, @store.coverage['app_path/dog.rb']
+    assert_nil @store.coverage['app_path/dog.rb']
   end
 
   def test_clear

--- a/test/coverband/collectors/coverage_test.rb
+++ b/test/coverband/collectors/coverage_test.rb
@@ -37,6 +37,20 @@ class CollectorsCoverageTest < Minitest::Test
     assert_equal(coverage['./test/dog.rb']['data'], [nil, nil, 1, 1, 1, nil, nil])
   end
 
+  test 'Dog eager load coverage' do
+    store = Coverband.configuration.store
+    assert_nil store.type
+    file = coverband.eager_loading do
+      require_unique_file
+    end
+    coverage = Coverband.configuration.store.coverage[file]
+    assert_nil coverage, 'No runtime coverage'
+    coverband.eager_loading!
+    coverage = Coverband.configuration.store.coverage[file]
+    refute_nil coverage, 'Eager load coverage is present'
+    assert_equal(coverage['data'], [nil, nil, 1, 1, 0, nil, nil])
+  end
+
   test 'gets coverage instance' do
     assert_equal Coverband::Collectors::Coverage, coverband.class
   end

--- a/test/forked/rails_rake_full_stack_test.rb
+++ b/test/forked/rails_rake_full_stack_test.rb
@@ -1,0 +1,22 @@
+require File.expand_path('../rails_test_helper', File.dirname(__FILE__))
+require 'rails'
+
+class RailsRakeFullStackTest < Minitest::Test
+
+  test 'rake tasks shows coverage properly within eager_loading' do
+    system("COVERBAND_CONFIG=./test/rails#{Rails::VERSION::MAJOR}_dummy/config/coverband.rb bundle exec rake -f test/rails#{Rails::VERSION::MAJOR}_dummy/Rakefile middleware")
+    store.type = :eager_loading
+    pundit_file = store.coverage.keys.grep(/pundit.rb/).first
+    refute_nil pundit_file
+    pundit_coverage = store.coverage[pundit_file]
+    refute_nil pundit_coverage
+    assert_includes pundit_coverage['data'], 1
+
+    store.type = nil
+    pundit_coverage = store.coverage[pundit_file]
+    assert_nil pundit_coverage
+  end
+end
+
+
+

--- a/test/rails4_dummy/Rakefile
+++ b/test/rails4_dummy/Rakefile
@@ -1,0 +1,6 @@
+# Add your own tasks in files placed in lib/tasks ending in .rake,
+# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+
+require_relative 'config/application'
+
+Rails.application.load_tasks

--- a/test/rails4_dummy/config/application.rb
+++ b/test/rails4_dummy/config/application.rb
@@ -5,7 +5,7 @@ require File.expand_path('boot', __dir__)
 require 'rails'
 require 'action_controller/railtie'
 require 'coverband'
-Coverband.eager_loading_coverage { Bundler.require(*Rails.groups) }
+Bundler.require(*Rails.groups)
 
 module Rails4Dummy
   class Application < Rails::Application

--- a/test/rails4_dummy/config/application.rb
+++ b/test/rails4_dummy/config/application.rb
@@ -5,9 +5,7 @@ require File.expand_path('boot', __dir__)
 require 'rails'
 require 'action_controller/railtie'
 require 'coverband'
-Coverband.eager_loading_coverage!
-Bundler.require(*Rails.groups)
-Coverband.report_coverage
+Coverband.eager_loading_coverage { Bundler.require(*Rails.groups) }
 
 module Rails4Dummy
   class Application < Rails::Application

--- a/test/rails4_dummy/config/application.rb
+++ b/test/rails4_dummy/config/application.rb
@@ -4,14 +4,13 @@ require File.expand_path('boot', __dir__)
 
 require 'rails'
 require 'action_controller/railtie'
+require 'coverband'
+Coverband.eager_loading_coverage!
+Bundler.require(*Rails.groups)
+Coverband.report_coverage
+
 module Rails4Dummy
   class Application < Rails::Application
-    # Coverband needs to be setup before any of the initializers to capture usage of them
-    Coverband.configure(File.open("#{Rails.root}/config/coverband.rb"))
-    config.middleware.use Coverband::BackgroundMiddleware
-    config.before_initialize do
-      Coverband.start
-    end
     config.eager_load = true
   end
 end

--- a/test/rails5_dummy/Rakefile
+++ b/test/rails5_dummy/Rakefile
@@ -1,0 +1,6 @@
+# Add your own tasks in files placed in lib/tasks ending in .rake,
+# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+
+require_relative 'config/application'
+
+Rails.application.load_tasks

--- a/test/rails5_dummy/config/application.rb
+++ b/test/rails5_dummy/config/application.rb
@@ -3,9 +3,7 @@
 require 'rails'
 require 'action_controller/railtie'
 require 'coverband'
-Coverband.eager_loading_coverage!
-Bundler.require(*Rails.groups)
-Coverband.report_coverage
+Coverband.eager_loading_coverage { Bundler.require(*Rails.groups) }
 
 module Rails5Dummy
   class Application < Rails::Application

--- a/test/rails5_dummy/config/application.rb
+++ b/test/rails5_dummy/config/application.rb
@@ -3,7 +3,7 @@
 require 'rails'
 require 'action_controller/railtie'
 require 'coverband'
-Coverband.eager_loading_coverage { Bundler.require(*Rails.groups) }
+Bundler.require(*Rails.groups)
 
 module Rails5Dummy
   class Application < Rails::Application

--- a/test/rails5_dummy/config/application.rb
+++ b/test/rails5_dummy/config/application.rb
@@ -3,15 +3,12 @@
 require 'rails'
 require 'action_controller/railtie'
 require 'coverband'
+Coverband.eager_loading_coverage!
+Bundler.require(*Rails.groups)
+Coverband.report_coverage
 
-module Dummy
+module Rails5Dummy
   class Application < Rails::Application
-    # Coverband needs to be setup before any of the initializers to capture usage of them
-    Coverband.configure(File.open("#{Rails.root}/config/coverband.rb"))
-    config.middleware.use Coverband::BackgroundMiddleware
-    config.before_initialize do
-      Coverband.start
-    end
     config.eager_load = true
   end
 end


### PR DESCRIPTION
Modifies rails apps to invoke eager loading within an `eager_loading` block.

Also adds a test that ensures gem coverage is handled correctly.