### PR TITLE
Limit the amount of reporting done by having eager load enabled

### DIFF
--- a/lib/coverband/utils/railtie.rb
+++ b/lib/coverband/utils/railtie.rb
@@ -6,7 +6,6 @@ module Coverband
       Coverband.eager_loading_coverage!
       super
     ensure
-      Coverband.report_coverage
       Coverband.runtime_coverage!
     end
   end
@@ -15,6 +14,12 @@ module Coverband
   class Railtie < Rails::Railtie
     initializer 'coverband.configure' do |app|
       app.middleware.use Coverband::BackgroundMiddleware
+    end
+
+    config.after_initialize do
+      Coverband.eager_loading_coverage!
+      Coverband.report_coverage
+      Coverband.runtime_coverage!
     end
 
     rake_tasks do


### PR DESCRIPTION
I am setting up the coverband gem at work and I noticed that initial boot times with `eager load` enabled have increased anywhere between 1.5-2 times. Digging into it, I noticed that the reporting done in modified `eager_load!` (`lib/coverband/utils/railtie.rb`) was the root cause. I took a simple benchmark to determine how long the reporting was taking and these are my findings:

(Each row represents how long the reporting took for each `eager_load!` method called within Rails)
```
 0.380000   0.000000   0.380000 (  0.382084)
  0.350000   0.000000   0.350000 (  0.348914)
  0.330000   0.000000   0.330000 (  0.330359)
  0.320000   0.000000   0.320000 (  0.324430)
  0.320000   0.000000   0.320000 (  0.315405)
  0.310000   0.000000   0.310000 (  0.318355)
  0.330000   0.000000   0.330000 (  0.333296)
  0.350000   0.000000   0.350000 (  0.354079)
  0.330000   0.000000   0.330000 (  0.323238)
  0.310000   0.000000   0.310000 (  0.319760)
  0.330000   0.000000   0.330000 (  0.326803)
  0.310000   0.010000   0.320000 (  0.316802)
  0.310000   0.000000   0.310000 (  0.316868)
  0.340000   0.000000   0.340000 (  0.341096)
  0.330000   0.000000   0.330000 (  0.331146)
  0.320000   0.000000   0.320000 (  0.318490)
  0.340000   0.000000   0.340000 (  0.342581)
  0.360000   0.000000   0.360000 (  0.357093)
  0.440000   0.010000   0.450000 (  0.448162)
  0.340000   0.000000   0.340000 (  0.345512)
  0.340000   0.000000   0.340000 (  0.337739)
  0.330000   0.000000   0.330000 (  0.336991)
  0.330000   0.000000   0.330000 (  0.327131)
  0.330000   0.000000   0.330000 (  0.324809)
  0.330000   0.000000   0.330000 (  0.329823)
  0.330000   0.000000   0.330000 (  0.329209)
  0.330000   0.000000   0.330000 (  0.334308)
  0.320000   0.000000   0.320000 (  0.324204)
  0.330000   0.000000   0.330000 (  0.329233)
  0.350000   0.000000   0.350000 (  0.349848)
  0.350000   0.000000   0.350000 (  0.349071)
  0.320000   0.010000   0.330000 (  0.321026)
  0.330000   0.000000   0.330000 (  0.330639)
  0.370000   0.010000   0.380000 (  0.366731)
  0.350000   0.000000   0.350000 (  0.344497)
  0.320000   0.000000   0.320000 (  0.324582)
  0.640000   0.030000   0.670000 (  0.665668) 
```

This illustrates that it is an expensive process. I propose that the reporting for `EAGER_TYPE` be done once after the Rails initialization which should yield the same results and significantly reduce the number of times the reporting is done. Let me know if I may have missed something in my understand where this would not work. Thanks!