### PR TITLE
fixes that we shouldn't report coverage if all the data is out of sync

### DIFF
--- a/lib/coverband/adapters/redis_store.rb
+++ b/lib/coverband/adapters/redis_store.rb
@@ -78,7 +78,7 @@ module Coverband
         local_type ||= opts.key?(:override_type) ? opts[:override_type] : type
         data = redis.get type_base_key(local_type)
         data = data ? JSON.parse(data) : {}
-        data.delete_if { |file_path, data| file_hash(file_path) != data['file_hash'] } unless opts[:skip_hash_check]
+        data.delete_if { |file_path, file_data| file_hash(file_path) != file_data['file_hash'] } unless opts[:skip_hash_check]
         data
       end
 

--- a/test/coverband/adapters/hash_redis_store_test.rb
+++ b/test/coverband/adapters/hash_redis_store_test.rb
@@ -123,7 +123,6 @@ class HashRedisStoreTest < Minitest::Test
     assert_equal [0, nil, 1, 2], @store.coverage['./dog.rb']['data']
     @store.instance_eval { @file_hash_cache = {} }
     mock_file_hash(hash: '123')
-    $debug = true
     assert_nil @store.coverage['./dog.rb']
   end
 

--- a/test/coverband/adapters/redis_store_test.rb
+++ b/test/coverband/adapters/redis_store_test.rb
@@ -36,6 +36,15 @@ unless ENV['COVERBAND_HASH_REDIS_STORE']
       assert current_time <= @store.coverage['app_path/dog.rb']['last_updated_at']
     end
 
+    def test_file_hash_change
+      mock_file_hash(hash: 'abc')
+      @store.save_report('app_path/dog.rb' => [0, nil, 1, 2])
+      assert_equal [0, nil, 1, 2], @store.coverage['app_path/dog.rb']['data']
+      mock_file_hash(hash: '123')
+      $debug = true
+      assert_nil @store.coverage['app_path/dog.rb']
+    end
+
     def test_store_coverage_by_type
       mock_file_hash
       expected = basic_coverage

--- a/test/coverband/adapters/redis_store_test.rb
+++ b/test/coverband/adapters/redis_store_test.rb
@@ -41,7 +41,6 @@ unless ENV['COVERBAND_HASH_REDIS_STORE']
       @store.save_report('app_path/dog.rb' => [0, nil, 1, 2])
       assert_equal [0, nil, 1, 2], @store.coverage['app_path/dog.rb']['data']
       mock_file_hash(hash: '123')
-      $debug = true
       assert_nil @store.coverage['app_path/dog.rb']
     end
 


### PR DESCRIPTION
This is a fix for #319 which came up a while ago, wanted to get the fix in before the next release.