### PR TITLE
Memory improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,6 @@ source 'https://rubygems.org'
 gemspec
 gem 'rails', '~>5'
 # these gems are used for testing gem tracking
+gem 'irb', require: false
 gem 'pundit'
 gem 'rainbow', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,8 @@ end
 
 desc 'load irb with this gem'
 task :console do
-  exec 'irb -I lib -r coverband'
+  puts 'running console'
+  exec 'bundle exec irb -I lib -r coverband'
 end
 
 # This is really just for testing and development because without configuration

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ end
 desc 'load irb with this gem'
 task :console do
   puts 'running console'
-  exec 'bundle exec irb -I lib -r coverband'
+  exec 'bundle exec console'
 end
 
 # This is really just for testing and development because without configuration

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -31,7 +31,7 @@ require 'coverband/integrations/rack_server_check'
 module Coverband
   @@configured = false
   CONFIG_FILE = './config/coverband.rb'
-  RUNTIME_TYPE = nil
+  RUNTIME_TYPE = :runtime
   EAGER_TYPE = :eager_loading
   MERGED_TYPE = :merged
   TYPES = [RUNTIME_TYPE, EAGER_TYPE]

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -31,10 +31,7 @@ require 'coverband/integrations/rack_server_check'
 module Coverband
   @@configured = false
   CONFIG_FILE = './config/coverband.rb'
-  # TODO: move to a symbol not nil as it is far better for memory on serialization
-  # breaking change to the model need auto-upgrade or migration to do this.
-  # RUNTIME_TYPE = :runtime
-  RUNTIME_TYPE = nil
+  RUNTIME_TYPE = :runtime
   EAGER_TYPE = :eager_loading
   MERGED_TYPE = :merged
   TYPES = [RUNTIME_TYPE, EAGER_TYPE]

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -31,7 +31,10 @@ require 'coverband/integrations/rack_server_check'
 module Coverband
   @@configured = false
   CONFIG_FILE = './config/coverband.rb'
-  RUNTIME_TYPE = :runtime
+  # TODO: move to a symbol not nil as it is far better for memory on serialization
+  # breaking change to the model need auto-upgrade or migration to do this.
+  # RUNTIME_TYPE = :runtime
+  RUNTIME_TYPE = nil
   EAGER_TYPE = :eager_loading
   MERGED_TYPE = :merged
   TYPES = [RUNTIME_TYPE, EAGER_TYPE]

--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -22,7 +22,7 @@ module Coverband
         raise ABSTRACT_KEY
       end
 
-      def clear_file!(_file)
+      def clear_file!(_file = nil)
         raise ABSTRACT_KEY
       end
 

--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -131,7 +131,11 @@ module Coverband
       end
 
       def array_add(latest, original)
-        latest.map.with_index { |v, i| (v && original[i]) ? v + original[i] : nil }
+        if Coverband.configuration.use_oneshot_lines_coverage
+          latest.map.with_index { |v, i| (v + original[i] >= 1 ? 1 : 0) if v && original[i] }
+        else
+          latest.map.with_index { |v, i| (v && original[i]) ? v + original[i] : nil }
+        end
       end
     end
   end

--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -15,6 +15,7 @@ module Coverband
 
       def initialize
         @file_hash_cache = {}
+        @type = Coverband::RUNTIME_TYPE
       end
 
       def clear!
@@ -100,6 +101,10 @@ module Coverband
       end
 
       def merge_reports(new_report, old_report, options = {})
+        # transparently update from RUNTIME_TYPE = nil to RUNTIME_TYPE = :runtime
+        # transparent update for format coveband_3_2
+        old_report = coverage(nil) if old_report.nil? && type == Coverband::RUNTIME_TYPE
+
         new_report = expand_report(new_report) unless options[:skip_expansion]
         keys = (new_report.keys + old_report.keys).uniq
         keys.each do |file|

--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -103,7 +103,7 @@ module Coverband
       def merge_reports(new_report, old_report, options = {})
         # transparently update from RUNTIME_TYPE = nil to RUNTIME_TYPE = :runtime
         # transparent update for format coveband_3_2
-        old_report = coverage(nil) if old_report.nil? && type == Coverband::RUNTIME_TYPE
+        old_report = coverage(nil, override_type: nil) if old_report.nil? && type == Coverband::RUNTIME_TYPE
 
         new_report = expand_report(new_report) unless options[:skip_expansion]
         keys = (new_report.keys + old_report.keys).uniq

--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -80,8 +80,8 @@ module Coverband
       def simulated_runtime_coverage
         runtime_data = coverage(Coverband::RUNTIME_TYPE)
         eager_data = coverage(Coverband::EAGER_TYPE)
-        eager_data.each_pair do |_key, vals|
-          vals['data'].map! { |el| el ? (0 - el) : el }
+        eager_data.values do |vals|
+          vals['data'].map! { |line_coverage| line_coverage ? (0 - line_coverage) : line_coverage }
         end
         merge_reports(runtime_data, eager_data, skip_expansion: true)
       end

--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -33,6 +33,14 @@ module Coverband
         raise ABSTRACT_KEY
       end
 
+      def save_coverage
+        raise ABSTRACT_KEY
+      end
+
+      def coverage(_local_type = nil)
+        raise ABSTRACT_KEY
+      end
+
       def size_in_mib
         format('%.2f', (size.to_f / 2**20))
       end
@@ -45,10 +53,6 @@ module Coverband
         data = report.dup
         data = merge_reports(data, coverage)
         save_coverage(data)
-      end
-
-      def coverage(_local_type = nil)
-        raise ABSTRACT_KEY
       end
 
       def get_coverage_report
@@ -72,10 +76,6 @@ module Coverband
         types.reduce({}) do |data, type|
           merge_reports(data, coverage(type), skip_expansion: true)
         end
-      end
-
-      def save_coverage
-        raise ABSTRACT_KEY
       end
 
       def file_hash(file)

--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -132,7 +132,7 @@ module Coverband
 
       def array_add(latest, original)
         if Coverband.configuration.use_oneshot_lines_coverage
-          latest.map.with_index { |v, i| (v + original[i] >= 1 ? 1 : 0) if v && original[i] }
+          latest.map!.with_index { |v, i| (v + original[i] >= 1 ? 1 : 0) if v && original[i] }
         else
           latest.map.with_index { |v, i| (v && original[i]) ? v + original[i] : nil }
         end

--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -130,9 +130,12 @@ module Coverband
         }
       end
 
+      # TODO: This should only be 2 cases get our dup / not dups aligned
       def array_add(latest, original)
         if Coverband.configuration.use_oneshot_lines_coverage
           latest.map!.with_index { |v, i| (v + original[i] >= 1 ? 1 : 0) if v && original[i] }
+        elsif Coverband.configuration.simulate_oneshot_lines_coverage
+          latest.map.with_index { |v, i| (v + original[i] >= 1 ? 1 : 0) if v && original[i] }
         else
           latest.map.with_index { |v, i| (v && original[i]) ? v + original[i] : nil }
         end

--- a/lib/coverband/adapters/base.rb
+++ b/lib/coverband/adapters/base.rb
@@ -82,6 +82,7 @@ module Coverband
         @file_hash_cache[file] ||= Digest::MD5.file(file).hexdigest
       end
 
+      # TODO: modify to extend report inline?
       def expand_report(report)
         expanded = {}
         report_time = Time.now.to_i

--- a/lib/coverband/adapters/redis_store.rb
+++ b/lib/coverband/adapters/redis_store.rb
@@ -31,6 +31,8 @@ module Coverband
         Coverband::TYPES.each do |type|
           @redis.del(type_base_key(type))
         end
+        # temporarily clear the old namespace of coverband_3_2
+        @redis.del(type_base_key(nil))
       end
 
       def clear_file!(filename)

--- a/lib/coverband/adapters/redis_store.rb
+++ b/lib/coverband/adapters/redis_store.rb
@@ -74,8 +74,8 @@ module Coverband
         reset_base_key
       end
 
-      def coverage(local_type = nil)
-        local_type ||= type
+      def coverage(local_type = nil, opts = {})
+        local_type ||= opts.key?(:override_type) ? opts[:override_type] : type
         data = redis.get type_base_key(local_type)
         data ? JSON.parse(data) : {}
       end

--- a/lib/coverband/adapters/redis_store.rb
+++ b/lib/coverband/adapters/redis_store.rb
@@ -11,11 +11,7 @@ module Coverband
       # used to store data to redis. It is changed only when breaking changes to our
       # redis format are required.
       ###
-<<<<<<< HEAD
       REDIS_STORAGE_FORMAT_VERSION = 'coverband_3_2'
-=======
-      REDIS_STORAGE_FORMAT_VERSION = 'coverband_3_expD'
->>>>>>> 9dd6890... using nil causes bad string allocations in serialization, RUNTIME_TYPE = :runtime
 
       attr_reader :redis_namespace
 

--- a/lib/coverband/adapters/redis_store.rb
+++ b/lib/coverband/adapters/redis_store.rb
@@ -72,7 +72,7 @@ module Coverband
         reset_base_key
       end
 
-      def coverage(local_type = Coverband::RUNTIME_TYPE)
+      def coverage(local_type = nil)
         local_type ||= type
         data = redis.get type_base_key(local_type)
         data ? JSON.parse(data) : {}

--- a/lib/coverband/adapters/redis_store.rb
+++ b/lib/coverband/adapters/redis_store.rb
@@ -11,7 +11,11 @@ module Coverband
       # used to store data to redis. It is changed only when breaking changes to our
       # redis format are required.
       ###
+<<<<<<< HEAD
       REDIS_STORAGE_FORMAT_VERSION = 'coverband_3_2'
+=======
+      REDIS_STORAGE_FORMAT_VERSION = 'coverband_3_expD'
+>>>>>>> 9dd6890... using nil causes bad string allocations in serialization, RUNTIME_TYPE = :runtime
 
       attr_reader :redis_namespace
 
@@ -72,7 +76,7 @@ module Coverband
         reset_base_key
       end
 
-      def coverage(local_type = nil)
+      def coverage(local_type = Coverband::RUNTIME_TYPE)
         local_type ||= type
         data = redis.get type_base_key(local_type)
         data ? JSON.parse(data) : {}

--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -31,7 +31,7 @@ module Coverband
       end
 
       def runtime!
-        @store.type = nil
+        @store.type = Coverband::RUNTIME_TYPE
       end
 
       def eager_loading!

--- a/lib/coverband/collectors/delta.rb
+++ b/lib/coverband/collectors/delta.rb
@@ -32,7 +32,7 @@ module Coverband
           transform_oneshot_lines_results(current_coverage)
         else
           new_results = generate
-          @@previous_coverage = current_coverage
+          @@previous_coverage = current_coverage unless Coverband.configuration.simulate_oneshot_lines_coverage
           new_results
         end
       end

--- a/lib/coverband/collectors/delta.rb
+++ b/lib/coverband/collectors/delta.rb
@@ -12,7 +12,11 @@ module Coverband
 
       class RubyCoverage
         def self.results
-          ::Coverage.peek_result
+          if Coverband.configuration.use_oneshot_lines_coverage
+            ::Coverage.result(clear: true, stop: false)
+          else
+            ::Coverage.peek_result
+          end
         end
       end
 

--- a/lib/coverband/collectors/delta.rb
+++ b/lib/coverband/collectors/delta.rb
@@ -62,7 +62,7 @@ module Coverband
       def transform_oneshot_lines_results(results)
         results.each_with_object({}) do |(file, coverage), new_results|
           @@stubs[file] ||= ::Coverage.line_stub(file)
-          transformed_line_counts = coverage[:oneshot_lines].each_with_object(@@stubs[file]) do |line_number, line_counts|
+          transformed_line_counts = coverage[:oneshot_lines].each_with_object(@@stubs[file].dup) do |line_number, line_counts|
             line_counts[line_number - 1] = 1
           end
           new_results[file] = transformed_line_counts

--- a/lib/coverband/collectors/delta.rb
+++ b/lib/coverband/collectors/delta.rb
@@ -24,7 +24,7 @@ module Coverband
 
       def results
         new_results = generate
-        @@previous_coverage = current_coverage
+        @@previous_coverage = current_coverage unless Coverband.configuration.use_oneshot_lines_coverage
         new_results
       end
 

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -52,7 +52,8 @@ module Coverband
       @groups = {}
       @web_debug = false
       @report_on_exit = true
-      @use_oneshot_lines_coverage = false
+      @use_oneshot_lines_coverage = ENV['ONESHOT'] || false
+      @simulate_oneshot_lines_coverage = ENV['SIMULATE_ONESHOT'] || false
       @current_root = nil
       @all_root_paths = nil
       @all_root_patterns = nil

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -54,6 +54,7 @@ module Coverband
       @use_oneshot_lines_coverage = false
       @current_root = nil
       @all_root_paths = nil
+      @all_root_patterns = nil
 
       # TODO: should we push these to adapter configs
       @s3_region = nil
@@ -158,7 +159,7 @@ module Coverband
     end
 
     def all_root_patterns
-      all_root_paths.map { |path| /^#{path}/ }.freeze
+      @all_root_patterns ||= all_root_paths.map { |path| /^#{path}/ }.freeze
     end
 
     SKIPPED_SETTINGS = %w[@s3_secret_access_key @store]

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -7,7 +7,8 @@ module Coverband
                   :reporter, :redis_namespace, :redis_ttl,
                   :background_reporting_enabled,
                   :background_reporting_sleep_seconds, :test_env,
-                  :web_enable_clear, :gem_details, :web_debug, :report_on_exit
+                  :web_enable_clear, :gem_details, :web_debug, :report_on_exit,
+                  :simulate_oneshot_lines_coverage
 
     attr_writer :logger, :s3_region, :s3_bucket, :s3_access_key_id, :s3_secret_access_key
     attr_reader :track_gems, :ignore, :use_oneshot_lines_coverage

--- a/lib/coverband/integrations/background.rb
+++ b/lib/coverband/integrations/background.rb
@@ -32,7 +32,9 @@ module Coverband
         @thread = Thread.new do
           loop do
             Coverband.report_coverage
-            logger.debug("Coverband: Reported coverage via thread. Sleeping #{sleep_seconds}s") if Coverband.configuration.verbose
+            if Coverband.configuration.verbose
+              logger.debug("Coverband: background reporting coverage (#{Coverband.configuration.store.type}). Sleeping #{sleep_seconds}s")
+            end
             sleep(sleep_seconds)
           end
         end

--- a/lib/coverband/utils/file_path_helper.rb
+++ b/lib/coverband/utils/file_path_helper.rb
@@ -8,16 +8,23 @@ module Coverband
     module FilePathHelper
       module_function
 
+      @@path_cache = {}
+
       ###
       # Takes a full path and converts to a relative path
       ###
       def full_path_to_relative(full_path)
+        return @@path_cache[full_path] if @@path_cache.key?(full_path)
+
         relative_filename = full_path
         Coverband.configuration.all_root_patterns.each do |root|
           relative_filename = relative_filename.sub(root, './')
           # once we have a relative path break out of the loop
           break if relative_filename.start_with? './'
         end
+
+        @@path_cache[full_path] = relative_filename
+
         relative_filename
       end
 

--- a/lib/coverband/utils/file_path_helper.rb
+++ b/lib/coverband/utils/file_path_helper.rb
@@ -14,7 +14,7 @@ module Coverband
       def full_path_to_relative(full_path)
         relative_filename = full_path
         Coverband.configuration.all_root_paths.each do |root|
-          relative_filename = relative_filename.gsub(/^#{root}/, './')
+          relative_filename = relative_filename.sub(/^#{root}/, './')
           # once we have a relative path break out of the loop
           break if relative_filename.start_with? './'
         end
@@ -42,7 +42,9 @@ module Coverband
         relative_filename = relative_path
         local_filename = relative_filename
         roots.each do |root|
-          relative_filename = relative_filename.gsub(/^#{root}/, './')
+          relative_filename = relative_filename.sub(/^#{root}/, './')
+          # once we have a relative path break out of the loop
+          break if relative_filename.start_with? './'
         end
         # the filename for our reports is expected to be a full path.
         # roots.last should be roots << current_root}/

--- a/lib/coverband/utils/file_path_helper.rb
+++ b/lib/coverband/utils/file_path_helper.rb
@@ -13,8 +13,8 @@ module Coverband
       ###
       def full_path_to_relative(full_path)
         relative_filename = full_path
-        Coverband.configuration.all_root_paths.each do |root|
-          relative_filename = relative_filename.sub(/^#{root}/, './')
+        Coverband.configuration.all_root_patterns.each do |root|
+          relative_filename = relative_filename.sub(root, './')
           # once we have a relative path break out of the loop
           break if relative_filename.start_with? './'
         end

--- a/lib/coverband/utils/source_file.rb
+++ b/lib/coverband/utils/source_file.rb
@@ -160,7 +160,8 @@ module Coverband
 
         return 0.0 if relevant_lines.zero?
 
-        Float(covered_lines.size * 100.0 / relevant_lines.to_f)
+        # handle edge case where runtime in dev can go over 100%
+        [Float(covered_lines.size * 100.0 / relevant_lines.to_f), 100.0].min
       end
 
       def formatted_covered_percent

--- a/test/benchmarks/benchmark.rake
+++ b/test/benchmarks/benchmark.rake
@@ -80,6 +80,7 @@ namespace :benchmarks do
       config.logger              = $stdout
       config.store               = benchmark_redis_store
       config.use_oneshot_lines_coverage = true if ENV['ONESHOT']
+      config.simulate_oneshot_lines_coverage = true if ENV['SIMULATE_ONESHOT']
     end
   end
 

--- a/test/benchmarks/benchmark.rake
+++ b/test/benchmarks/benchmark.rake
@@ -54,9 +54,9 @@ namespace :benchmarks do
     # moving from 5 second of time to 12 still shows slower based on when classifier is required
     # make sure to be plugged in while benchmarking ;) Otherwise you get very unreliable results
     require 'classifier-reborn'
-    if ENV['COVERAGE']
+    if ENV['COVERAGE'] || ENV['ONESHOT']
       require 'coverage'
-      ::Coverage.start
+      ::Coverage.start(oneshot_lines: !!ENV['ONESHOT'])
     end
     require 'redis'
     require 'coverband'
@@ -79,6 +79,7 @@ namespace :benchmarks do
       config.root                = Dir.pwd
       config.logger              = $stdout
       config.store               = benchmark_redis_store
+      config.use_oneshot_lines_coverage = true if ENV['ONESHOT']
     end
   end
 

--- a/test/coverband/adapters/base_test.rb
+++ b/test/coverband/adapters/base_test.rb
@@ -3,49 +3,71 @@
 require File.expand_path('../../test_helper', File.dirname(__FILE__))
 
 class AdaptersBaseTest < Minitest::Test
-  def setup
-    super
-    @test_file_path = '/tmp/coverband_filestore_test_path.json'
-    @store = Coverband::Adapters::FileStore.new(@test_file_path)
-    mock_file_hash
+
+  def test_abstract_methods
+    abstract_methods = %w(clear! clear_file! migrate! size save_coverage coverage)
+    abstract_methods.each do |method|
+      assert_raises RuntimeError do
+        Coverband::Adapters::Base.new.send(method.to_sym)
+      end
+    end
   end
 
-  def test_covered_merge
-    old_time = 1541958097
-    current_time = Time.now.to_i
-    old_data = {
-      'first_updated_at' => old_time,
-      'last_updated_at' => current_time,
-      'file_hash' => 'abcd',
-      'data' => [5, 7, nil]
-    }
-    old_report = { '/projects/coverband_demo/config/coverband.rb' => old_data,
-                   '/projects/coverband_demo/config/initializers/assets.rb' => old_data,
-                   '/projects/coverband_demo/config/initializers/cookies_serializer.rb' => old_data }
-    new_report = { '/projects/coverband_demo/config/coverband.rb' => [5, 7, nil],
-                   '/projects/coverband_demo/config/initializers/filter_logging.rb' => [5, 7, nil],
-                   '/projects/coverband_demo/config/initializers/wrap_parameters.rb' => [5, 7, nil],
-                   '/projects/coverband_demo/app/controllers/application_controller.rb' => [5, 7, nil] }
-    expected_merge = {
-      'first_updated_at' => old_time,
-      'last_updated_at' => current_time,
-      'file_hash' => 'abcd',
-      'data' => [10, 14, nil]
-    }
-    new_data = {
-      'first_updated_at' => current_time,
-      'last_updated_at' => current_time,
-      'file_hash' => 'abcd',
-      'data' => [5, 7, nil]
-    }
-    expected_result = {
-      '/projects/coverband_demo/app/controllers/application_controller.rb' => new_data,
-      '/projects/coverband_demo/config/coverband.rb' => expected_merge,
-      '/projects/coverband_demo/config/initializers/assets.rb' => old_data,
-      '/projects/coverband_demo/config/initializers/cookies_serializer.rb' => old_data,
-      '/projects/coverband_demo/config/initializers/filter_logging.rb' => new_data,
-      '/projects/coverband_demo/config/initializers/wrap_parameters.rb' => new_data
-    }
-    assert_equal expected_result, @store.send(:merge_reports, new_report, old_report)
+  def test_size_in_mib
+    base = Coverband::Adapters::Base.new
+    def base.size
+      3.0
+    end
+    assert_equal "0.00", base.size_in_mib
+  end
+
+  describe 'Coverband::Adapters::Base using file' do
+    def setup
+      super
+      @test_file_path = '/tmp/coverband_filestore_test_path.json'
+      @store = Coverband::Adapters::FileStore.new(@test_file_path)
+      mock_file_hash
+    end
+
+
+
+    def test_covered_merge
+      old_time = 1541958097
+      current_time = Time.now.to_i
+      old_data = {
+        'first_updated_at' => old_time,
+        'last_updated_at' => current_time,
+        'file_hash' => 'abcd',
+        'data' => [5, 7, nil]
+      }
+      old_report = { '/projects/coverband_demo/config/coverband.rb' => old_data,
+                     '/projects/coverband_demo/config/initializers/assets.rb' => old_data,
+                     '/projects/coverband_demo/config/initializers/cookies_serializer.rb' => old_data }
+      new_report = { '/projects/coverband_demo/config/coverband.rb' => [5, 7, nil],
+                     '/projects/coverband_demo/config/initializers/filter_logging.rb' => [5, 7, nil],
+                     '/projects/coverband_demo/config/initializers/wrap_parameters.rb' => [5, 7, nil],
+                     '/projects/coverband_demo/app/controllers/application_controller.rb' => [5, 7, nil] }
+      expected_merge = {
+        'first_updated_at' => old_time,
+        'last_updated_at' => current_time,
+        'file_hash' => 'abcd',
+        'data' => [10, 14, nil]
+      }
+      new_data = {
+        'first_updated_at' => current_time,
+        'last_updated_at' => current_time,
+        'file_hash' => 'abcd',
+        'data' => [5, 7, nil]
+      }
+      expected_result = {
+        '/projects/coverband_demo/app/controllers/application_controller.rb' => new_data,
+        '/projects/coverband_demo/config/coverband.rb' => expected_merge,
+        '/projects/coverband_demo/config/initializers/assets.rb' => old_data,
+        '/projects/coverband_demo/config/initializers/cookies_serializer.rb' => old_data,
+        '/projects/coverband_demo/config/initializers/filter_logging.rb' => new_data,
+        '/projects/coverband_demo/config/initializers/wrap_parameters.rb' => new_data
+      }
+      assert_equal expected_result, @store.send(:merge_reports, new_report, old_report)
+    end
   end
 end

--- a/test/coverband/adapters/base_test.rb
+++ b/test/coverband/adapters/base_test.rb
@@ -21,6 +21,17 @@ class AdaptersBaseTest < Minitest::Test
     assert_equal "0.00", base.size_in_mib
   end
 
+  def test_array_add
+    original = [5, 7, nil, nil]
+    latest = [3, 4, nil, 1]
+    assert_equal [8, 11, nil, nil], Coverband::Adapters::Base.new.send(:array_add, latest, original)
+    Coverband.configuration.stubs(:use_oneshot_lines_coverage).returns(true)
+    assert_equal [1, 1, nil, nil], Coverband::Adapters::Base.new.send(:array_add, latest, original)
+    Coverband.configuration.stubs(:use_oneshot_lines_coverage).returns(false)
+    Coverband.configuration.stubs(:simulate_oneshot_lines_coverage).returns(true)
+    assert_equal [1, 1, nil, nil], Coverband::Adapters::Base.new.send(:array_add, latest, original)
+  end
+
   describe 'Coverband::Adapters::Base using file' do
     def setup
       super
@@ -28,8 +39,6 @@ class AdaptersBaseTest < Minitest::Test
       @store = Coverband::Adapters::FileStore.new(@test_file_path)
       mock_file_hash
     end
-
-
 
     def test_covered_merge
       old_time = 1541958097

--- a/test/coverband/adapters/file_store_test.rb
+++ b/test/coverband/adapters/file_store_test.rb
@@ -3,45 +3,56 @@
 require File.expand_path('../../test_helper', File.dirname(__FILE__))
 
 class AdaptersFileStoreTest < Minitest::Test
-  def setup
-    super
-    @test_file_path = '/tmp/coverband_filestore_test_path.json'
-    File.open(@test_file_path, 'w') { |f| f.write(test_data.to_json) }
-    @store = Coverband::Adapters::FileStore.new(@test_file_path)
+
+  def test_covered_lines_when_no_file
+    @store = Coverband::Adapters::FileStore.new('')
+    expected = {}
+    assert_equal expected, @store.coverage
   end
 
-  def test_coverage
-    assert_equal @store.coverage['dog.rb']['data'][0],  1
-    assert_equal @store.coverage['dog.rb']['data'][1],  2
-  end
+  describe 'Coverband::Adapters::FileStore with file' do
+    def setup
+      super
+      @test_file_path = '/tmp/coverband_filestore_test_path.json'
+      File.open(@test_file_path, 'w') { |f| f.write(test_data.to_json) }
+      @store = Coverband::Adapters::FileStore.new(@test_file_path)
+    end
 
-  def test_covered_lines_when_null
-    assert_nil @store.coverage['none.rb']
-  end
+    def test_size
+      assert @store.size > 1
+    end
 
-  def test_covered_files
-    assert_equal @store.covered_files, ['dog.rb']
-  end
+    def test_coverage
+      assert_equal @store.coverage['dog.rb']['data'][0],  1
+      assert_equal @store.coverage['dog.rb']['data'][1],  2
+    end
 
-  def test_clear
-    @store.clear!
-    assert_equal false, File.exist?(@test_file_path)
-  end
+    def test_covered_lines_when_null
+      assert_nil @store.coverage['none.rb']
+    end
 
-  def test_save_report
-    mock_file_hash
-    @store.send(:save_report, 'cat.rb' => [0, 1])
-    assert_equal @store.coverage['cat.rb']['data'][1], 1
-  end
+    def test_covered_files
+      assert_equal @store.covered_files, ['dog.rb']
+    end
 
-  private
+    def test_clear
+      @store.clear!
+      assert_equal false, File.exist?(@test_file_path)
+    end
 
-  def test_data
-    {
-      'dog.rb' => { 'data' => [1, 2, nil],
-                    'file_hash' => 'abcd',
-                    'first_updated_at' => 1541968729,
-                    'last_updated_at' => 1541968729 }
-    }
+    def test_save_report
+      mock_file_hash
+      @store.send(:save_report, 'cat.rb' => [0, 1])
+      assert_equal @store.coverage['cat.rb']['data'][1], 1
+    end
+
+    def test_data
+      {
+        'dog.rb' => { 'data' => [1, 2, nil],
+                      'file_hash' => 'abcd',
+                      'first_updated_at' => 1541968729,
+                      'last_updated_at' => 1541968729 }
+      }
+    end
   end
 end

--- a/test/coverband/adapters/redis_store_test.rb
+++ b/test/coverband/adapters/redis_store_test.rb
@@ -73,7 +73,7 @@ class RedisTest < Minitest::Test
   end
 
   def test_clear
-    @redis.expects(:del).twice
+    @redis.expects(:del).times(3)
     @store.clear!
   end
 end

--- a/test/coverband/adapters/redis_store_test.rb
+++ b/test/coverband/adapters/redis_store_test.rb
@@ -68,6 +68,14 @@ class RedisTest < Minitest::Test
     assert_equal example_line, @store.coverage['app_path/dog.rb']['data']
   end
 
+  def test_coverage_with_simulate_oneshot_lines_coverage
+    Coverband.configuration.stubs(:simulate_oneshot_lines_coverage).returns(true)
+    mock_file_hash
+    expected = basic_coverage
+    @store.save_report(expected)
+    assert_equal example_line, @store.get_coverage_report[:runtime]['app_path/dog.rb']['data']
+  end
+
   def test_coverage_when_null
     assert_nil @store.coverage['app_path/dog.rb']
   end

--- a/test/coverband/adapters/redis_store_test.rb
+++ b/test/coverband/adapters/redis_store_test.rb
@@ -84,4 +84,26 @@ class RedisTest < Minitest::Test
     @redis.expects(:del).times(3)
     @store.clear!
   end
+
+  def test_clear_file
+    mock_file_hash
+    @store.type = :eager_loading
+    @store.save_report('app_path/dog.rb' => [0, 1, 1])
+    @store.type = Coverband::RUNTIME_TYPE
+    @store.save_report('app_path/dog.rb' => [1, 0, 1])
+    assert_equal [1, 1, 2], @store.get_coverage_report[:merged]['app_path/dog.rb']['data']
+    @store.clear_file!('app_path/dog.rb')
+    assert_nil @store.get_coverage_report[:merged]['app_path/dog.rb']
+  end
+
+  def test_size
+    mock_file_hash
+    @store.type = :eager_loading
+    @store.save_report('app_path/dog.rb' => [0, 1, 1])
+    assert @store.size > 1
+  end
+
+  def test_base_key
+    assert @store.send(:base_key).end_with?(Coverband::RUNTIME_TYPE.to_s)
+  end
 end

--- a/test/coverband/adapters/redis_store_test.rb
+++ b/test/coverband/adapters/redis_store_test.rb
@@ -46,19 +46,19 @@ class RedisTest < Minitest::Test
       assert_equal expected[key], data['data']
     end
 
-    @store.type = nil
+    @store.type = Coverband::RUNTIME_TYPE
     assert_equal [], @store.coverage.keys
   end
 
   def test_merged_coverage_with_types
     mock_file_hash
-    assert_nil @store.type
+    assert_equal Coverband::RUNTIME_TYPE, @store.type
     @store.type = :eager_loading
     @store.save_report('app_path/dog.rb' => [0, 1, 1])
-    @store.type = nil
+    @store.type = Coverband::RUNTIME_TYPE
     @store.save_report('app_path/dog.rb' => [1, 0, 1])
     assert_equal [1, 1, 2], @store.get_coverage_report[:merged]['app_path/dog.rb']['data']
-    assert_nil @store.type
+    assert_equal Coverband::RUNTIME_TYPE, @store.type
   end
 
   def test_coverage_for_file

--- a/test/coverband/collectors/coverage_test.rb
+++ b/test/coverband/collectors/coverage_test.rb
@@ -39,7 +39,7 @@ class CollectorsCoverageTest < Minitest::Test
 
   test 'Dog eager load coverage' do
     store = Coverband.configuration.store
-    assert_nil store.type
+    assert_equal Coverband::RUNTIME_TYPE, store.type
     file = coverband.eager_loading do
       require_unique_file
     end

--- a/test/coverband/collectors/delta_test.rb
+++ b/test/coverband/collectors/delta_test.rb
@@ -50,8 +50,17 @@ class CollectorsDeltaTest < Minitest::Test
   end
 
   if Coverband.configuration.one_shot_coverage_implemented_in_ruby_version?
-    test 'one shot lines results' do
+    test 'oneshot coverage calls clear' do
+      Coverband.configuration.stubs(:use_oneshot_lines_coverage).returns(true)
+      current_coverage = {
+        'car.rb' => [1, 5]
+      }
 
+      ::Coverage.expects(:result).with(clear: true, stop: false).returns(current_coverage)
+      results = Coverband::Collectors::Delta::RubyCoverage.results
+    end
+
+    test 'one shot lines results' do
       Coverband.configuration.stubs(:use_oneshot_lines_coverage).returns(true)
       current_coverage = {}
       results = Coverband::Collectors::Delta.results(mock_coverage(current_coverage))

--- a/test/coverband/coverband_test.rb
+++ b/test/coverband/coverband_test.rb
@@ -23,6 +23,19 @@ class CoverbandTest < Minitest::Test
     ::Coverband.start
   end
 
+  test 'Coverband#configured? works' do
+    Coverband.configure
+    assert Coverband.configured?
+  end
+
+  test 'Eager load coverage block' do
+    Coverband.eager_loading_coverage {
+      #some code
+      1 + 1
+    }
+    assert_equal :runtime, Coverband.configuration.store.type
+  end
+
   test 'Eager load coverage' do
     Coverband.eager_loading_coverage!
     assert_equal :eager_loading, Coverband.configuration.store.type

--- a/test/coverband/coverband_test.rb
+++ b/test/coverband/coverband_test.rb
@@ -27,6 +27,6 @@ class CoverbandTest < Minitest::Test
     Coverband.eager_loading_coverage!
     assert_equal :eager_loading, Coverband.configuration.store.type
     Coverband.runtime_coverage!
-    assert_nil Coverband.configuration.store.type
+    assert_equal :runtime, Coverband.configuration.store.type
   end
 end

--- a/test/coverband/utils/html_formatter_test.rb
+++ b/test/coverband/utils/html_formatter_test.rb
@@ -13,7 +13,6 @@ class HTMLFormatterTest < Minitest::Test
   test 'generate dynamic content hosted html report' do
     Coverband.configure do |config|
       config.store             = @store
-      config.s3_bucket         = nil
       config.ignore            = ['notsomething.rb']
     end
     mock_file_hash
@@ -31,7 +30,6 @@ class HTMLFormatterTest < Minitest::Test
   test 'generate static HTML report file' do
     Coverband.configure do |config|
       config.store             = @store
-      config.s3_bucket         = nil
       config.ignore            = ['notsomething.rb']
     end
     mock_file_hash

--- a/test/forked/rails_full_stack_test.rb
+++ b/test/forked/rails_full_stack_test.rb
@@ -45,7 +45,7 @@ class RailsFullStackTest < Minitest::Test
       results = store.coverage[dummy_controller]['data']
       assert_equal(eager_expected, results)
 
-      store.type = nil
+      store.type = Coverband::RUNTIME_TYPE
       runtime_expected = [0, 0, 1, nil, nil]
       results = store.coverage[dummy_controller]['data']
     end

--- a/test/forked/rails_rake_full_stack_test.rb
+++ b/test/forked/rails_rake_full_stack_test.rb
@@ -4,6 +4,7 @@ require 'rails'
 class RailsRakeFullStackTest < Minitest::Test
 
   test 'rake tasks shows coverage properly within eager_loading' do
+    store.instance_variable_set(:@redis_namespace, 'coverband_test')
     store.clear!
     system("COVERBAND_CONFIG=./test/rails#{Rails::VERSION::MAJOR}_dummy/config/coverband.rb bundle exec rake -f test/rails#{Rails::VERSION::MAJOR}_dummy/Rakefile middleware")
     store.instance_variable_set(:@redis_namespace, 'coverband_test')

--- a/test/forked/rails_rake_full_stack_test.rb
+++ b/test/forked/rails_rake_full_stack_test.rb
@@ -16,8 +16,13 @@ class RailsRakeFullStackTest < Minitest::Test
     assert_includes pundit_coverage['data'], 1
 
     store.type = Coverband::RUNTIME_TYPE
-    pundit_coverage = store.coverage[pundit_file]
-    assert_nil pundit_coverage
+    if ENV['SIMULATE_ONESHOT']
+      pundit_coverage = store.get_coverage_report[Coverband::RUNTIME_TYPE][pundit_file]
+      assert pundit_coverage['data'].compact.all? { |el| el == 0}
+    else
+      pundit_coverage = store.coverage[pundit_file]
+      assert_nil pundit_coverage
+    end
   end
 
   test "ignored rake tasks don't add coverage" do

--- a/test/forked/rails_rake_full_stack_test.rb
+++ b/test/forked/rails_rake_full_stack_test.rb
@@ -14,7 +14,7 @@ class RailsRakeFullStackTest < Minitest::Test
     refute_nil pundit_coverage
     assert_includes pundit_coverage['data'], 1
 
-    store.type = nil
+    store.type = Coverband::RUNTIME_TYPE
     pundit_coverage = store.coverage[pundit_file]
     assert_nil pundit_coverage
   end
@@ -27,7 +27,7 @@ class RailsRakeFullStackTest < Minitest::Test
     assert_nil output.match(/Coverband: Reported coverage via thread/)
     coverage_report = store.get_coverage_report
     empty_hash = {}
-    assert_equal empty_hash, coverage_report[nil]
+    assert_equal empty_hash, coverage_report[Coverband::RUNTIME_TYPE]
     assert_equal empty_hash, coverage_report[:eager_loading]
     assert_equal empty_hash, coverage_report[:merged]
   end

--- a/test/rails4_dummy/config/coverband.rb
+++ b/test/rails4_dummy/config/coverband.rb
@@ -8,4 +8,6 @@ Coverband.configure do |config|
   config.background_reporting_enabled = true
   config.track_gems = true
   config.gem_details = true
+  config.use_oneshot_lines_coverage = true if ENV['ONESHOT']
+  config.simulate_oneshot_lines_coverage = true if ENV['SIMULATE_ONESHOT']
 end

--- a/test/rails5_dummy/config/coverband.rb
+++ b/test/rails5_dummy/config/coverband.rb
@@ -8,4 +8,6 @@ Coverband.configure do |config|
   config.background_reporting_enabled = true
   config.track_gems = true
   config.gem_details = true
+  config.use_oneshot_lines_coverage = true if ENV['ONESHOT']
+  config.simulate_oneshot_lines_coverage = true if ENV['SIMULATE_ONESHOT']
 end

--- a/test/rails_test_helper.rb
+++ b/test/rails_test_helper.rb
@@ -22,8 +22,9 @@ def rails_setup
   ENV['RAILS_ENV'] = 'test'
   require 'rails'
   # coverband must be required after rails
-  load 'coverband/utils/railtie.rb'
   Coverband.configure("./test/rails#{Rails::VERSION::MAJOR}_dummy/config/coverband.rb")
+  load 'coverband/utils/railtie.rb'
+
   require_relative "../test/rails#{Rails::VERSION::MAJOR}_dummy/config/environment"
   require 'capybara/rails'
   # Our coverage report is wrapped in display:none as of now

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,12 +19,15 @@ require 'pry-byebug'
 require_relative 'unique_files'
 $VERBOSE = original_verbosity
 
-SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-SimpleCov.start do
-  add_filter 'test/forked'
+unless ENV['ONESHOT'] || ENV['SIMULATE_ONESHOT']
+  SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+  SimpleCov.start do
+    add_filter 'test/forked'
+  end
+
+  Coveralls.wear!
 end
 
-Coveralls.wear!
 
 module Coverband
   module Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,6 +31,7 @@ module Coverband
     def self.reset
       Coverband.configuration.redis_namespace = 'coverband_test'
       Coverband.configuration.store.instance_variable_set(:@redis_namespace, 'coverband_test')
+      Coverband.configuration.store.class.class_variable_set(:@@path_cache, {})
       [:eager_loading, nil].each do |type|
         Coverband.configuration.store.type = type
         Coverband.configuration.store.clear!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,7 +32,7 @@ module Coverband
       Coverband.configuration.redis_namespace = 'coverband_test'
       Coverband.configuration.store.instance_variable_set(:@redis_namespace, 'coverband_test')
       Coverband.configuration.store.class.class_variable_set(:@@path_cache, {})
-      [:eager_loading, nil].each do |type|
+      [:eager_loading, :runtime].each do |type|
         Coverband.configuration.store.type = type
         Coverband.configuration.store.clear!
       end


### PR DESCRIPTION
I believe all of these improvements should help resolve the memory issues seen in issue #277 

This fixes issues around adding oneshot
   * it had a large memory hit due to `::Coverage.line_stub(file)`
   * bugs related to previous coverage
   * gets to 0 retained memory between requests
   * seems to have NO memory growth flatlining at basically the same as non-coverband
   * has slightly increased up-front allocations to avoid later allocations (stubs cache, etc)
   * this is recommended for anyone running 2.6, and likely will become the default after being optional in this release

Adds support for simulated_oneshot for older Ruby versions that don't support it
   * gets to 0 retained memory between requests
   * seems to significantly reduce Heroku memory growth beyond the fixes of our current implementation
   * optional configurable opt-in: `config.simulate_oneshot_lines_coverage = true`

Beyond that, it includes some other fixes that improve the memory usage on the current default as well... Which when running on Heroku shows significantly reduced memory growth. Such as the `@@path_cache = {}` which avoids repeatedly making shortened path strings.

benchmark now supports running in 3 modes... Working on the same for the forked tests

* default: `bundle exec rake benchmarks:run_big`
* oneshot:  `ONESHOT=true bundle exec rake benchmarks:run_big`
* `SIMULATE_ONESHOT=true bundle exec rake benchmarks:run_big`