### PR TITLE
Batch report calls in hash_redis_store

### DIFF
--- a/lib/coverband/adapters/hash_redis_store.rb
+++ b/lib/coverband/adapters/hash_redis_store.rb
@@ -71,10 +71,12 @@ module Coverband
             updated_time: updated_time
           )
         end.to_json
+        return unless keys.any?
+
         arguments_key = [@redis_namespace, SecureRandom.uuid].compact.join('.')
         @redis.set(arguments_key, json)
         @redis.evalsha(script_id, [arguments_key])
-        @redis.sadd(files_key, keys) if keys.any?
+        @redis.sadd(files_key, keys)
       end
 
       def coverage(local_type = nil)

--- a/lua/install.sh
+++ b/lua/install.sh
@@ -5,6 +5,6 @@ pip install hererocks
 hererocks $LUA_DIR -l5.1 -rlatest
 source $LUA_DIR/bin/activate
 lua -v
-for i in luacov busted redis-lua inspect; do 
+for i in luacov busted redis-lua inspect lua-cjson; do 
   luarocks install $i;
 done

--- a/lua/lib/persist-coverage.lua
+++ b/lua/lib/persist-coverage.lua
@@ -1,36 +1,32 @@
-local function hgetall(hash_key)
-  local flat_map = redis.call('HGETALL', hash_key)
-  local result = {}
-  for i = 1, #flat_map, 2 do
-    result[flat_map[i]] = flat_map[i + 1]
-  end
-  return result
-end
-
-local hash_values =  cjson.decode(redis.call('get', (KEYS[1])))
-local function remove(key)
-  local val = hash_values[key]
-  hash_values[key] = nil
-  return val
-end
-
+local hash_values_array =  cjson.decode(redis.call('get', (KEYS[1])))
 redis.call('DEL', KEYS[1])
-local first_updated_at = remove('first_updated_at')
-local last_updated_at = remove('last_updated_at')
-local file = remove('file')
-local file_hash = remove('file_hash')
-local ttl = remove('ttl')
-local file_length = remove('file_length')
-local hash_key = remove('hash_key')
-redis.call('HMSET', hash_key, 'last_updated_at', last_updated_at, 'file', file, 'file_hash', file_hash, 'file_length', file_length)
-redis.call('HSETNX', hash_key, 'first_updated_at', first_updated_at)
-for line, coverage in pairs(hash_values) do
-  if coverage  == '-1' then
-    redis.call("HSET", hash_key, line, coverage)
-  else
-    redis.call("HINCRBY", hash_key, line, coverage)
+for i, hash_values in ipairs(hash_values_array) do
+  local function remove(key)
+    local val = hash_values[key]
+    hash_values[key] = nil
+    return val
   end
-end
-if ttl ~= '-1' then
-  redis.call("EXPIRE", hash_key, ttl)
+  local first_updated_at = remove('first_updated_at')
+  local last_updated_at = remove('last_updated_at')
+  local file = remove('file')
+  local file_hash = remove('file_hash')
+  local ttl = remove('ttl')
+  local file_length = remove('file_length')
+  local hash_key = remove('hash_key')
+  redis.call('HMSET', hash_key, 'file', file, 'file_hash', file_hash, 'file_length', file_length)
+
+  if (last_updated_at ~= cjson.null) then
+    redis.call('HSET', hash_key, 'last_updated_at', last_updated_at)
+  end
+  redis.call('HSETNX', hash_key, 'first_updated_at', first_updated_at)
+  for line, coverage in pairs(hash_values) do
+    if coverage  == '-1' then
+      redis.call("HSET", hash_key, line, coverage)
+    else
+      redis.call("HINCRBY", hash_key, line, coverage)
+    end
+  end
+  if ttl > -1 then
+    redis.call("EXPIRE", hash_key, ttl)
+  end
 end

--- a/lua/lib/persist-coverage.lua
+++ b/lua/lib/persist-coverage.lua
@@ -7,7 +7,7 @@ local function hgetall(hash_key)
   return result
 end
 
-local hash_values =  hgetall(KEYS[1])
+local hash_values =  cjson.decode(redis.call('get', (KEYS[1])))
 local function remove(key)
   local val = hash_values[key]
   hash_values[key] = nil

--- a/lua/test/bootstrap.lua
+++ b/lua/test/bootstrap.lua
@@ -1,4 +1,5 @@
 inspect = require "inspect"
+cjson = require 'cjson'
 require './lua/test/redis-call'
 
 

--- a/lua/test/test-persist-coverage.lua
+++ b/lua/test/test-persist-coverage.lua
@@ -29,21 +29,19 @@ describe("incr-and-stor", function()
     local last_updated_at = first_updated_at
 
     local key = 'hash_key'
-    redis.call( 'hmset', key, 
-    'hash_key', "coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd",
-    'first_updated_at', 
-    first_updated_at, 
-    'last_updated_at', 
-    last_updated_at, 
-    'file', "./dog.rb", 
-    'file_hash', 'abcd', 
-    'ttl', '-1', 
-    'file_length', 3, 
-    0, 0, 
-    1, 1, 
-    2, 2)
-
-
+    local json = cjson.encode({
+      hash_key = "coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd",
+      first_updated_at = first_updated_at, 
+      last_updated_at = last_updated_at, 
+      file = "./dog.rb",
+      file_hash = 'abcd', 
+      ttl = '-1', 
+      file_length = 3, 
+      ['0'] = 0, 
+      ['1'] = 1, 
+      ['2'] = 2
+    });
+    redis.call( 'set', key, json)
 
     call_redis_script('persist-coverage.lua',  { key },  {});
     local results = hgetall("coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd")
@@ -61,17 +59,19 @@ describe("incr-and-stor", function()
     assert.is_false(false, redis.call('exists', key))
 
     last_updated_at = "1569453953"
-    redis.call( 'hmset', key, 
-    'hash_key', "coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd",
-    'first_updated_at', first_updated_at, 
-    'last_updated_at', last_updated_at, 
-    'file', "./dog.rb", 
-    'file_hash', 'abcd', 
-    'ttl', '-1', 
-    'file_length', 3, 
-    0, 1, 
-    1, 1, 
-    2, 1)
+    json = cjson.encode({
+      hash_key="coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd",
+      first_updated_at=first_updated_at, 
+      last_updated_at=last_updated_at, 
+      file="./dog.rb", 
+      file_hash='abcd', 
+      ttl='-1', 
+      file_length=3, 
+      ['0']= 1, 
+      ['1']= 1, 
+      ['2']= 1
+    })
+    redis.call( 'set', key, json )
 
     call_redis_script('persist-coverage.lua',  { key },  {} );
     results = hgetall("coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd")

--- a/lua/test/test-persist-coverage.lua
+++ b/lua/test/test-persist-coverage.lua
@@ -13,7 +13,7 @@ describe("incr-and-stor", function()
 
 
   local function clean_redis() 
-    redis.call('DEL', 'coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd')
+    redis.call('flushdb')
   end
 
   before_each(function()
@@ -24,22 +24,37 @@ describe("incr-and-stor", function()
     clean_redis()
   end)
 
-  it("should add single items", function()
+  it("Adds data on multiple files", function()
     local first_updated_at = "1569453853"
     local last_updated_at = first_updated_at
 
     local key = 'hash_key'
     local json = cjson.encode({
-      hash_key = "coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd",
-      first_updated_at = first_updated_at, 
-      last_updated_at = last_updated_at, 
-      file = "./dog.rb",
-      file_hash = 'abcd', 
-      ttl = '-1', 
-      file_length = 3, 
-      ['0'] = 0, 
-      ['1'] = 1, 
-      ['2'] = 2
+      {
+        hash_key = "coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd",
+        first_updated_at = first_updated_at, 
+        last_updated_at = last_updated_at, 
+        file = "./dog.rb",
+        file_hash = 'abcd', 
+        ttl = -1, 
+        file_length = 3, 
+        ['0'] = 0, 
+        ['1'] = 1, 
+        ['2'] = 2
+      },
+
+      {
+        hash_key = "coverband_hash_3_3.coverband_test.runtime../fish.rb.1234",
+        first_updated_at = first_updated_at, 
+        last_updated_at = last_updated_at, 
+        file = "./fish.rb",
+        file_hash = '1234', 
+        ttl = -1, 
+        file_length = 3, 
+        ['0'] = 1, 
+        ['1'] = 0, 
+        ['2'] = 1 
+      }
     });
     redis.call( 'set', key, json)
 
@@ -55,22 +70,36 @@ describe("incr-and-stor", function()
       first_updated_at = first_updated_at ,
       last_updated_at = last_updated_at
     }, results)
+
+    results = hgetall("coverband_hash_3_3.coverband_test.runtime../fish.rb.1234")
+    assert.are.same({
+      ["0"] = "1",
+      ["1"] = "0",
+      ["2"] = "1",
+      file = "./fish.rb",
+      file_hash = "1234",
+      file_length = "3",
+      first_updated_at = first_updated_at ,
+      last_updated_at = last_updated_at
+    }, results)
+
+
     
     assert.is_false(false, redis.call('exists', key))
 
     last_updated_at = "1569453953"
-    json = cjson.encode({
+    json = cjson.encode({{
       hash_key="coverband_hash_3_3.coverband_test.runtime../dog.rb.abcd",
       first_updated_at=first_updated_at, 
       last_updated_at=last_updated_at, 
       file="./dog.rb", 
       file_hash='abcd', 
-      ttl='-1', 
+      ttl=-1, 
       file_length=3, 
       ['0']= 1, 
       ['1']= 1, 
       ['2']= 1
-    })
+    }})
     redis.call( 'set', key, json )
 
     call_redis_script('persist-coverage.lua',  { key },  {} );


### PR DESCRIPTION
Little bump up in cpu but much faster:

### Before:

![image](https://user-images.githubusercontent.com/96786/66276527-06cc4480-e862-11e9-8f0b-faa221ec3c2c.png)

```
➜  coverband git:(change_to_hash) COVERBAND_HASH_REDIS_STORE=t bundle exec rake benchmarks:redis_reporting
/Users/karlbaum/workspace/coverband/lib/coverband.rb:35: warning: already initialized constant Coverband::Adapters::RedisStore
/Users/karlbaum/workspace/coverband/lib/coverband/adapters/redis_store.rb:8: warning: previous definition of RedisStore was here
D, [2019-10-06T17:51:00.626595 #70722] DEBUG -- : using default configuration
runs benchmarks on reporting large sets of files to redis
Warming up --------------------------------------
   store_reports_all     1.000  i/100ms
Calculating -------------------------------------
   store_reports_all      2.029  (± 0.0%) i/s -     31.000  in  15.384839s
Warming up --------------------------------------
store_reports_subset     5.000  i/100ms
Calculating -------------------------------------
store_reports_subset     58.196  (± 8.6%) i/s -      1.155k in  20.025083s
```

### After:

![i mage](https://user-images.githubusercontent.com/96786/66276501-b9e86e00-e861-11e9-81f3-0d805c7f39db.png)

```
➜  coverband git:(batch_call_lua) COVERBAND_HASH_REDIS_STORE=t bundle exec rake benchmarks:redis_reporting
runs benchmarks on reporting large sets of files to redis
Warming up --------------------------------------
   store_reports_all     1.000  i/100ms
Calculating -------------------------------------
   store_reports_all      4.660  (± 0.0%) i/s -     70.000  in  15.066954s
Warming up --------------------------------------
store_reports_subset    13.000  i/100ms
Calculating -------------------------------------
store_reports_subset    131.136  (± 6.9%) i/s -      2.613k in  20.049154s
```

Looks to be about 2X as fast according to our performance benchmark task.
