### PR TITLE
avoid hitting redis all at the same time during runtime. This doesn't…

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ config.ignore +=  ['config/application.rb',
                    'config/environments/*',
                    'lib/tasks/*']
 ```
+
 ### View Tracking
 
 Coverband allows an optional feature to track all view files that are used by an application.
@@ -235,6 +236,14 @@ ENV['AWS_REGION']
 ENV['AWS_ACCESS_KEY_ID']
 ENV['AWS_SECRET_ACCESS_KEY']
 ```
+
+### Avoiding Cache Stampede
+
+If you have many servers and they all hit Redis at the same time you can see spikes in your Redis CPU, and memory. This is do to a concept called [cache stampede](https://en.wikipedia.org/wiki/Cache_stampede). It is better to spread out the reporting across your servers. A simple way to do this is to add a random wiggle on your background reporting. This configuration option allows a wiggle. The right amount of wiggle depends on the numbers of servers you have and how willing you are to have delays in your coverage reporting. I would recommend at least 1 second per server. 
+
+Add a wiggle (in seconds) to the background thread to avoid all your servers reporting at the same time:
+
+`config.reporting_wiggle = 30`
 
 ### Redis Hash Store
 

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -8,9 +8,11 @@ module Coverband
                   :background_reporting_enabled,
                   :background_reporting_sleep_seconds, :test_env,
                   :web_enable_clear, :gem_details, :web_debug, :report_on_exit,
-                  :simulate_oneshot_lines_coverage, :track_views, :view_tracker
+                  :simulate_oneshot_lines_coverage, :track_views, :view_tracker,
+                  :reporting_wiggle
 
-    attr_writer :logger, :s3_region, :s3_bucket, :s3_access_key_id, :s3_secret_access_key, :password
+    attr_writer :logger, :s3_region, :s3_bucket, :s3_access_key_id,
+                :s3_secret_access_key, :password
     attr_reader :track_gems, :ignore, :use_oneshot_lines_coverage
 
     #####
@@ -82,6 +84,7 @@ module Coverband
       @s3_secret_access_key = nil
       @redis_namespace = nil
       @redis_ttl = 2_592_000 # in seconds. Default is 30 days.
+      @reporting_wiggle = nil
     end
 
     def logger

--- a/lib/coverband/integrations/background.rb
+++ b/lib/coverband/integrations/background.rb
@@ -33,6 +33,9 @@ module Coverband
           loop do
             Coverband.report_coverage
             Coverband.configuration.view_tracker&.report_views_tracked
+            if Coverband.configuration.reporting_wiggle
+              sleep_seconds = Coverband.configuration.background_reporting_sleep_seconds + rand(Coverband.configuration.reporting_wiggle.to_i)
+            end
             if Coverband.configuration.verbose
               logger.debug("Coverband: background reporting coverage (#{Coverband.configuration.store.type}). Sleeping #{sleep_seconds}s")
             end

--- a/test/coverband/integrations/background_test.rb
+++ b/test/coverband/integrations/background_test.rb
@@ -19,6 +19,16 @@ class BackgroundTest < Minitest::Test
     2.times { Coverband::Background.start }
   end
 
+  def test_start_with_wiggle
+    Thread.expects(:new).yields.returns(ThreadDouble.new(true))
+    Coverband::Background.expects(:loop).yields
+    Coverband::Background.expects(:sleep).with(35)
+    Coverband::Background.expects(:rand).with(10).returns(5)
+    Coverband.configuration.reporting_wiggle = 10
+    Coverband::Collectors::Coverage.instance.expects(:report_coverage).once
+    2.times { Coverband::Background.start }
+  end
+
   def test_start_dead_thread
     Thread.expects(:new).yields.returns(ThreadDouble.new(false)).twice
     Coverband::Background.expects(:loop).yields.twice


### PR DESCRIPTION
… fix bootup and at_exit which could also cause spikes. We will deploy this an monitor the impact.

This should show a step-change during runtime on my Redis CPU monitor, if this works how we intend it to. After we merge this I can do an RC release and put it on production to put it through some testing.