### PR TITLE
This is to fix issue #271 where running tests wipes out local apps th…

### DIFF
--- a/test/benchmarks/benchmark.rake
+++ b/test/benchmarks/benchmark.rake
@@ -130,7 +130,7 @@ namespace :benchmarks do
       x.config(time: 12, warmup: 5, suite: suite)
       x.report 'coverband' do
         work
-        Coverband.report_coverage(true)
+        Coverband.report_coverage
       end
       x.report 'no coverband' do
         work
@@ -225,7 +225,7 @@ namespace :benchmarks do
       10.times do
         Coverband.configure do |config|
           redis_url = ENV['CACHE_REDIS_URL'] || ENV['REDIS_URL']
-          config.store = Coverband::Adapters::RedisStore.new(Redis.new(url: redis_url), redis_namespace: 'coverband_data')
+          config.store = Coverband::Adapters::RedisStore.new(Redis.new(url: redis_url), redis_namespace: 'coverband_bench_data')
         end
       end
     end.pretty_print

--- a/test/coverband/adapters/redis_store_test.rb
+++ b/test/coverband/adapters/redis_store_test.rb
@@ -7,8 +7,11 @@ class RedisTest < Minitest::Test
 
   def setup
     super
+    Coverband.configuration.redis_namespace = 'coverband_test'
     @redis = Redis.new
-    @store = Coverband::Adapters::RedisStore.new(@redis)
+    @store = Coverband::Adapters::RedisStore.new(@redis, redis_namespace: 'coverband_test')
+    Coverband.configuration.store = @store
+    @store.clear!
   end
 
   def test_coverage

--- a/test/coverband/collectors/coverage_test.rb
+++ b/test/coverband/collectors/coverage_test.rb
@@ -8,7 +8,7 @@ class CollectorsCoverageTest < Minitest::Test
   def setup
     super
     Coverband.configure do |config|
-      config.store = Coverband::Adapters::RedisStore.new(Redis.new)
+      config.store = Coverband::Adapters::RedisStore.new(Redis.new, redis_namespace: 'coverband_test')
     end
     @coverband = Coverband::Collectors::Coverage.instance.reset_instance
     # preload first coverage hit

--- a/test/coverband/configuration_test.rb
+++ b/test/coverband/configuration_test.rb
@@ -12,7 +12,7 @@ class BaseTest < Minitest::Test
       config.root_paths          = ['/app_path/']
       config.ignore              = ['config/envionments']
       config.reporter            = 'std_out'
-      config.store               = Coverband::Adapters::RedisStore.new(Redis.new)
+      config.store               = Coverband::Adapters::RedisStore.new(Redis.new, redis_namespace: 'coverband_test')
     end
   end
 

--- a/test/coverband/reporters/base_test.rb
+++ b/test/coverband/reporters/base_test.rb
@@ -97,7 +97,7 @@ class ReportsBaseTest < Minitest::Test
 
   test "#get_current_scov_data_imp doesn't ignore folders with default ignore keys" do
     @redis = Redis.new
-    store = Coverband::Adapters::RedisStore.new(@redis)
+    store = Coverband::Adapters::RedisStore.new(@redis, redis_namespace: 'coverband_test')
     store.clear!
 
     Coverband.configure do |config|
@@ -140,7 +140,7 @@ class ReportsBaseTest < Minitest::Test
         "data"=>[16, 16, 16, nil, 16, 16, nil, nil, 16, nil, 16, 32, 32, nil, 32, 32, 32, 32, 32, 32, 32, nil, nil, 16, nil, 16, 32, 23, 0, 0, 0, 0, nil, nil, nil, nil, 0, 0, nil, nil, 16, 32, 32, 32, nil, nil, nil, nil, nil, 16, 32, nil, nil, 16, 32, nil, nil]}
       }
     @redis = Redis.new
-    store = Coverband::Adapters::RedisStore.new(@redis)
+    store = Coverband::Adapters::RedisStore.new(@redis, redis_namespace: 'coverband_test')
     store.clear!
 
     Coverband.configure do |config|

--- a/test/coverband/reporters/console_test.rb
+++ b/test/coverband/reporters/console_test.rb
@@ -8,7 +8,7 @@ class HTMLReportTest < Minitest::Test
   def setup
     super
     @redis = Redis.new
-    @store = Coverband::Adapters::RedisStore.new(@redis)
+    @store = Coverband::Adapters::RedisStore.new(@redis, redis_namespace: 'coverband_test')
     @store.clear!
   end
 

--- a/test/coverband/reporters/html_test.rb
+++ b/test/coverband/reporters/html_test.rb
@@ -6,7 +6,7 @@ class ReportHTMLTest < Minitest::Test
   def setup
     super
     @redis = Redis.new
-    @store = Coverband::Adapters::RedisStore.new(@redis)
+    @store = Coverband::Adapters::RedisStore.new(@redis, redis_namespace: 'coverband_test')
     @store.clear!
     Coverband.configure do |config|
       config.store             = @store

--- a/test/coverband/utils/html_formatter_test.rb
+++ b/test/coverband/utils/html_formatter_test.rb
@@ -6,7 +6,7 @@ class HTMLFormatterTest < Minitest::Test
   def setup
     super
     @redis = Redis.new
-    @store = Coverband::Adapters::RedisStore.new(@redis)
+    @store = Coverband::Adapters::RedisStore.new(@redis, redis_namespace: 'coverband_test')
     @store.clear!
   end
 

--- a/test/forked/rails_rake_full_stack_test.rb
+++ b/test/forked/rails_rake_full_stack_test.rb
@@ -5,6 +5,7 @@ class RailsRakeFullStackTest < Minitest::Test
 
   test 'rake tasks shows coverage properly within eager_loading' do
     system("COVERBAND_CONFIG=./test/rails#{Rails::VERSION::MAJOR}_dummy/config/coverband.rb bundle exec rake -f test/rails#{Rails::VERSION::MAJOR}_dummy/Rakefile middleware")
+    store.instance_variable_set(:@redis_namespace, 'coverband_test')
     store.type = :eager_loading
     pundit_file = store.coverage.keys.grep(/pundit.rb/).first
     refute_nil pundit_file
@@ -17,6 +18,3 @@ class RailsRakeFullStackTest < Minitest::Test
     assert_nil pundit_coverage
   end
 end
-
-
-

--- a/test/integration/full_stack_test.rb
+++ b/test/integration/full_stack_test.rb
@@ -11,7 +11,7 @@ class FullStackTest < Minitest::Test
     super
     Coverband::Collectors::Coverage.instance.reset_instance
     Coverband.configure do |config|
-      config.store = Coverband::Adapters::RedisStore.new(Redis.new)
+      config.store = Coverband::Adapters::RedisStore.new(Redis.new(), redis_namespace: 'coverband_test')
       config.s3_bucket = nil
       config.background_reporting_enabled = true
       config.root_paths = ["#{File.expand_path('../', File.dirname(__FILE__))}/"]

--- a/test/rails4_dummy/config/coverband.rb
+++ b/test/rails4_dummy/config/coverband.rb
@@ -1,6 +1,6 @@
 Coverband.configure do |config|
   config.root              = Dir.pwd
-  config.store             = Coverband::Adapters::RedisStore.new(Redis.new(url: ENV['REDIS_URL'])) if defined? Redis
+  config.store             = Coverband::Adapters::RedisStore.new(Redis.new(url: ENV['REDIS_URL']), redis_namespace: 'coverband_test') if defined? Redis
   config.ignore            = %w[vendor .erb$ .slim$]
   config.root_paths        = []
   config.logger              = Rails.logger

--- a/test/rails5_dummy/config/coverband.rb
+++ b/test/rails5_dummy/config/coverband.rb
@@ -1,6 +1,6 @@
 Coverband.configure do |config|
   config.root              = Dir.pwd
-  config.store             = Coverband::Adapters::RedisStore.new(Redis.new(url: ENV['REDIS_URL'])) if defined? Redis
+  config.store             = Coverband::Adapters::RedisStore.new(Redis.new(url: ENV['REDIS_URL']), redis_namespace: 'coverband_test') if defined? Redis
   config.ignore            = %w[vendor .erb$ .slim$]
   config.root_paths        = []
   config.logger            = Rails.logger

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,12 +29,14 @@ Coveralls.wear!
 module Coverband
   module Test
     def self.reset
+      Coverband.configuration.redis_namespace = 'coverband_test'
       [:eager_loading, nil].each do |type|
         Coverband.configuration.store.type = type
         Coverband.configuration.store.clear!
       end
       Coverband.configuration.reset
       Coverband::Collectors::Coverage.instance.reset_instance
+      Coverband.configuration.redis_namespace = 'coverband_test'
       Coverband::Background.stop
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,6 +30,7 @@ module Coverband
   module Test
     def self.reset
       Coverband.configuration.redis_namespace = 'coverband_test'
+      Coverband.configuration.store.instance_variable_set(:@redis_namespace, 'coverband_test')
       [:eager_loading, nil].each do |type|
         Coverband.configuration.store.type = type
         Coverband.configuration.store.clear!


### PR DESCRIPTION
…at aren't using a namespace

Sadly, even with all of this something is still wiping out the standard namespace when tests are run... Any ideas of what I might be missing?

My best guess is something is clearing so early it is before the namespace is configured / set.