### PR TITLE
avoid running coverband on known tasks, capture errors and log warnin…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,8 @@ Metrics/ParameterLists:
   Max: 10
 Naming/AccessorMethodName:
   Enabled: false
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
 Naming/PredicateName:
   Enabled: true
 Style/TernaryParentheses:

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -98,7 +98,7 @@ module Coverband
   private_class_method def self.coverage_instance
     Coverband::Collectors::Coverage.instance
   end
-  unless ENV['COVERBAND_DISABLE_AUTO_START'] || tasks_to_ignore?
+  unless ENV['COVERBAND_DISABLE_AUTO_START']
     begin
       # Coverband should be setup as early as possible
       # to capture usage of things loaded by initializers or other Rails engines

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -98,13 +98,18 @@ module Coverband
   private_class_method def self.coverage_instance
     Coverband::Collectors::Coverage.instance
   end
-  unless ENV['COVERBAND_DISABLE_AUTO_START']
-    # Coverband should be setup as early as possible
-    # to capture usage of things loaded by initializers or other Rails engines
-    configure
-    start
-    require 'coverband/utils/railtie' if defined? ::Rails::Railtie
-    require 'coverband/integrations/resque' if defined? ::Resque
-    require 'coverband/integrations/bundler' if defined? ::Bundler
+  unless ENV['COVERBAND_DISABLE_AUTO_START'] || tasks_to_ignore?
+    begin
+      # Coverband should be setup as early as possible
+      # to capture usage of things loaded by initializers or other Rails engines
+      configure
+      start
+      require 'coverband/utils/railtie' if defined? ::Rails::Railtie
+      require 'coverband/integrations/resque' if defined? ::Resque
+      require 'coverband/integrations/bundler' if defined? ::Bundler
+    rescue Redis::CannotConnectError => error
+      Coverband.configuration.logger.info "Redis is not available (#{error}), Coverband not configured"
+      Coverband.configuration.logger.info 'If this is a setup task like assets:precompile feel free to ignore'
+    end
   end
 end

--- a/lib/coverband/collectors/view_tracker.rb
+++ b/lib/coverband/collectors/view_tracker.rb
@@ -29,10 +29,10 @@ module Coverband
 
         @roots = options.fetch(:roots) { Coverband.configuration.all_root_patterns }
         @roots = @roots.split(',') if @roots.is_a?(String)
+        @one_time_timestamp = false
 
         @logged_views = []
         @views_to_record = []
-        redis_store.set(tracker_time_key, Time.now.to_i) unless redis_store.exists(tracker_time_key)
       end
 
       ###
@@ -105,6 +105,8 @@ module Coverband
       end
 
       def report_views_tracked
+        redis_store.set(tracker_time_key, Time.now.to_i) unless @one_time_timestamp || redis_store.exists(tracker_time_key)
+        @one_time_timestamp = true
         reported_time = Time.now.to_i
         views_to_record.each do |file|
           redis_store.hset(tracker_key, file, reported_time)

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -32,8 +32,7 @@ module Coverband
                     'db:setup',
                     'db:structure:dump',
                     'db:structure:load',
-                    'db:version'
-                  ]
+                    'db:version']
 
     # Heroku when building assets runs code from a dynamic directory
     # /tmp was added to avoid coverage from /tmp/build directories during

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -23,7 +23,17 @@ module Coverband
     IGNORE_TASKS = ['coverband:clear',
                     'coverband:coverage',
                     'coverband:coverage_server',
-                    'coverband:migrate']
+                    'coverband:migrate',
+                    'assets:precompile',
+                    'db:version',
+                    'db:create',
+                    'db:drop',
+                    'db:seed',
+                    'db:setup',
+                    'db:structure:dump',
+                    'db:structure:load',
+                    'db:version'
+                  ]
 
     # Heroku when building assets runs code from a dynamic directory
     # /tmp was added to avoid coverage from /tmp/build directories during

--- a/lib/coverband/utils/railtie.rb
+++ b/lib/coverband/utils/railtie.rb
@@ -29,9 +29,11 @@ module Coverband
     end
 
     config.after_initialize do
-      Coverband.eager_loading_coverage!
-      Coverband.report_coverage
-      Coverband.runtime_coverage!
+      unless Coverband.tasks_to_ignore?
+        Coverband.eager_loading_coverage!
+        Coverband.report_coverage
+        Coverband.runtime_coverage!
+      end
     end
 
     rake_tasks do

--- a/test/forked/rails_rake_full_stack_test.rb
+++ b/test/forked/rails_rake_full_stack_test.rb
@@ -49,6 +49,10 @@ class RailsRakeFullStackTest < Minitest::Test
   test "doesn't exit non-zero with error on missing redis" do
     output = `COVERBAND_CONFIG=./test/rails#{Rails::VERSION::MAJOR}_dummy/config/coverband_missing_redis.rb bundle exec rake -f test/rails#{Rails::VERSION::MAJOR}_dummy/Rakefile -T`
     assert_equal 0, $?.to_i
-    assert output.match(/coverage failed to store/)
+    if ENV['COVERBAND_HASH_REDIS_STORE']
+      assert output.match(/Redis is not available/)
+    else
+      assert output.match(/coverage failed to store/)
+    end
   end
 end

--- a/test/forked/rails_rake_full_stack_test.rb
+++ b/test/forked/rails_rake_full_stack_test.rb
@@ -45,4 +45,10 @@ class RailsRakeFullStackTest < Minitest::Test
     assert_equal empty_hash, coverage_report[:eager_loading]
     assert_equal empty_hash, coverage_report[:merged]
   end
+
+  test "doesn't exit non-zero with error on missing redis" do
+    output = `COVERBAND_CONFIG=./test/rails#{Rails::VERSION::MAJOR}_dummy/config/coverband_missing_redis.rb bundle exec rake -f test/rails#{Rails::VERSION::MAJOR}_dummy/Rakefile -T`
+    assert_equal 0, $?.to_i
+    assert output.match(/coverage failed to store/)
+  end
 end

--- a/test/rails4_dummy/config/coverband_missing_redis.rb
+++ b/test/rails4_dummy/config/coverband_missing_redis.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative '../../rails5_dummy/config/coverband_missing_redis'

--- a/test/rails5_dummy/config/coverband_missing_redis.rb
+++ b/test/rails5_dummy/config/coverband_missing_redis.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Coverband.configure do |config|
+  config.root              = Dir.pwd
+  config.store             = Coverband::Adapters::RedisStore.new(Redis.new(db: 2, url: 'redis://127.0.0.1:123'), redis_namespace: 'coverband_test') if defined? Redis
+  config.ignore            = %w[vendor .erb$ .slim$]
+  config.root_paths        = []
+  config.logger            = Rails.logger
+  config.verbose           = true
+  config.background_reporting_enabled = true
+  config.track_gems = true
+  config.gem_details = true
+  config.use_oneshot_lines_coverage = true if ENV['ONESHOT']
+  config.simulate_oneshot_lines_coverage = true if ENV['SIMULATE_ONESHOT']
+end


### PR DESCRIPTION
…gs on bootup, avoid connecting to Redis unless it is actually used...

---

OK, this resolves some of the recent issues where startup on various jobs that don't need coverage would fail. This takes a couple of approaches, due to we have slightly different issues between the normal adapter the new HashRedisAdapter and with the view tracker.

1. This expands the rake task ignore list to include a bunch of common tasks we would likely want to ignore. This should help folks not have to do anything special when running things like `asset:precompile` on heroku or in CI environments (that have yet to stand up Redis).
2. This rescues Redis connection errors a few different places where they can occur (railtie, startup configuration, etc). This will output a warning in cases where the task isn't covered by our default ignore, but the user wouldn't like Coverband to block their app startup
3. For the view tracker, move from hitting Redis on initialization to lazily hit during runtime. This avoids startup costs when the view tracker will never actually be used (in rake tasks for example). @bhb I believe this is why you started to get the error on the upgrade. The old view_tracker didn't hit Redis in the initialization, and the next version did, which would have surfaced this error. 
    a. Note: The old Redis adapter doesn't connect eagerly either, but the new adapter does to ensure the Redis server is new enough to support LUA scripting, if we could come up with a good way to avoid that during initialization that could be good, but I don't think we want to defer the check until runtime only as it could be confusing, I don't have a good idea for that yet.

I ran with old adapter, new, and with view_tracker (on and off), with Redis turned off and this either works silently or outputs log warnings and moves on with the task as one would expect.

