### PR TITLE
Remove unneeded dup

### DIFF
--- a/lib/coverband/collectors/delta.rb
+++ b/lib/coverband/collectors/delta.rb
@@ -12,7 +12,7 @@ module Coverband
 
       class RubyCoverage
         def self.results
-          ::Coverage.peek_result.dup
+          ::Coverage.peek_result
         end
       end
 


### PR DESCRIPTION
Looks like ::Coverage.peek_result makes a new hash each call.

```
irb(main):002:0> Coverage.peek_result.object_id == Coverage.peek_result.object_id
=> false
```

![image](https://user-images.githubusercontent.com/96786/59103495-06945a80-88fd-11e9-9946-e0d47ea0dd7a.png)

