### PR TITLE
Add ability to benchmark ton of files

### DIFF
--- a/test/benchmarks/benchmark.rake
+++ b/test/benchmarks/benchmark.rake
@@ -370,6 +370,17 @@ namespace :benchmarks do
     run_work(true)
   end
 
+  task run_big: %i[setup setup_redis] do
+    require 'memory_profiler'
+    require './test/unique_files'
+    1000.times { require_unique_file }
+    # warmup
+    3.times { Coverband.report_coverage }
+    MemoryProfiler.report do
+      10.times { Coverband.report_coverage }
+    end.pretty_print
+  end
+
   # desc 'runs benchmarks file store'
   task run_file: %i[setup setup_file] do
     puts 'Coverband configured with file store'

--- a/test/unique_files.rb
+++ b/test/unique_files.rb
@@ -19,6 +19,8 @@ def remove_unique_files
   FileUtils.rm_r(UNIQUE_FILES_DIR) if File.exist?(UNIQUE_FILES_DIR)
 end
 
-Minitest.after_run do
-  remove_unique_files
+if defined?(Minitest)
+  Minitest.after_run do
+    remove_unique_files
+  end
 end


### PR DESCRIPTION
Run:
```
bundle exec rake benchmarks:run_big
```
This benchmarks report_coverage on 1000 files using the `require_unique_file`.

Outputs the results of memory_profile to $stdout.