### PR TITLE
reduce string allocations

### DIFF
--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -4,6 +4,13 @@ module Coverband
   module Adapters
     class Base
       include Coverband::Utils::FilePathHelper
+
+      DATA_KEY = 'data'
+      FIRST_UPDATED_KEY = 'first_updated_at'
+      LAST_UPDATED_KEY = 'last_updated_at'
+      FILE_HASH = 'file_hash'
+      ABSTRACT_KEY = 'abstract'
+
       attr_accessor :type
 
       def initialize
@@ -11,19 +18,19 @@ module Coverband
       end
 
       def clear!
-        raise 'abstract'
+        raise ABSTRACT_KEY
       end
 
       def clear_file!(_file)
-        raise 'abstract'
+        raise ABSTRACT_KEY
       end
 
       def migrate!
-        raise 'abstract'
+        raise ABSTRACT_KEY
       end
 
       def size
-        raise 'abstract'
+        raise ABSTRACT_KEY
       end
 
       def size_in_mib
@@ -41,7 +48,7 @@ module Coverband
       end
 
       def coverage(_local_type = nil)
-        raise 'abstract'
+        raise ABSTRACT_KEY
       end
 
       def get_coverage_report
@@ -68,7 +75,7 @@ module Coverband
       end
 
       def save_coverage
-        raise 'abstract'
+        raise ABSTRACT_KEY
       end
 
       def file_hash(file)
@@ -81,10 +88,10 @@ module Coverband
         updated_time = type == Coverband::EAGER_TYPE ? nil : report_time
         report.each_pair do |key, line_data|
           extended_data = {
-            'first_updated_at' => report_time,
-            'last_updated_at' => updated_time,
-            'file_hash' => file_hash(key),
-            'data' => line_data
+            FIRST_UPDATED_KEY => report_time,
+            LAST_UPDATED_KEY => updated_time,
+            FILE_HASH => file_hash(key),
+            DATA_KEY => line_data
           }
           expanded[full_path_to_relative(key)] = extended_data
         end
@@ -97,7 +104,7 @@ module Coverband
         keys.each do |file|
           new_report[file] = if new_report[file] &&
                                 old_report[file] &&
-                                new_report[file]['file_hash'] == old_report[file]['file_hash']
+                                new_report[file][FILE_HASH] == old_report[file][FILE_HASH]
                                merge_expanded_data(new_report[file], old_report[file])
                              elsif new_report[file]
                                new_report[file]
@@ -110,10 +117,10 @@ module Coverband
 
       def merge_expanded_data(new_expanded, old_expanded)
         {
-          'first_updated_at' => old_expanded['first_updated_at'],
-          'last_updated_at' => new_expanded['last_updated_at'],
-          'file_hash' => new_expanded['file_hash'],
-          'data' => array_add(new_expanded['data'], old_expanded['data'])
+          FIRST_UPDATED_KEY => old_expanded[FIRST_UPDATED_KEY],
+          LAST_UPDATED_KEY => new_expanded[LAST_UPDATED_KEY],
+          FILE_HASH => new_expanded[FILE_HASH],
+          DATA_KEY => array_add(new_expanded[DATA_KEY], old_expanded[DATA_KEY])
         }
       end
 

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -52,6 +52,8 @@ module Coverband
       @web_debug = false
       @report_on_exit = true
       @use_oneshot_lines_coverage = false
+      @current_root = nil
+      @all_root_paths = nil
 
       # TODO: should we push these to adapter configs
       @s3_region = nil
@@ -143,14 +145,20 @@ module Coverband
     end
 
     def current_root
-      File.expand_path(Coverband.configuration.root)
+      @current_root ||= File.expand_path(Coverband.configuration.root).freeze
     end
 
     def all_root_paths
-      roots = Coverband.configuration.root_paths.dup
-      roots += Coverband.configuration.gem_paths.dup if Coverband.configuration.track_gems
-      roots << "#{Coverband.configuration.current_root}/"
-      roots
+      return @all_root_paths if @all_root_paths
+
+      @all_root_paths = Coverband.configuration.root_paths.dup
+      @all_root_paths += Coverband.configuration.gem_paths.dup if Coverband.configuration.track_gems
+      @all_root_paths << "#{Coverband.configuration.current_root}/"
+      @all_root_paths
+    end
+
+    def all_root_patterns
+      all_root_paths.map { |path| /^#{path}/ }.freeze
     end
 
     SKIPPED_SETTINGS = %w[@s3_secret_access_key @store]

--- a/lib/coverband/reporters/base.rb
+++ b/lib/coverband/reporters/base.rb
@@ -9,6 +9,9 @@ module Coverband
     class Base
       class << self
         include Coverband::Utils::FilePathHelper
+
+        DATA_KEY = 'data'
+
         def report(store, _options = {})
           all_roots = Coverband.configuration.all_root_paths
           scov_style_report = get_current_scov_data_imp(store, all_roots)
@@ -54,9 +57,9 @@ module Coverband
             fixed_report[name] = {}
             report.each_pair do |key, vals|
               filename = relative_path_to_full(key, roots)
-              fixed_report[name][filename] = if fixed_report[name].key?(filename) && fixed_report[name][filename]['data'] && vals['data']
-                                               merged_data = merge_arrays(fixed_report[name][filename]['data'], vals['data'])
-                                               vals['data'] = merged_data
+              fixed_report[name][filename] = if fixed_report[name].key?(filename) && fixed_report[name][filename][DATA_KEY] && vals[DATA_KEY]
+                                               merged_data = merge_arrays(fixed_report[name][filename][DATA_KEY], vals[DATA_KEY])
+                                               vals[DATA_KEY] = merged_data
                                                vals
                                              else
                                                vals

--- a/test/benchmarks/benchmark.rake
+++ b/test/benchmarks/benchmark.rake
@@ -373,6 +373,7 @@ namespace :benchmarks do
   task run_big: %i[setup setup_redis] do
     require 'memory_profiler'
     require './test/unique_files'
+    # ensure we cleared from last run
     benchmark_redis_store.clear!
 
     1000.times { require_unique_file }


### PR DESCRIPTION
Fix inspired by new benchmark... We are using strings poorly a few places...Wondering if we can get JSON to use them better as well.

Prior to fix:

```
Allocated String Report
-----------------------------------
     40101  "^/Users/danmayer/projects/coverband/"
     40101  /Users/danmayer/projects/coverband/lib/coverband/utils/file_path_helper.rb:17

     30090  "data"
     20060  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/json-2.2.0/lib/json/common.rb:156
     10030  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:99

     30090  "file_hash"
     20060  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/json-2.2.0/lib/json/common.rb:156
     10030  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:99

     30090  "first_updated_at"
     20060  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/json-2.2.0/lib/json/common.rb:156
     10030  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:99

     30090  "last_updated_at"
     20060  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/json-2.2.0/lib/json/common.rb:156
     10030  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:99

     20060  "/Users/danmayer/projects/coverband"
     10030  /Users/danmayer/projects/coverband/lib/coverband/configuration.rb:146
     10030  /Users/danmayer/projects/coverband/lib/coverband/configuration.rb:152

     20060  "/Users/danmayer/projects/coverband/"
     10030  /Users/danmayer/projects/coverband/lib/coverband/configuration.rb:152
     10030  /Users/danmayer/projects/coverband/lib/coverband/utils/file_path_helper.rb:17

     20000  "4748375a25eb275a00c8d63c3d36cf90"
     10000  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/json-2.2.0/lib/json/common.rb:156
     10000  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:99

     10030  "^"
     10030  /Users/danmayer/projects/coverband/lib/coverband/utils/file_path_helper.rb:17

```

After the fix:

```
Allocated String Report
-----------------------------------
     30090  "data"
     20060  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/json-2.2.0/lib/json/common.rb:156
     10030  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:99

     30090  "file_hash"
     20060  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/json-2.2.0/lib/json/common.rb:156
     10030  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:99

     30090  "first_updated_at"
     20060  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/json-2.2.0/lib/json/common.rb:156
     10030  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:99

     30090  "last_updated_at"
     20060  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/json-2.2.0/lib/json/common.rb:156
     10030  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:99

     30000  "4748375a25eb275a00c8d63c3d36cf90"
     20000  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:99
     10000  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/json-2.2.0/lib/json/common.rb:156

       100  ""
 ```