### PR TITLE
Coverage server depends on environment

### DIFF
--- a/lib/coverband/utils/tasks.rb
+++ b/lib/coverband/utils/tasks.rb
@@ -15,6 +15,7 @@ namespace :coverband do
 
   desc 'report runtime Coverband code coverage'
   task :coverage_server do
+    Rake.application['environment'].invoke if Rake::Task.task_defined?('environment')
     Rack::Server.start app: Coverband::Reporters::Web.new, Port: ENV.fetch('COVERBAND_COVERAGE_PORT', 1022).to_i
   end
 


### PR DESCRIPTION
Without environment loaded, getting the following error

```
/Users/karlbaum/.gem/ruby/2.4.4/gems/activerecord-4.2.11.1/lib/active_record/connection_adapters/connection_specification.rb:248:in `resolve_symbol_connection': 'development' database is not configured. Available: [] (ActiveRecord::AdapterNotSpecified)
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/activerecord-4.2.11.1/lib/active_record/connection_adapters/connection_specification.rb:211:in `resolve_connection'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/activerecord-4.2.11.1/lib/active_record/connection_adapters/connection_specification.rb:139:in `resolve'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/activerecord-4.2.11.1/lib/active_record/connection_adapters/connection_specification.rb:169:in `spec'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/activerecord-4.2.11.1/lib/active_record/connection_handling.rb:50:in `establish_connection'
	from config/puma.rb:18:in `block in _load_from'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/puma-3.12.0/lib/puma/configuration.rb:276:in `block in run_hooks'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/puma-3.12.0/lib/puma/configuration.rb:276:in `each'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/puma-3.12.0/lib/puma/configuration.rb:276:in `run_hooks'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/puma-3.12.0/lib/puma/cluster.rb:271:in `worker'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/puma-3.12.0/lib/puma/cluster.rb:137:in `block (2 levels) in spawn_workers'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/puma-3.12.0/lib/puma/cluster.rb:137:in `fork'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/puma-3.12.0/lib/puma/cluster.rb:137:in `block in spawn_workers'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/puma-3.12.0/lib/puma/cluster.rb:133:in `times'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/puma-3.12.0/lib/puma/cluster.rb:133:in `spawn_workers'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/puma-3.12.0/lib/puma/cluster.rb:211:in `check_workers'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/puma-3.12.0/lib/puma/cluster.rb:484:in `run'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/puma-3.12.0/lib/puma/launcher.rb:184:in `run'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/puma-3.12.0/lib/rack/handler/puma.rb:70:in `run'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/rack-1.6.11/lib/rack/server.rb:287:in `start'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/rack-1.6.11/lib/rack/server.rb:148:in `start'
	from /Users/karlbaum/.gem/ruby/2.4.4/gems/coverband-4.2.1/lib/coverband/utils/tasks.rb:18:in `block (2 levels) in <top (required)>'
```