### PR TITLE
Use msgpack

### DIFF
--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   # to test support for sdk 1, uncomment this line
   # spec.add_development_dependency 'aws-sdk', '~> 1'
   # to test sdk 2 use this one
+  spec.add_dependency 'msgpack'
   spec.add_development_dependency 'aws-sdk-s3', '~> 1'
   spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'capybara'

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'logger'
+require 'msgpack'
 require 'json'
 require 'redis'
 require 'coverband/version'

--- a/lib/coverband/adapters/hash_redis_store.rb
+++ b/lib/coverband/adapters/hash_redis_store.rb
@@ -77,7 +77,7 @@ module Coverband
           next unless files_data.any?
 
           arguments_key = [@redis_namespace, SecureRandom.uuid].compact.join('.')
-          @redis.set(arguments_key, { ttl: @ttl, files_data: files_data }.to_json, ex: JSON_PAYLOAD_EXPIRATION)
+          @redis.set(arguments_key, { ttl: @ttl, files_data: files_data }.to_msgpack, ex: JSON_PAYLOAD_EXPIRATION)
           @redis.evalsha(hash_incr_script, [arguments_key])
         end
         @redis.sadd(files_key, keys) if keys.any?

--- a/lua/install.sh
+++ b/lua/install.sh
@@ -13,6 +13,6 @@ pip install hererocks
 hererocks $LUA_DIR -l5.1 -rlatest
 source $LUA_DIR/bin/activate
 lua -v
-for i in luacov busted redis-lua inspect lua-cjson; do 
+for i in luacov busted redis-lua inspect lua-cjson lua-cmsgpack; do 
   luarocks install $i;
 done

--- a/lua/install.sh
+++ b/lua/install.sh
@@ -1,18 +1,15 @@
 #!/bin/bash
 
 LUA_DIR="$HOME/lua51"
-BUSTED="$LUA_DIR/bin/busted"
+LUA="$LUA_DIR/bin/lua"
 
-if [ -f "$BUSTED" ]
-then
-  echo "$BUSTED already exists"
-  exit 0
+if [ ! -f $LUA ]; then
+  echo "Installing lua"
+  pip install hererocks
+  hererocks $LUA_DIR -l5.1 -rlatest
 fi
-
-pip install hererocks
-hererocks $LUA_DIR -l5.1 -rlatest
 source $LUA_DIR/bin/activate
-lua -v
+$LUA -v
 for i in luacov busted redis-lua inspect lua-cjson lua-cmsgpack; do 
   luarocks install $i;
 done

--- a/lua/lib/persist-coverage.lua
+++ b/lua/lib/persist-coverage.lua
@@ -7,7 +7,7 @@ local hmset = function (key, dict)
   end
   return redis.call('HMSET', key, unpack(bulk))
 end
-local payload = cjson.decode(redis.call('get', (KEYS[1])))
+local payload = cmsgpack.unpack(redis.call('get', (KEYS[1])))
 local ttl = payload.ttl
 local files_data = payload.files_data
 redis.call('DEL', KEYS[1])
@@ -22,7 +22,7 @@ for _, file_data in ipairs(files_data) do
   for line, coverage in pairs(file_data.coverage) do
     redis.call("HINCRBY", hash_key, line, coverage)
   end
-  if ttl and ttl ~= cjson.null then
+  if ttl then
     redis.call("EXPIRE", hash_key, ttl)
   end
 end

--- a/lua/test/bootstrap.lua
+++ b/lua/test/bootstrap.lua
@@ -1,5 +1,5 @@
 inspect = require "inspect"
-cjson = require 'cjson'
+cmsgpack = require "cmsgpack"
 require './lua/test/redis-call'
 
 

--- a/lua/test/test-persist-coverage.lua
+++ b/lua/test/test-persist-coverage.lua
@@ -27,7 +27,7 @@ describe("persist-coverage", function()
     local last_updated_at = first_updated_at
 
     local key = 'hash_key'
-    local json = cjson.encode({
+    local json = cmsgpack.pack({
       ttl = nil,
       files_data = {
         {
@@ -92,7 +92,7 @@ describe("persist-coverage", function()
     assert.is_false(false, redis.call('exists', key))
 
     last_updated_at = "1569453953"
-    json = cjson.encode({
+    json = cmsgpack.pack({
       ttl = nil,
       files_data = {
         {


### PR DESCRIPTION
### Before

![image](https://user-images.githubusercontent.com/96786/68353642-375d0380-00d8-11ea-94bf-faadccc51a70.png)

```
runs benchmarks on reporting large sets of files to redis
Warming up --------------------------------------
   store_reports_all     1.000  i/100ms
Calculating -------------------------------------
   store_reports_all      3.192  (± 0.0%) i/s -     48.000  in  15.146428s
Warming up --------------------------------------
store_reports_subset     9.000  i/100ms
Calculating -------------------------------------
store_reports_subset     95.632  (± 9.4%) i/s -      1.899k in  20.066744
```

### After

![image](https://user-images.githubusercontent.com/96786/68353800-a2a6d580-00d8-11ea-8236-697854e2c791.png)

```
Warming up --------------------------------------
   store_reports_all     1.000  i/100ms
Calculating -------------------------------------
   store_reports_all      3.564  (± 0.0%) i/s -     54.000  in  15.242361s
Warming up --------------------------------------
store_reports_subset    10.000  i/100ms
Calculating -------------------------------------
store_reports_subset    102.395  (± 9.8%) i/s -      2.030k in  20.031830s
```

Using msg_pack gives around a 6.8% speed increase along with a moderate decrease in memory usage.  CPU utilization does go up but that seems to correlate to more commands per second.