### PR TITLE
Add benchmark of rails init

### DIFF
--- a/test/benchmarks/benchmark.rake
+++ b/test/benchmarks/benchmark.rake
@@ -415,6 +415,18 @@ namespace :benchmarks do
     `open tmp/timeseries.jpg`
   end
 
+  desc 'benchmark initialization of rails'
+  task :init_rails do
+    require 'benchmark'
+    require 'benchmark/ips'
+    Benchmark.ips do |x|
+      x.config(time: 60, warmup: 0)
+      x.report('init_rails') do
+        system('bundle exec rake init_rails -f ./test/benchmarks/init_rails.rake')
+      end
+    end
+  end
+
   desc 'compare Coverband Ruby Coverage with Filestore with normal Ruby'
   task :compare_file do
     puts 'comparing Coverage loaded/not, this takes some time for output...'

--- a/test/benchmarks/init_rails.rake
+++ b/test/benchmarks/init_rails.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails'
+require 'coverband'
+
+desc 'Initialize rails'
+task 'init_rails' do
+  Coverband.configure("./test/rails#{Rails::VERSION::MAJOR}_dummy/config/coverband.rb")
+  require "./test/rails#{Rails::VERSION::MAJOR}_dummy/config/environment"
+end


### PR DESCRIPTION
For help benchmarking #307.

With the #307 change, this benchmark shows:

```
0.191  (± 0.0%) i/s -     12.000  in  63.296159s
```

Compared to master:

```
0.170  (± 0.0%) i/s -     11.000  in  65.282413s
```

It shows a modest speed increase. That being said, in this benchmark test I only see eager_load being called twice when rails inits. I have seen it being called 4 times in a larger rails project. In #307, it looks like eager_load is being called by rails 37 times which I have not seen but I don't doubt it as I don't know how and when rails calls eager_load. If it is being called that many times, that would definitely have a large impact on rails initialization.

