### PR TITLE
add support for timestamps on view tracking

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ end
 desc 'load irb with this gem'
 task :console do
   puts 'running console'
-  exec 'bundle exec console'
+  exec 'bundle console'
 end
 
 # This is really just for testing and development because without configuration

--- a/lib/coverband/collectors/view_tracker.rb
+++ b/lib/coverband/collectors/view_tracker.rb
@@ -7,7 +7,8 @@ module Coverband
     ###
     # This class tracks view file usage via ActiveSupport::Notifications
     #
-    # This is a port of Flatfoot, a project I open sourced years ago, but am now rolling into Coverband
+    # This is a port of Flatfoot, a project I open sourced years ago,
+    # but am now rolling into Coverband
     # https://github.com/livingsocial/flatfoot
     #
     # TODO: test and ensure slim, haml, and other support
@@ -59,26 +60,43 @@ module Coverband
       end
 
       def used_views
-        views = redis_store.smembers(tracker_key)
-        normalized_views = []
-        views.each do |view|
+        views = redis_store.hgetall(tracker_key)
+        normalized_views = {}
+        views.each_pair do |view, time|
           roots.each do |root|
             view = view.gsub(/#{root}/, '')
           end
-          normalized_views << view
+          normalized_views[view] = time
         end
         normalized_views
       end
 
       def unused_views
-        recently_used_views = used_views
+        recently_used_views = used_views.keys
         all_views = target.reject { |view| recently_used_views.include?(view) }
         # since layouts don't include format we count them used if they match with ANY formats
         all_views.reject { |view| view.match(/\/layouts\//) && recently_used_views.any? { |used_view| view.include?(used_view) } }
       end
 
+      def tracking_since
+        if (tracking_time = redis_store.get(tracker_time_key))
+          Time.at(tracking_time.to_i).iso8601
+        else
+          'N/A'
+        end
+      end
+
       def reset_recordings
         redis_store.del(tracker_key)
+        redis_store.del(tracker_time_key)
+      end
+
+      def clear_file!(filename)
+        return unless filename
+
+        filename = "#{@project_directory}/#{filename}"
+        redis_store.hdel(tracker_key, filename)
+        logged_views.delete(filename)
       end
 
       def self.supported_version?
@@ -86,8 +104,11 @@ module Coverband
       end
 
       def report_views_tracked
+        # TODO: move to initializer
+        redis_store.set(tracker_time_key, Time.now.to_i) unless redis_store.exists(tracker_time_key)
+        reported_time = Time.now.to_i
         views_to_record.each do |file|
-          redis_store.sadd(tracker_key, file)
+          redis_store.hset(tracker_key, file, reported_time)
         end
         self.views_to_record = []
       rescue StandardError => e
@@ -117,7 +138,11 @@ module Coverband
       end
 
       def tracker_key
-        'render_tracker'
+        'render_tracker_2'
+      end
+
+      def tracker_time_key
+        'render_tracker_time'
       end
     end
   end

--- a/lib/coverband/version.rb
+++ b/lib/coverband/version.rb
@@ -5,5 +5,5 @@
 # use format '4.2.1.rc.1' ~> 4.2.1.rc to prerelease versions like v4.2.1.rc.2 and v4.2.1.rc.3
 ###
 module Coverband
-  VERSION = '4.2.2'
+  VERSION = '4.2.3.rc.1'
 end

--- a/public/application.css
+++ b/public/application.css
@@ -784,6 +784,10 @@ td {
   display: inline-block;
 }
 
+.last_seen_at {
+  font-size: 8px;
+}
+
 .notice {
   color: #856404;
   background-color: #fff3cd;

--- a/test/coverband/collectors/view_tracker_test.rb
+++ b/test/coverband/collectors/view_tracker_test.rb
@@ -2,9 +2,13 @@ require File.expand_path('../../test_helper', File.dirname(__FILE__))
 
 class ReporterTest < Minitest::Test
 
+  def tracker_key
+    'render_tracker_2'
+  end
+
   def setup
     super
-    fake_store.raw_store.del('render_tracker')
+    fake_store.raw_store.del(tracker_key)
   end
 
   test "init correctly" do
@@ -20,7 +24,7 @@ class ReporterTest < Minitest::Test
     Coverband::Collectors::ViewTracker.expects(:supported_version?).returns(true)
     store = fake_store
     file_path = "#{File.expand_path(Coverband.configuration.root)}/file"
-    store.raw_store.expects(:sadd).with('render_tracker', file_path)
+    store.raw_store.expects(:hset).with(tracker_key, file_path, anything)
     tracker = Coverband::Collectors::ViewTracker.new(store: store, roots: 'dir')
     tracker.track_views('name', 'start', 'finish', 'id', {:identifier => file_path})
     tracker.report_views_tracked
@@ -31,7 +35,7 @@ class ReporterTest < Minitest::Test
     Coverband::Collectors::ViewTracker.expects(:supported_version?).returns(true)
     store = fake_store
     file_path = "#{File.expand_path(Coverband.configuration.root)}/layout"
-    store.raw_store.expects(:sadd).with('render_tracker', file_path)
+    store.raw_store.expects(:hset).with(tracker_key, file_path, anything)
     tracker = Coverband::Collectors::ViewTracker.new(store: store, roots: 'dir')
     tracker.track_views('name', 'start', 'finish', 'id', {:layout => file_path})
     tracker.report_views_tracked
@@ -45,7 +49,7 @@ class ReporterTest < Minitest::Test
     tracker = Coverband::Collectors::ViewTracker.new(store: store, roots: 'dir')
     tracker.track_views('name', 'start', 'finish', 'id', {:identifier => file_path})
     tracker.report_views_tracked
-    assert_equal [file_path], tracker.used_views
+    assert_equal [file_path], tracker.used_views.keys
   end
 
   test "report unused partials" do
@@ -62,10 +66,22 @@ class ReporterTest < Minitest::Test
   test "reset store" do
     Coverband::Collectors::ViewTracker.expects(:supported_version?).returns(true)
     store = fake_store
-    store.raw_store.expects(:del).with('render_tracker')
+    store.raw_store.expects(:del).with(tracker_key)
+    store.raw_store.expects(:del).with('render_tracker_time')
     tracker = Coverband::Collectors::ViewTracker.new(store: store, roots: 'dir')
     tracker.track_views('name', 'start', 'finish', 'id', {:identifier => 'file'})
     tracker.reset_recordings
+  end
+
+  test "clear_file" do
+    Coverband::Collectors::ViewTracker.expects(:supported_version?).returns(true)
+    store = fake_store
+    file_path = "#{File.expand_path(Coverband.configuration.root)}/file"
+    store.raw_store.expects(:hdel).with(tracker_key, file_path)
+    tracker = Coverband::Collectors::ViewTracker.new(store: store, roots: 'dir')
+    tracker.track_views('name', 'start', 'finish', 'id', {:identifier => file_path})
+    tracker.clear_file!('file')
+    assert_equal [], tracker.logged_views
   end
 
   protected

--- a/views/view_tracker.erb
+++ b/views/view_tracker.erb
@@ -13,8 +13,13 @@
       <%= display_nav(show_coverage_link: true) %>
       <div id="content">
         <% tracker = Coverband::Collectors::ViewTracker.new(store: Coverband.configuration.store) %>
+        <h3>
+          <% if Coverband.configuration.web_enable_clear %>
+            <%= button("#{base_path}clear_view_tracking", 'reset view tracker', delete: true) %>
+          <% end %>
+        </h3>
         <h2>Unused Views: (<%= tracker.unused_views.length %>)</h2>
-        <p>These views have never been rendered</p>
+        <p>These views have not been rendered since recording started at <%= tracker.tracking_since %></p>
         <ul>
         <% tracker.unused_views.each do |view_file| %>
           <li><%= view_file %></li>
@@ -24,8 +29,14 @@
         <h2>Used Views: (<%= tracker.used_views.length %>)</h2>
         <p>These views have been rendered at least once</p>
         <ul>
-        <% tracker.used_views.each do |view_file| %>
-          <li><%= view_file %></li>
+        <% tracker.used_views.each_pair do |view_file, time_at| %>
+          <li>
+            <%= view_file %>
+            <span class="last_seen_at">last activity recorded <%= Time.at(time_at.to_i)%></span>
+            <% if Coverband.configuration.web_enable_clear %>
+              <%= button("#{base_path}clear_view_tracking_file?filename=#{view_file}", 'reset tracked file', delete: true) %>
+            <% end %>
+          </li>
         <% end %>
         </ul>
       </div>


### PR DESCRIPTION
and for clearing all view tracking or individual files.

<img width="819" alt="Screen Shot 2019-09-11 at 12 15 20 PM" src="https://user-images.githubusercontent.com/24925/64723545-f35dd180-d48d-11e9-9edb-5511636f3973.png">
