### PR TITLE
Fix ignore issues

### DIFF
--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -71,7 +71,7 @@ module Coverband
       ###
       def track_file?(file)
         @ignore_patterns.none? do |pattern|
-          file.include?(pattern)
+          file.match(pattern)
         end && (file.start_with?(@project_directory) ||
                 (@track_gems &&
                  Coverband.configuration.gem_paths.any? { |path| file.start_with?(path) }))

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -38,7 +38,7 @@ module Coverband
     # Heroku when building assets runs code from a dynamic directory
     # /tmp was added to avoid coverage from /tmp/build directories during
     # heroku asset compilation
-    IGNORE_DEFAULTS = %w[vendor .erb$ .slim$ /tmp internal:prelude schema.rb]
+    IGNORE_DEFAULTS = %w[vendor/ .erb$ .slim$ /tmp internal:prelude schema.rb]
 
     # Add in missing files which were never loaded
     # we need to know what all paths to check for unloaded files
@@ -154,7 +154,7 @@ module Coverband
 
       # by default we ignore vendor where many deployments put gems
       # we will remove this default if track_gems is set
-      @ignore.delete('vendor')
+      @ignore.delete('vendor/')
       # while we want to allow vendored gems we don't want to track vendored ruby STDLIB
       @ignore << 'vendor/ruby-*' unless @ignore.include?('vendor/ruby-*')
       add_group('App', root)

--- a/lib/coverband/version.rb
+++ b/lib/coverband/version.rb
@@ -5,5 +5,5 @@
 # use format '4.2.1.rc.1' ~> 4.2.1.rc to prerelease versions like v4.2.1.rc.2 and v4.2.1.rc.3
 ###
 module Coverband
-  VERSION = '4.2.4.rc.1'
+  VERSION = '4.2.4.rc.2'
 end

--- a/test/coverband/collectors/coverage_test.rb
+++ b/test/coverband/collectors/coverage_test.rb
@@ -82,6 +82,15 @@ class CollectorsCoverageTest < Minitest::Test
     assert_equal false, @coverband.send(:track_file?, heroku_build_file)
   end
 
+  # verifies a fix where we were storing, merging, and tracking ignored files
+  # then just filtering them out of the final report
+  test 'ignores uses regex same as reporter does' do
+    regex_file = Coverband.configuration.current_root + '/config/initializers/fake.rb'
+    assert_equal true, @coverband.send(:track_file?, regex_file)
+    @coverband.instance_variable_set(:@ignore_patterns, ['config/initializers/*'])
+    assert_equal false, @coverband.send(:track_file?, regex_file)
+  end
+
   test 'one shot line coverage disabled for ruby >= 2.6' do
     return unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5.0')
 

--- a/test/coverband/collectors/view_tracker_test.rb
+++ b/test/coverband/collectors/view_tracker_test.rb
@@ -32,6 +32,26 @@ class ReporterTest < Minitest::Test
     assert_equal [file_path], tracker.logged_views
   end
 
+  test 'track partials that include the word vendor in the path' do
+    Coverband::Collectors::ViewTracker.expects(:supported_version?).returns(true)
+    store = fake_store
+    file_path = "#{File.expand_path(Coverband.configuration.root)}/vendor_relations/file"
+    tracker = Coverband::Collectors::ViewTracker.new(store: store, roots: 'dir')
+    tracker.track_views('name', 'start', 'finish', 'id', identifier: file_path)
+    tracker.report_views_tracked
+    assert_equal [file_path], tracker.used_views.keys
+  end
+
+  test 'ignore partials that include the folder vendor in the path' do
+    Coverband::Collectors::ViewTracker.expects(:supported_version?).returns(true)
+    store = fake_store
+    file_path = "#{File.expand_path(Coverband.configuration.root)}/vendor/file"
+    tracker = Coverband::Collectors::ViewTracker.new(store: store, roots: 'dir')
+    tracker.track_views('name', 'start', 'finish', 'id', identifier: file_path)
+    tracker.report_views_tracked
+    assert_equal Hash.new, tracker.used_views
+  end
+
   test 'track layouts' do
     Coverband::Collectors::ViewTracker.expects(:supported_version?).returns(true)
     store = fake_store

--- a/test/coverband/configuration_test.rb
+++ b/test/coverband/configuration_test.rb
@@ -18,7 +18,7 @@ class BaseTest < Minitest::Test
 
   test 'ignore works with equal' do
     coverband = Coverband::Collectors::Coverage.instance.reset_instance
-    expected = ['vendor', '.erb$', '.slim$', '/tmp', 'internal:prelude', 'schema.rb', 'config/envionments']
+    expected = ['vendor/', '.erb$', '.slim$', '/tmp', 'internal:prelude', 'schema.rb', 'config/envionments']
     assert_equal expected, Coverband.configuration.ignore
   end
 
@@ -27,7 +27,7 @@ class BaseTest < Minitest::Test
       config.ignore += ['config/initializers']
     end
     coverband = Coverband::Collectors::Coverage.instance.reset_instance
-    expected = ['vendor',
+    expected = ['vendor/',
                 '.erb$',
                 '.slim$',
                 '/tmp',

--- a/test/rails5_dummy/config/coverband.rb
+++ b/test/rails5_dummy/config/coverband.rb
@@ -3,7 +3,7 @@
 Coverband.configure do |config|
   config.root              = Dir.pwd
   config.store             = Coverband::Adapters::RedisStore.new(Redis.new(db: 2, url: ENV['REDIS_URL']), redis_namespace: 'coverband_test') if defined? Redis
-  config.ignore            = %w[vendor .erb$ .slim$]
+  config.ignore            = %w[.erb$ .slim$]
   config.root_paths        = []
   config.logger            = Rails.logger
   config.verbose           = true


### PR DESCRIPTION
These two issues came up while configuring Coverband for a new app... The vendor one, in particular, makes it look like we are missing data.

The move from include to match, is to keep the filters in sync we were allowing files in that we would filter out during reporting... This can lead to a lot of extra work for storage and merging. 