### PR TITLE
Remove unused link from table of contents in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
   <a href="#key-features">Key Features</a> •
   <a href="#installation">Installation</a> •
   <a href="#coverage-report">Coverage Report</a> •
-  <a href="#verify-correct-installation">Verify Correct Installation</a> •
   <a href="#advanced-config">Advanced Config</a> •
   <a href="#license">License</a> •
   <a href="/changes.md">Change Log / Roadmap</a>


### PR DESCRIPTION
Another micro-fix from me:
"Verify correct installation" section was removed in c26f379, but a link in table-of-contents stayed since then.