### PR TITLE
Use hmset and hgetall to pass args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
   - redis-server
 script:
   - sudo ./lua/install.sh 
-  - ./lua51/bin/busted lua/test/*
+  - ./tmp/lua51/bin/busted lua/test/*
   - bundle exec rake rubocop
   - COVERBAND_HASH_REDIS_STORE=t bundle exec rake
   - COVERBAND_HASH_REDIS_STORE=t bundle exec rake forked_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ gemfile:
 services:
   - redis-server
 script:
+  - sudo ./lua/install.sh 
+  - ./lua51/bin/busted lua/test/*
   - bundle exec rake rubocop
   - COVERBAND_HASH_REDIS_STORE=t bundle exec rake
   - COVERBAND_HASH_REDIS_STORE=t bundle exec rake forked_tests

--- a/lua/install.sh
+++ b/lua/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+pip install hererocks
+hererocks lua51 -l5.1 -rlatest
+source lua51/bin/activate
+lua -v
+for i in luacov busted redis-lua inspect; do 
+  luarocks install $i;
+done

--- a/lua/install.sh
+++ b/lua/install.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
+LUA_DIR="./tmp/lua51"
 pip install hererocks
-hererocks lua51 -l5.1 -rlatest
-source lua51/bin/activate
+hererocks $LUA_DIR -l5.1 -rlatest
+source $LUA_DIR/bin/activate
 lua -v
 for i in luacov busted redis-lua inspect; do 
   luarocks install $i;

--- a/lua/lib/persist-coverage.lua
+++ b/lua/lib/persist-coverage.lua
@@ -1,5 +1,14 @@
-local hash_values = redis.call('HGETALL', KEYS[1])
-function remove(key)
+local function hgetall(hash_key)
+  local flat_map = redis.call('HGETALL', hash_key)
+  local result = {}
+  for i = 1, #flat_map, 2 do
+    result[flat_map[i]] = flat_map[i + 1]
+  end
+  return result
+end
+
+local hash_values =  hgetall(KEYS[1])
+local function remove(key)
   local val = hash_values[key]
   hash_values[key] = nil
   return val

--- a/lua/test/bootstrap.lua
+++ b/lua/test/bootstrap.lua
@@ -1,0 +1,4 @@
+inspect = require "inspect"
+require './lua/test/redis-call'
+
+

--- a/lua/test/harness.lua
+++ b/lua/test/harness.lua
@@ -1,5 +1,4 @@
-inspect = require "inspect"
-require './lua/test/redis-call'
+require './lua/test/bootstrap'
 
 
 KEYS = {}

--- a/lua/test/redis-call.lua
+++ b/lua/test/redis-call.lua
@@ -36,6 +36,14 @@ redis.call = function(cmd, ...)
       end
 
       return result;
+    end,
+    hgetall = function()
+      local new_result = {}
+      for key, value in pairs(result) do
+        table.insert(new_result, key)
+        table.insert(new_result, value)
+      end
+      return new_result
     end
   }
 

--- a/lua/test/test-persist-coverage.lua
+++ b/lua/test/test-persist-coverage.lua
@@ -2,9 +2,16 @@ local call_redis_script = require "./lua/test/harness";
 
 describe("incr-and-stor", function()
 
-  -- Flush the database before running the tests
+  function clean_redis() 
+    redis.call('DEL', 'coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd')
+  end
+
   before_each(function()
-    redis.call('FLUSHDB')
+    clean_redis()
+  end)
+
+  after_each(function()
+    clean_redis()
   end)
 
   it("should add single items", function()

--- a/lua/test/test-persist-coverage.lua
+++ b/lua/test/test-persist-coverage.lua
@@ -1,8 +1,18 @@
 local call_redis_script = require "./lua/test/harness";
 
 describe("incr-and-stor", function()
+  local function hgetall(hash_key)
+    local flat_map = redis.call('HGETALL', hash_key)
+    local result = {}
+    for i = 1, #flat_map, 2 do
+      result[flat_map[i]] = flat_map[i + 1]
+    end
+    return result
+  end
 
-  function clean_redis() 
+
+
+  local function clean_redis() 
     redis.call('DEL', 'coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd')
   end
 
@@ -36,7 +46,7 @@ describe("incr-and-stor", function()
 
 
     call_redis_script('persist-coverage.lua',  { key },  {});
-    local results = redis.call('HGETALL', "coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd")
+    local results = hgetall("coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd")
     assert.are.same({
       ["0"] = "0",
       ["1"] = "1",
@@ -64,7 +74,7 @@ describe("incr-and-stor", function()
     2, 1)
 
     call_redis_script('persist-coverage.lua',  { key },  {} );
-    results = redis.call('HGETALL', "coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd")
+    results = hgetall("coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd")
     assert.are.same({
       ["0"] = "1",
       ["1"] = "2",

--- a/lua/test/test-persist-coverage.lua
+++ b/lua/test/test-persist-coverage.lua
@@ -17,9 +17,25 @@ describe("incr-and-stor", function()
   it("should add single items", function()
     local first_updated_at = "1569453853"
     local last_updated_at = first_updated_at
-    local args = { first_updated_at, last_updated_at, "./dog.rb", "abcd", '-1', 3, 0, 1, 2 }
-    local keys = {"coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd", 0, 1, 2 }
-    call_redis_script('persist-coverage.lua',  keys ,  args );
+
+    local key = 'hash_key'
+    redis.call( 'hmset', key, 
+    'hash_key', "coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd",
+    'first_updated_at', 
+    first_updated_at, 
+    'last_updated_at', 
+    last_updated_at, 
+    'file', "./dog.rb", 
+    'file_hash', 'abcd', 
+    'ttl', '-1', 
+    'file_length', 3, 
+    0, 0, 
+    1, 1, 
+    2, 2)
+
+
+
+    call_redis_script('persist-coverage.lua',  { key },  {});
     local results = redis.call('HGETALL', "coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd")
     assert.are.same({
       ["0"] = "0",
@@ -31,11 +47,23 @@ describe("incr-and-stor", function()
       first_updated_at = first_updated_at ,
       last_updated_at = last_updated_at
     }, results)
+    
+    assert.is_false(false, redis.call('exists', key))
 
     last_updated_at = "1569453953"
-    args = { last_updated_at, last_updated_at, "./dog.rb", "abcd", '-1', 3, 1, 1, 1 }
-    keys = {"coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd", 0, 1, 2 }
-    call_redis_script('persist-coverage.lua',  keys ,  args );
+    redis.call( 'hmset', key, 
+    'hash_key', "coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd",
+    'first_updated_at', first_updated_at, 
+    'last_updated_at', last_updated_at, 
+    'file', "./dog.rb", 
+    'file_hash', 'abcd', 
+    'ttl', '-1', 
+    'file_length', 3, 
+    0, 1, 
+    1, 1, 
+    2, 1)
+
+    call_redis_script('persist-coverage.lua',  { key },  {} );
     results = redis.call('HGETALL', "coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd")
     assert.are.same({
       ["0"] = "1",
@@ -48,5 +76,6 @@ describe("incr-and-stor", function()
       last_updated_at = last_updated_at 
     }, results)
 
+    assert.is_false(false, redis.call('exists', key))
   end)
 end)


### PR DESCRIPTION
Uses about 25% less cpu on redis instance:

Before on master:

![image](https://user-images.githubusercontent.com/96786/66274871-f95a8e80-e850-11e9-83c6-4009ae542293.png)

```
  coverband git:(master) COVERBAND_HASH_REDIS_STORE=t bundle exec rake benchmarks:redis_reporting
Warming up --------------------------------------
   store_reports_all     1.000  i/100ms
Calculating -------------------------------------
   store_reports_all      3.871  (±25.8%) i/s -     56.000  in  15.148240s
Warming up --------------------------------------
store_reports_subset     7.000  i/100ms
Calculating -------------------------------------
store_reports_subset    109.200  (±12.8%) i/s -      2.149k in  20.008229s
```

On this branch:

![image](https://user-images.githubusercontent.com/96786/66274898-55251780-e851-11e9-9de4-8a17aaa90ec2.png)

```
➜  coverband git:(change_to_hash) COVERBAND_HASH_REDIS_STORE=t bundle exec rake benchmarks:redis_reporting
runs benchmarks on reporting large sets of files to redis
Warming up --------------------------------------
   store_reports_all     1.000  i/100ms
Calculating -------------------------------------
   store_reports_all      2.319  (± 0.0%) i/s -     35.000  in  15.179692s
Warming up --------------------------------------
store_reports_subset     6.000  i/100ms
Calculating -------------------------------------
store_reports_subset     60.083  (±10.0%) i/s -      1.194k in  20.056954s
```

Seems a little slower