### PR TITLE
Remove repeated integrations/background require from coverband.rb

### DIFF
--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -23,11 +23,10 @@ require 'coverband/collectors/coverage'
 require 'coverband/reporters/base'
 require 'coverband/reporters/html_report'
 require 'coverband/reporters/console_report'
-require 'coverband/integrations/background'
-require 'coverband/integrations/rack_server_check'
 require 'coverband/reporters/web'
-require 'coverband/integrations/background_middleware'
 require 'coverband/integrations/background'
+require 'coverband/integrations/background_middleware'
+require 'coverband/integrations/rack_server_check'
 
 module Coverband
   @@configured = false


### PR DESCRIPTION
Hi,
Just noticed that `require 'coverband/integrations/background'` was called two times.