### PR TITLE
add better callout on unused files, in standard directories

### DIFF
--- a/lib/coverband/utils/result.rb
+++ b/lib/coverband/utils/result.rb
@@ -55,11 +55,16 @@ module Coverband
       # the line-by-line coverage to zero (if relevant) or nil (comments / whitespace etc).
       def self.add_not_loaded_files(result, tracked_files)
         if tracked_files
+          # TODO: Can we get rid of this dup it wastes memory
           result = result.dup
           Dir[tracked_files].each do |file|
             absolute = File.expand_path(file)
 
-            result[absolute] ||= Coverband::Utils::LinesClassifier.new.classify(File.foreach(absolute))
+            puts "hit #{absolute} "*60 if result[absolute].nil?
+            result[absolute] ||= {
+              'data' => Array.new(File.foreach(absolute).to_a.length) { 0 },
+              'never_loaded' => true
+            }
           end
         end
 

--- a/lib/coverband/utils/result.rb
+++ b/lib/coverband/utils/result.rb
@@ -59,10 +59,8 @@ module Coverband
           result = result.dup
           Dir[tracked_files].each do |file|
             absolute = File.expand_path(file)
-
-            puts "hit #{absolute} "*60 if result[absolute].nil?
             result[absolute] ||= {
-              'data' => Array.new(File.foreach(absolute).to_a.length) { 0 },
+              'data' => Array.new(File.foreach(absolute).count) { 0 },
               'never_loaded' => true
             }
           end

--- a/lib/coverband/utils/source_file.rb
+++ b/lib/coverband/utils/source_file.rb
@@ -87,6 +87,8 @@ module Coverband
       attr_reader :first_updated_at
       # the date this version of the file last saw any coverage activity
       attr_reader :last_updated_at
+      # meta data that the file was never loaded during boot or runtime
+      attr_reader :never_loaded
       NOT_AVAILABLE = 'not available'
 
       def initialize(filename, file_data)
@@ -97,6 +99,7 @@ module Coverband
           @first_updated_at = @last_updated_at = NOT_AVAILABLE
           @first_updated_at = Time.at(file_data['first_updated_at']) if file_data['first_updated_at']
           @last_updated_at =  Time.at(file_data['last_updated_at']) if file_data['last_updated_at']
+          @never_loaded = file_data['never_loaded'] || false
         else
           # TODO: Deprecate this code path this was backwards compatability from 3-4
           @coverage = file_data

--- a/public/application.css
+++ b/public/application.css
@@ -687,6 +687,10 @@ a.src_link {
   background: url("./magnify.png") no-repeat left 50%;
   padding-left: 18px; }
 
+.red a.src_link {
+    color: #990000;
+   }
+
 tr, td {
   margin: 0;
   padding: 0; }

--- a/test/coverband/reporters/html_test.rb
+++ b/test/coverband/reporters/html_test.rb
@@ -36,6 +36,19 @@ class ReportHTMLTest < Minitest::Test
     assert_match 'app/models/user.rb', html
   end
 
+  test 'files with no Coverage but in project details page list warning' do
+    @store.send(:save_report, basic_coverage_full_path)
+
+    filename = basic_coverage_file_full_path
+    base_path = Dir.pwd
+    # in project, but not in coverage data
+    html = Coverband::Reporters::HTMLReport.new(Coverband.configuration.store,
+                                                filename: "#{Dir.pwd}/test/fixtures/app/models/user.rb",
+                                                base_path: base_path,
+                                                open_report: false).file_details
+    assert_match 'This file was never loaded', html
+  end
+
   test 'generate static HTML report file' do
     @store.send(:save_report, basic_coverage)
 

--- a/views/file_list.erb
+++ b/views/file_list.erb
@@ -35,7 +35,8 @@
     <tbody>
       <% source_files.each do |source_file| %>
         <tr>
-          <td class="strong">
+          <% source_class = source_file.never_loaded ? 'strong red' : 'strong'%>
+          <td class="<%= source_class %>">
             <%= link_to_source_file(source_file) %>
           </td>
           <td class="<%= coverage_css_class(source_file.covered_percent) %> strong"><%= source_file.covered_percent.round(2).to_s %> %</td>

--- a/views/source_file.erb
+++ b/views/source_file.erb
@@ -15,6 +15,13 @@
       <% if Coverband.configuration.web_enable_clear %>
         <%= button("#{base_path}clear_file?filename=#{source_file.relative_path}", 'clear file coverage') %> &nbsp;
       <% end %>
+
+      <% if source_file.never_loaded %>
+        <br/>
+        <span class="red">
+          <strong>This file was never loaded during app runtime or loading!</strong>
+        </span>
+      <% end %>
     </h4>
     <div>
       <b><%= source_file.lines_of_code %></b> relevant lines.


### PR DESCRIPTION
makes it more clear that a file in standard directories was never loaded or used.

<img width="1642" alt="Screen Shot 2019-09-13 at 5 10 04 PM" src="https://user-images.githubusercontent.com/24925/64899677-d110b300-d649-11e9-8b76-5cf11d5d9564.png">

<img width="1637" alt="Screen Shot 2019-09-13 at 3 51 32 PM" src="https://user-images.githubusercontent.com/24925/64899683-d7069400-d649-11e9-81d3-0ea053f3b73b.png">
