### PR TITLE
Add benchmark subset of files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,3 @@ script:
   # passes locally on 2.3.5 on travis passes sometimes on 2.4 and always on 2.6.1
   #- bundle exec rake benchmarks:memory
   - bundle exec rake benchmarks
-before_install:
-  - echo 'this is a hack to clear default bundler and force bundler 1.17.3'
-  - ls /home/travis/.rvm/gems/
-  - rm /home/travis/.rvm/gems/ruby-2.3.7@global/specifications/bundler-2.0.1.gemspec || true
-  - rm /home/travis/.rvm/gems/ruby-2.4.6@global/specifications/bundler-2.0.1.gemspec || true
-  - rm /home/travis/.rvm/gems/ruby-2.5.5@global/specifications/bundler-2.0.1.gemspec || true
-  - gem uninstall bundler || true
-  - gem install bundler -v '1.17.3'
-  - bundler --version

--- a/test/benchmarks/benchmark.rake
+++ b/test/benchmarks/benchmark.rake
@@ -141,7 +141,7 @@ namespace :benchmarks do
   end
 
   def fake_line_numbers
-    24.times.each_with_object({}) do |line, line_hash|
+    28.times.each_with_object({}) do |line, line_hash|
       line_hash[(line + 1).to_s] = rand(5)
     end
   end
@@ -183,7 +183,13 @@ namespace :benchmarks do
     5.times { store.save_report(report) }
     Benchmark.ips do |x|
       x.config(time: 15, warmup: 5)
-      x.report('store_reports') { store.save_report(report) }
+      x.report('store_reports_all') { store.save_report(report) }
+    end
+    keys_subset = report.keys.first(100)
+    report_subset = report.select { |key, _value| keys_subset.include?(key) }
+    Benchmark.ips do |x|
+      x.config(time: 20, warmup: 5)
+      x.report('store_reports_subset') { store.save_report(report_subset) }
     end
   end
 

--- a/test/benchmarks/benchmark.rake
+++ b/test/benchmarks/benchmark.rake
@@ -140,9 +140,11 @@ namespace :benchmarks do
     Coverband::Collectors::Coverage.instance.reset_instance
   end
 
+  LINES = 45
+  NON_NIL_LINES = 18
   def fake_line_numbers
-    28.times.each_with_object({}) do |line, line_hash|
-      line_hash[(line + 1).to_s] = rand(5)
+    LINES.times.map do |line|
+      coverage = (line < NON_NIL_LINES) ? rand(5) : nil
     end
   end
 


### PR DESCRIPTION
- Added benchmark of storing subset of files
- Added nil's to fake coverage data
- Fixed incorrect format for fake coverage data

### RedisStore
```
➜  coverband git:(benchmark_subset_of_files) bundle exec rake benchmarks:redis_reporting
D, [2019-08-07T09:45:48.251145 #22282] DEBUG -- : using default configuration
runs benchmarks on reporting large sets of files to redis
Warming up --------------------------------------
   store_reports_all     2.000  i/100ms
Calculating -------------------------------------
   store_reports_all     24.709  (± 4.0%) i/s -    370.000  in  15.008521s
Warming up --------------------------------------
store_reports_subset     4.000  i/100ms
Calculating -------------------------------------
store_reports_subset     40.661  (± 4.9%) i/s -    812.000  in  20.004844s
```

### HashRedisStore

```
runs benchmarks on reporting large sets of files to redis
Warming up --------------------------------------
   store_reports_all     1.000  i/100ms
Calculating -------------------------------------
   store_reports_all      4.535  (± 0.0%) i/s -     68.000  in  15.030560s
Warming up --------------------------------------
store_reports_subset    11.000  i/100ms
Calculating -------------------------------------
store_reports_subset     96.209  (± 7.3%) i/s -      1.925k in  20.102280s
```