### PR TITLE
Spike on runtime relevant lines

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,10 @@ Style/NumericLiteralPrefix:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false
+Style/SymbolProc:
+  Enabled: false
+Style/RegexpLiteral:
+  Enabled: false
 Performance/Casecmp:
   Enabled: false
 Performance/RegexpMatch:

--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -38,10 +38,10 @@ module Coverband
         @store.type = Coverband::EAGER_TYPE
       end
 
-      def eager_loading(&block)
+      def eager_loading
         old_coverage_type = @store.type
         eager_loading!
-        block.call
+        yield
       ensure
         report_coverage
         @store.type = old_coverage_type

--- a/lib/coverband/utils/results.rb
+++ b/lib/coverband/utils/results.rb
@@ -30,7 +30,7 @@ module Coverband
 
         return 0.0 unless runtime_file
 
-        return 100.0 unless eager_file
+        return runtime_file.formatted_covered_percent unless eager_file
 
         runtime_relavant_lines = eager_file.relevant_lines - eager_file.covered_lines_count
         runtime_file.runtime_relavant_calculations(runtime_relavant_lines) { |file| file.formatted_covered_percent }

--- a/lib/coverband/utils/results.rb
+++ b/lib/coverband/utils/results.rb
@@ -20,6 +20,22 @@ module Coverband
         get_results(results_type).source_files.find { |file| file.filename == source_file.filename }
       end
 
+      def runtime_relevant_coverage(source_file)
+        eager_loading_coverage = get_results(Coverband::EAGER_TYPE)
+        runtime_coverage = get_results(Coverband::RUNTIME_TYPE)
+        return unless eager_loading_coverage && runtime_coverage
+
+        eager_file = eager_loading_coverage.source_files.find { |file| file.filename == source_file.filename }
+        runtime_file = runtime_coverage.source_files.find { |file| file.filename == source_file.filename }
+
+        return 0.0 unless runtime_file
+
+        return 100.0 unless eager_file
+
+        runtime_relavant_lines = eager_file.relevant_lines - eager_file.covered_lines_count
+        runtime_file.runtime_relavant_calculations(runtime_relavant_lines) { |file| file.formatted_covered_percent }
+      end
+
       ###
       # TODO: Groups still have some issues, this should be generic for groups, but right now gem_name
       # is specifically called out, need to revisit all gorups code.

--- a/lib/coverband/utils/results.rb
+++ b/lib/coverband/utils/results.rb
@@ -33,7 +33,7 @@ module Coverband
         return 100.0 unless eager_file
 
         runtime_relavant_lines = eager_file.relevant_lines - eager_file.covered_lines_count
-        runtime_file.runtime_relavant_calculations(runtime_relavant_lines, &:formatted_covered_percent)
+        runtime_file.runtime_relavant_calculations(runtime_relavant_lines) { |file| file.formatted_covered_percent }
       end
 
       ###

--- a/lib/coverband/utils/results.rb
+++ b/lib/coverband/utils/results.rb
@@ -33,7 +33,7 @@ module Coverband
         return 100.0 unless eager_file
 
         runtime_relavant_lines = eager_file.relevant_lines - eager_file.covered_lines_count
-        runtime_file.runtime_relavant_calculations(runtime_relavant_lines) { |file| file.formatted_covered_percent }
+        runtime_file.runtime_relavant_calculations(runtime_relavant_lines, &:formatted_covered_percent)
       end
 
       ###

--- a/lib/coverband/utils/results.rb
+++ b/lib/coverband/utils/results.rb
@@ -35,7 +35,7 @@ module Coverband
       end
 
       def runtime_relavent_lines(source_file)
-        return 0 unless eager_loading_coverage && runtime_coverage
+        return 0 unless runtime_coverage
 
         eager_file = get_eager_file(source_file)
         runtime_file = get_runtime_file(source_file)

--- a/lib/coverband/utils/results.rb
+++ b/lib/coverband/utils/results.rb
@@ -21,12 +21,10 @@ module Coverband
       end
 
       def runtime_relevant_coverage(source_file)
-        eager_loading_coverage = get_results(Coverband::EAGER_TYPE)
-        runtime_coverage = get_results(Coverband::RUNTIME_TYPE)
         return unless eager_loading_coverage && runtime_coverage
 
-        eager_file = eager_loading_coverage.source_files.find { |file| file.filename == source_file.filename }
-        runtime_file = runtime_coverage.source_files.find { |file| file.filename == source_file.filename }
+        eager_file = get_eager_file(source_file)
+        runtime_file = get_runtime_file(source_file)
 
         return 0.0 unless runtime_file
 
@@ -34,6 +32,17 @@ module Coverband
 
         runtime_relavant_lines = eager_file.relevant_lines - eager_file.covered_lines_count
         runtime_file.runtime_relavant_calculations(runtime_relavant_lines) { |file| file.formatted_covered_percent }
+      end
+
+      def runtime_relavent_lines(source_file)
+        return 0 unless eager_loading_coverage && runtime_coverage
+
+        eager_file = get_eager_file(source_file)
+        runtime_file = get_runtime_file(source_file)
+
+        return runtime_file.covered_lines_count unless eager_file
+
+        eager_file.relevant_lines - eager_file.covered_lines_count
       end
 
       ###
@@ -69,6 +78,22 @@ module Coverband
       end
 
       private
+
+      def get_eager_file(source_file)
+        eager_loading_coverage.source_files.find { |file| file.filename == source_file.filename }
+      end
+
+      def get_runtime_file(source_file)
+        runtime_coverage.source_files.find { |file| file.filename == source_file.filename }
+      end
+
+      def eager_loading_coverage
+        get_results(Coverband::EAGER_TYPE)
+      end
+
+      def runtime_coverage
+        get_results(Coverband::RUNTIME_TYPE)
+      end
 
       ###
       # This is a first version of lazy loading the results

--- a/lib/coverband/utils/source_file.rb
+++ b/lib/coverband/utils/source_file.rb
@@ -90,9 +90,9 @@ module Coverband
       NOT_AVAILABLE = 'not available'
 
 
-
       def initialize(filename, file_data)
         @filename = filename
+        @runtime_relavant_lines = nil
         if file_data.is_a?(Hash)
           @coverage = file_data['data']
           @first_updated_at = @last_updated_at = NOT_AVAILABLE

--- a/lib/coverband/utils/source_file.rb
+++ b/lib/coverband/utils/source_file.rb
@@ -89,6 +89,8 @@ module Coverband
       attr_reader :last_updated_at
       NOT_AVAILABLE = 'not available'
 
+
+
       def initialize(filename, file_data)
         @filename = filename
         if file_data.is_a?(Hash)
@@ -101,6 +103,13 @@ module Coverband
           @first_updated_at = NOT_AVAILABLE
           @last_updated_at = NOT_AVAILABLE
         end
+      end
+
+      def runtime_relavant_calculations(runtime_relavant_lines)
+        @runtime_relavant_lines = runtime_relavant_lines
+        yield self
+      ensure
+        @runtime_relavant_lines = nil
       end
 
       # The path to this source file relative to the projects directory
@@ -171,7 +180,7 @@ module Coverband
       end
 
       def relevant_lines
-        lines.size - never_lines.size - skipped_lines.size
+        @runtime_relavant_lines || (lines.size - never_lines.size - skipped_lines.size)
       end
 
       # Returns all covered lines as SimpleCov::SourceFile::Line

--- a/lib/coverband/utils/source_file.rb
+++ b/lib/coverband/utils/source_file.rb
@@ -11,6 +11,8 @@ module Coverband
   module Utils
     class SourceFile
       include Coverband::Utils::FilePathHelper
+
+      # TODO: Refactor Line into its own file
       # Representation of a single line in a source file including
       # this specific line's source code, line_number and code coverage,
       # with the coverage being either nil (coverage not applicable, e.g. comment
@@ -98,6 +100,7 @@ module Coverband
           @first_updated_at = Time.at(file_data['first_updated_at']) if file_data['first_updated_at']
           @last_updated_at =  Time.at(file_data['last_updated_at']) if file_data['last_updated_at']
         else
+          # TODO: Deprecate this code path this was backwards compatability from 3-4
           @coverage = file_data
           @first_updated_at = NOT_AVAILABLE
           @last_updated_at = NOT_AVAILABLE

--- a/lib/coverband/utils/source_file.rb
+++ b/lib/coverband/utils/source_file.rb
@@ -89,7 +89,6 @@ module Coverband
       attr_reader :last_updated_at
       NOT_AVAILABLE = 'not available'
 
-
       def initialize(filename, file_data)
         @filename = filename
         @runtime_relavant_lines = nil

--- a/test/coverband/utils/file_groups_test.rb
+++ b/test/coverband/utils/file_groups_test.rb
@@ -50,6 +50,6 @@ describe Coverband::Utils::FileGroups, :vendored_gems do
   end
 
   it 'does has gem files' do
-    assert_equal 'gem_name.rb', subject.grouped_results['Gems'].first.first.short_name
+    assert_equal '.gem_name.rb', subject.grouped_results['Gems'].first.first.short_name
   end
 end

--- a/test/coverband/utils/results_test.rb
+++ b/test/coverband/utils/results_test.rb
@@ -4,22 +4,38 @@ require File.expand_path('../../test_helper', File.dirname(__FILE__))
 
 describe 'results' do
   describe 'with a (mocked) Coverage.result' do
+    let(:source_file) { Coverband::Utils::SourceFile.new(source_fixture('app/models/user.rb'), run_lines) }
     let(:eager_lines) { [nil, 1, 1, 0, nil, nil, 1, 0, nil, nil] }
     let(:run_lines) { [nil, nil, nil, 1, nil, nil, nil,nil, nil, nil] }
     let(:original_result) do
-      {
-        Coverband::EAGER_TYPE => {source_fixture('app/models/user.rb') => eager_lines},
-        Coverband::RUNTIME_TYPE => {source_fixture('app/models/user.rb') => run_lines},
+      orig = {
         Coverband::MERGED_TYPE => {source_fixture('app/models/user.rb') => eager_lines},
       }
+      orig.merge!({Coverband::EAGER_TYPE => {source_fixture('app/models/user.rb') => eager_lines}}) if eager_lines
+      orig.merge!({Coverband::RUNTIME_TYPE => {source_fixture('app/models/user.rb') => run_lines}}) if run_lines
+      orig
     end
+    subject { Coverband::Utils::Results.new(original_result) }
 
-    describe 'a runtime relevant lines is supported' do
-      subject { Coverband::Utils::Results.new(original_result) }
-      let(:source_file) { Coverband::Utils::SourceFile.new(source_fixture('app/models/user.rb'), run_lines) }
-
+    describe 'runtime relevant lines is supported' do
       it 'has correct runtime relevant coverage' do
         assert_equal 50.0, subject.runtime_relevant_coverage(source_file)
+      end
+    end
+
+    describe 'runtime relevant lines when no runtime coverage exists' do
+      let(:run_lines) { nil }
+
+      it 'has correct runtime relevant coverage when no runtime coverage exists' do
+        assert_equal 0.0, subject.runtime_relevant_coverage(source_file)
+      end
+    end
+
+    describe 'runtime relevant lines when no eager coverage exists' do
+      let(:eager_lines) { nil }
+
+      it 'has correct runtime relevant coverage when no runtime coverage exists' do
+        assert_equal 100.0, subject.runtime_relevant_coverage(source_file)
       end
     end
   end

--- a/test/coverband/utils/results_test.rb
+++ b/test/coverband/utils/results_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require File.expand_path('../../test_helper', File.dirname(__FILE__))
+
+describe 'results' do
+  describe 'with a (mocked) Coverage.result' do
+    let(:eager_lines) { [nil, 1, 1, 0, nil, nil, 1, 0, nil, nil] }
+    let(:run_lines) { [nil, nil, nil, 1, nil, nil, nil,nil, nil, nil] }
+    let(:original_result) do
+      {
+        Coverband::EAGER_TYPE => {source_fixture('app/models/user.rb') => eager_lines},
+        Coverband::RUNTIME_TYPE => {source_fixture('app/models/user.rb') => run_lines},
+        Coverband::MERGED_TYPE => {source_fixture('app/models/user.rb') => eager_lines},
+      }
+    end
+
+    describe 'a runtime relevant lines is supported' do
+      subject { Coverband::Utils::Results.new(original_result) }
+      let(:source_file) { Coverband::Utils::SourceFile.new(source_fixture('app/models/user.rb'), run_lines) }
+
+      it 'has 3 runtime_relevant_lines' do
+        assert_equal 50.0, subject.runtime_relevant_coverage(source_file)
+      end
+    end
+  end
+end

--- a/test/coverband/utils/results_test.rb
+++ b/test/coverband/utils/results_test.rb
@@ -18,7 +18,7 @@ describe 'results' do
       subject { Coverband::Utils::Results.new(original_result) }
       let(:source_file) { Coverband::Utils::SourceFile.new(source_fixture('app/models/user.rb'), run_lines) }
 
-      it 'has 3 runtime_relevant_lines' do
+      it 'has correct runtime relevant coverage' do
         assert_equal 50.0, subject.runtime_relevant_coverage(source_file)
       end
     end

--- a/test/coverband/utils/results_test.rb
+++ b/test/coverband/utils/results_test.rb
@@ -21,21 +21,33 @@ describe 'results' do
       it 'has correct runtime relevant coverage' do
         assert_equal 50.0, subject.runtime_relevant_coverage(source_file)
       end
+
+      it 'has correct runtime relevant lines' do
+        assert_equal 2, subject.runtime_relavent_lines(source_file)
+      end
     end
 
     describe 'runtime relevant lines when no runtime coverage exists' do
       let(:run_lines) { nil }
 
-      it 'has correct runtime relevant coverage when no runtime coverage exists' do
+      it 'has correct runtime relevant lines' do
         assert_equal 0.0, subject.runtime_relevant_coverage(source_file)
+      end
+
+      it 'has correct runtime relevant lines' do
+        assert_equal 2, subject.runtime_relavent_lines(source_file)
       end
     end
 
     describe 'runtime relevant lines when no eager coverage exists' do
       let(:eager_lines) { nil }
 
-      it 'has correct runtime relevant coverage when no runtime coverage exists' do
+      it 'has correct runtime relevant lines' do
         assert_equal 100.0, subject.runtime_relevant_coverage(source_file)
+      end
+
+      it 'has correct runtime relevant lines' do
+        assert_equal 1, subject.runtime_relavent_lines(source_file)
       end
     end
   end

--- a/views/file_list.erb
+++ b/views/file_list.erb
@@ -39,7 +39,7 @@
             <%= link_to_source_file(source_file) %>
           </td>
           <td class="<%= coverage_css_class(source_file.covered_percent) %> strong"><%= source_file.covered_percent.round(2).to_s %> %</td>
-          <% runtime_percentage = result.file_with_type(source_file, Coverband::RUNTIME_TYPE)&.formatted_covered_percent %>
+          <% runtime_percentage = result.runtime_relevant_coverage(source_file) %>
           <td class="<%= "#{coverage_css_class(runtime_percentage)}" %> strong">
             <%= "#{runtime_percentage || '0'} %" %>
           </td>

--- a/views/source_file.erb
+++ b/views/source_file.erb
@@ -8,7 +8,7 @@
       covered,
 
       <span class="<%= coverage_css_class(source_file.covered_percent) %>">
-        <%= (result.file_with_type(source_file, Coverband::RUNTIME_TYPE)&.covered_percent || 0).round(2).to_s %> %
+        <%= result.runtime_relevant_coverage(source_file) %> %
       </span>
       runtime covered
 
@@ -18,6 +18,7 @@
     </h4>
     <div>
       <b><%= source_file.lines_of_code %></b> relevant lines.
+      <b><%= result.runtime_relavent_lines(source_file) %></b> runtime relevant lines.
       <span class="green"><b><%= source_file.covered_lines.count %></b> lines covered</span> and
       <span class="red"><b><%= source_file.missed_lines.count %></b> lines missed.</span>
     </div>


### PR DESCRIPTION
take a look at this spike and let me know your thoughts @kbaum it definitely adds some complexity, but I can't think of a much better way to allow a source file to know data about a source file from a different execution time context.

This needs further cleanup but wanted to see if the approach makes sense.