### PR TITLE
Increase hash_redis_store save_report batch size

### DIFF
--- a/lib/coverband/adapters/hash_redis_store.rb
+++ b/lib/coverband/adapters/hash_redis_store.rb
@@ -22,7 +22,7 @@ module Coverband
       def initialize(redis, opts = {})
         super()
         @redis_namespace = opts[:redis_namespace]
-        @save_report_batch_size = opts[:save_report_batch_size] || 5
+        @save_report_batch_size = opts[:save_report_batch_size] || 100
         @format_version = REDIS_STORAGE_FORMAT_VERSION
         @redis = redis
         raise 'HashRedisStore requires redis >= 2.6.0' unless supported?


### PR DESCRIPTION
For large projects, this seems like a reasonable default for save_report batch size:

See discussion here: https://github.com/danmayer/coverband/pull/355#issuecomment-550257873