### PR TITLE
DISCUSSION: Feature/move to marshal

### DIFF
--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -4,6 +4,13 @@ module Coverband
   module Adapters
     class Base
       include Coverband::Utils::FilePathHelper
+
+      DATA_KEY = 'data'
+      FIRST_UPDATED_KEY = 'first_updated_at'
+      LAST_UPDATED_KEY = 'last_updated_at'
+      FILE_HASH = 'file_hash'
+      ABSTRACT_KEY = 'abstract'
+
       attr_accessor :type
 
       def initialize
@@ -11,19 +18,19 @@ module Coverband
       end
 
       def clear!
-        raise 'abstract'
+        raise ABSTRACT_KEY
       end
 
       def clear_file!(_file)
-        raise 'abstract'
+        raise ABSTRACT_KEY
       end
 
       def migrate!
-        raise 'abstract'
+        raise ABSTRACT_KEY
       end
 
       def size
-        raise 'abstract'
+        raise ABSTRACT_KEY
       end
 
       def size_in_mib
@@ -41,7 +48,7 @@ module Coverband
       end
 
       def coverage(_local_type = nil)
-        raise 'abstract'
+        raise ABSTRACT_KEY
       end
 
       def get_coverage_report
@@ -68,7 +75,7 @@ module Coverband
       end
 
       def save_coverage
-        raise 'abstract'
+        raise ABSTRACT_KEY
       end
 
       def file_hash(file)
@@ -81,10 +88,10 @@ module Coverband
         updated_time = type == Coverband::EAGER_TYPE ? nil : report_time
         report.each_pair do |key, line_data|
           extended_data = {
-            'first_updated_at' => report_time,
-            'last_updated_at' => updated_time,
-            'file_hash' => file_hash(key),
-            'data' => line_data
+            FIRST_UPDATED_KEY => report_time,
+            LAST_UPDATED_KEY => updated_time,
+            FILE_HASH => file_hash(key),
+            DATA_KEY => line_data
           }
           expanded[full_path_to_relative(key)] = extended_data
         end
@@ -97,7 +104,7 @@ module Coverband
         keys.each do |file|
           new_report[file] = if new_report[file] &&
                                 old_report[file] &&
-                                new_report[file]['file_hash'] == old_report[file]['file_hash']
+                                new_report[file][FILE_HASH] == old_report[file][FILE_HASH]
                                merge_expanded_data(new_report[file], old_report[file])
                              elsif new_report[file]
                                new_report[file]
@@ -110,10 +117,10 @@ module Coverband
 
       def merge_expanded_data(new_expanded, old_expanded)
         {
-          'first_updated_at' => old_expanded['first_updated_at'],
-          'last_updated_at' => new_expanded['last_updated_at'],
-          'file_hash' => new_expanded['file_hash'],
-          'data' => array_add(new_expanded['data'], old_expanded['data'])
+          FIRST_UPDATED_KEY => old_expanded[FIRST_UPDATED_KEY],
+          LAST_UPDATED_KEY => new_expanded[LAST_UPDATED_KEY],
+          FILE_HASH => new_expanded[FILE_HASH],
+          DATA_KEY => array_add(new_expanded[DATA_KEY], old_expanded[DATA_KEY])
         }
       end
 

--- a/lib/coverband/reporters/base.rb
+++ b/lib/coverband/reporters/base.rb
@@ -9,6 +9,9 @@ module Coverband
     class Base
       class << self
         include Coverband::Utils::FilePathHelper
+
+        DATA_KEY = 'data'
+
         def report(store, _options = {})
           all_roots = Coverband.configuration.all_root_paths
           scov_style_report = get_current_scov_data_imp(store, all_roots)
@@ -54,9 +57,9 @@ module Coverband
             fixed_report[name] = {}
             report.each_pair do |key, vals|
               filename = relative_path_to_full(key, roots)
-              fixed_report[name][filename] = if fixed_report[name].key?(filename) && fixed_report[name][filename]['data'] && vals['data']
-                                               merged_data = merge_arrays(fixed_report[name][filename]['data'], vals['data'])
-                                               vals['data'] = merged_data
+              fixed_report[name][filename] = if fixed_report[name].key?(filename) && fixed_report[name][filename][DATA_KEY] && vals[DATA_KEY]
+                                               merged_data = merge_arrays(fixed_report[name][filename][DATA_KEY], vals[DATA_KEY])
+                                               vals[DATA_KEY] = merged_data
                                                vals
                                              else
                                                vals

--- a/test/benchmarks/benchmark.rake
+++ b/test/benchmarks/benchmark.rake
@@ -373,6 +373,7 @@ namespace :benchmarks do
   task run_big: %i[setup setup_redis] do
     require 'memory_profiler'
     require './test/unique_files'
+    # ensure we cleared from last run
     benchmark_redis_store.clear!
 
     1000.times { require_unique_file }


### PR DESCRIPTION
OK, this is another interesting idea... it looks like most of the issues with Redis and memory other than our delta class are due to JSON. I did some quick research and Marshal is much better... This would need additional work before it could be merged.

serialization benchmarks
https://gist.github.com/shilov/1691428

HUGE Win on the memory benchmark... JSON disappears, Coverband memory cut nearly in half, redis uses 1/5th of memory, and other drops 1/8th...

The basic idea could also be interesting with MsgPack (new gem dependency required), or [json-write-stream](https://github.com/camertron/json-write-stream) (also new gem dependency, but should avoid current JSON issues).

current on master:

```
allocated memory by gem
-----------------------------------
  41363300  json-2.2.0
  33647110  coverband/lib
  20013810  redis-4.1.0
  16630496  other
```

on this branch:

```
allocated memory by gem
-----------------------------------
  19721410  coverband/lib
   4745850  redis-4.1.0
   2160900  other
```
I am pushing coverband:demo to test this on Heroku now to watch the impact. I will add graphs when they are up long enough to collect data.

Full report:

```
bundle exec rake benchmarks:run_big
D, [2019-06-11T15:57:56.427011 #86630] DEBUG -- : using default configuration
D, [2019-06-11T15:57:56.430657 #86630] DEBUG -- : Coverband: Starting background reporting
Total allocated: 26628160 bytes (245280 objects)
Total retained:  153720 bytes (1015 objects)

allocated memory by gem
-----------------------------------
  19721410  coverband/lib
   4745850  redis-4.1.0
   2160900  other

allocated memory by file
-----------------------------------
  13408290  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb
   5544880  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb
   2633300  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb
   2160900  <internal:prelude>
   2109750  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb
    768240  /Users/danmayer/projects/coverband/lib/coverband/adapters/base.rb
      2000  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis.rb
       800  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/client.rb

allocated memory by location
-----------------------------------
   9983080  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83
   3425210  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:105
   2610570  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb:43
   2245920  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb:48
   2160900  <internal:prelude>:76
   2098550  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:28
   1537200  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb:15
   1334400  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb:49
    502800  /Users/danmayer/projects/coverband/lib/coverband/adapters/base.rb:86
    426960  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb:38
    242320  /Users/danmayer/projects/coverband/lib/coverband/adapters/base.rb:103
     21360  /Users/danmayer/projects/coverband/lib/coverband/adapters/base.rb:45
     16730  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb:59
      4000  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:19
      4000  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:8
      4000  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb:68
      1600  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:24
      1600  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb:364
      1360  /Users/danmayer/projects/coverband/lib/coverband/adapters/base.rb:87
       800  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis.rb:801
       800  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/client.rb:123
       800  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:18
       800  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:27
       400  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis.rb:782
       400  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis.rb:783
       400  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis.rb:907
       400  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb:387
       400  /Users/danmayer/projects/coverband/lib/coverband/adapters/base.rb:101
       400  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb:22

allocated memory by class
-----------------------------------
  15676480  String
   5015840  Array
   3884160  Hash
   1216800  Enumerator
    802400  Bignum
     27520  Thread::Backtrace
      2160  Data
      1440  IO::EAGAINWaitReadable
       960  Time
       400  Coverband::Collectors::Delta

allocated objects by gem
-----------------------------------
    244600  coverband/lib
       540  redis-4.1.0
       140  other

allocated objects by file
-----------------------------------
    170560  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb
     73950  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb
       250  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb
       220  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb
       140  <internal:prelude>
        90  /Users/danmayer/projects/coverband/lib/coverband/adapters/base.rb
        50  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis.rb
        20  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/client.rb

allocated objects by location
-----------------------------------
    150480  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83
     33360  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb:49
     20280  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb:48
     20080  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:105
     10150  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb:15
     10150  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb:38
       140  <internal:prelude>:76
       100  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:19
       100  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb:68
        50  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb:43
        50  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb:59
        40  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:24
        40  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb:364
        40  /Users/danmayer/projects/coverband/lib/coverband/adapters/base.rb:103
        20  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis.rb:801
        20  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/client.rb:123
        20  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:18
        20  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:27
        20  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:28
        20  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:8
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/base.rb:87
        10  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis.rb:782
        10  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis.rb:783
        10  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis.rb:907
        10  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb:387
        10  /Users/danmayer/projects/coverband/lib/coverband/adapters/base.rb:101
        10  /Users/danmayer/projects/coverband/lib/coverband/adapters/base.rb:45
        10  /Users/danmayer/projects/coverband/lib/coverband/adapters/base.rb:86
        10  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb:22

allocated objects by class
-----------------------------------
    130860  String
     74040  Array
     20060  Bignum
     10140  Enumerator
     10100  Hash
        20  Data
        20  IO::EAGAINWaitReadable
        20  Thread::Backtrace
        10  Coverband::Collectors::Delta
        10  Time

retained memory by gem
-----------------------------------
    153720  coverband/lib

retained memory by file
-----------------------------------
    153720  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb

retained memory by location
-----------------------------------
    153720  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb:15

retained memory by class
-----------------------------------
    102912  Array
     50808  Hash

retained objects by gem
-----------------------------------
      1015  coverband/lib

retained objects by file
-----------------------------------
      1015  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb

retained objects by location
-----------------------------------
      1015  /Users/danmayer/projects/coverband/lib/coverband/collectors/delta.rb:15

retained objects by class
-----------------------------------
      1014  Array
         1  Hash


Allocated String Report
-----------------------------------
     20160  ""
     20060  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83
        20  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:27
        20  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb:364
        20  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb:43
        20  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb:59
        20  <internal:prelude>:76

     20060  "data"
     20060  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

     20060  "file_hash"
     20060  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

     20060  "first_updated_at"
     20060  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

     20060  "last_updated_at"
     20060  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

     10000  "4748375a25eb275a00c8d63c3d36cf90"
     10000  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        30  "3"
        20  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:19
        10  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:24

        20  "\r\n"
        10  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb:43
        10  <internal:prelude>:76

        20  "$209578\r\n\x04\b{\x02\xEB\x03I\",./lib/coverband/integrations/bundler.rb\x06:\x06EF{\tI\"\x15first_updated_at\x06;\x00Tl+\a\xE6#\x00]I\"\x14last_updated_at\x06;\x00Tl+\a\xE6#\x00]I\"\x0Efile_hash\x06;\x00TI\"%48bdb2a092dea731284553b51415cf88\x06;\x00FI\"\tdata\x06;\x00T[\r00i\x06i\x06i\x000"
        10  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/ruby.rb:59
        10  <internal:prelude>:76

        20  "$3"
        20  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:19

        20  "$35"
        20  /Users/danmayer/.rvm/gems/ruby-2.3.5/gems/redis-4.1.0/lib/redis/connection/command_helper.rb:19

        20  "./lib/coverband/integrations/bundler.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/benchmarks/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/0075aa8e-f574-4fab-8204-175ca9036d07/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/00c90c2c-11aa-4345-a97d-65b620a840d2/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/00f1170c-d24a-4511-971d-bbd33364edb4/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/0126fcca-e15a-4cb8-9cde-e09b2df54fa9/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/013916c4-b3db-4e9e-a926-0629bca5b989/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/016fd683-0141-4210-af69-40ba20927c54/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/01b24acc-a646-4930-b8df-d7d503256f1d/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/01bdddbe-1a0d-4bb2-9635-202abdcb2497/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/01fa1347-02b5-4e01-abab-c8fb1729ea80/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/026c174d-00a4-43e7-a528-8dfc742b5cf7/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/027a8b68-a472-4c64-bdd1-84185880abba/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/02c78a41-27f8-4edf-bdc5-1c9a3b90aa5f/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/031e34ab-57d7-4c16-86ed-838f5b4bd6ed/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/03a1ae24-5af8-42fb-b209-c50ad2bb481f/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/03a5ddab-60d1-4069-bbbb-af8f7a57da5a/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/03bd61a8-5ece-43f7-82fd-bee16a34c296/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/044583d1-2640-4d69-a2df-afe60a82ee3b/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/048bb0c3-7e99-4c82-8af5-73c8804a335c/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/04e9d0f2-e4cc-49f8-8a66-d9b49ff29645/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/05ad5004-0192-4b66-b8c1-9ea0d48a1dfe/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/06188b30-5e1f-4b6a-98d3-b686737b5b34/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/069864b3-acb6-48de-8e12-a532e966ce84/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/06a126c0-d6da-4145-a558-197d8e49296d/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/06b592b8-ea25-4a92-a42f-3fabf4c6fd4f/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/07cd3f89-efd9-4916-83ed-d90efdf1552e/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/07d5c49b-e46f-4cb4-81ea-bca03a36884f/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/07f1405b-6750-404e-934c-69bd206cbf65/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/081adb41-dc57-4891-a802-6e1530fa99bd/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/0855db64-6765-4c5f-bc7f-f7a55ff4a556/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/08771aa5-52d0-4753-a599-a3b27aeb1670/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/08f1be3b-ab2d-40af-97d5-b1b942873e7d/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/09258c9e-2aef-4e79-af90-7997bb304206/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/0935dc06-ac7f-43a4-b5af-8d9b93f0a67f/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/09471efe-a69a-48df-99d8-eb9cdd67a77a/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/094cfe17-f63b-4eec-a74d-7e491651152d/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83

        20  "./test/unique_files/096e0a12-6737-4a3b-8f41-d9ee09197d99/dog.rb"
        20  /Users/danmayer/projects/coverband/lib/coverband/adapters/redis_store.rb:83


Retained String Report
-----------------------------------
```