### PR TITLE
Don't clobber environment method on main

### DIFF
--- a/lib/coverband/utils/tasks.rb
+++ b/lib/coverband/utils/tasks.rb
@@ -4,7 +4,7 @@ namespace :coverband do
   # handles configuring in require => false and COVERBAND_DISABLE_AUTO_START cases
   Coverband.configure unless Coverband.configured?
 
-  environment = -> {
+  environment = lambda {
     Coverband.configuration.report_on_exit = false
     Coverband.configuration.background_reporting_enabled = false
     Rake.application['environment'].invoke if Rake::Task.task_defined?('environment')

--- a/lib/coverband/utils/tasks.rb
+++ b/lib/coverband/utils/tasks.rb
@@ -4,15 +4,15 @@ namespace :coverband do
   # handles configuring in require => false and COVERBAND_DISABLE_AUTO_START cases
   Coverband.configure unless Coverband.configured?
 
-  def environment
+  environment = -> {
     Coverband.configuration.report_on_exit = false
     Coverband.configuration.background_reporting_enabled = false
     Rake.application['environment'].invoke if Rake::Task.task_defined?('environment')
-  end
+  }
 
   desc 'report runtime Coverband code coverage'
   task :coverage do
-    environment
+    environment.call
     if Coverband.configuration.reporter == 'scov'
       Coverband::Reporters::HTMLReport.new(Coverband.configuration.store).report
     else
@@ -22,7 +22,7 @@ namespace :coverband do
 
   desc 'report runtime Coverband code coverage'
   task :coverage_server do
-    environment
+    environment.call
     Rack::Server.start app: Coverband::Reporters::Web.new, Port: ENV.fetch('COVERBAND_COVERAGE_PORT', 1022).to_i
   end
 
@@ -31,7 +31,7 @@ namespace :coverband do
   ###
   desc 'reset Coverband coverage data, helpful for development, debugging, etc'
   task :clear do
-    environment
+    environment.call
     Coverband.configuration.store.clear!
   end
 
@@ -40,7 +40,7 @@ namespace :coverband do
   ###
   desc 'upgrade previous Coverband datastore to latest format'
   task :migrate do
-    environment
+    environment.call
     Coverband.configuration.store.migrate!
   end
 end


### PR DESCRIPTION
The `environment` method in the Coverband rake task is currently defined on the global namespace, see:

https://kevinjalbert.com/defined_methods-in-rake-tasks-you-re-gonna-have-a-bad-time/

We had an issue because a factory was defining an attribute named `environment` and hitting a conflict with this globally-defined method.

Instead of defining a method here, how about a proc in a closure? This keeps the code encapsulated and will avoid conflicts like this.