### PR TITLE
handle stdlib branch coverage options, now a default in simplecov 0.1…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,10 @@ Style/ClassVars:
   Enabled: false
 Style/MultilineBlockChain:
   Enabled: false
+Style/StringLiterals:
+  Enabled: false
+Style/IfInsideElse:
+  Enabled: false    
 Style/FrozenStringLiteralComment:
   Enabled: true
 Style/GuardClause:

--- a/lib/coverband/collectors/coverage.rb
+++ b/lib/coverband/collectors/coverage.rb
@@ -89,12 +89,17 @@ module Coverband
         raise NotImplementedError, 'Coverage needs Ruby > 2.3.0' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
 
         require 'coverage'
-        if Coverage.ruby_version_greater_than_or_equal_to?('2.6.0')
-          ::Coverage.start(oneshot_lines: Coverband.configuration.use_oneshot_lines_coverage) unless ::Coverage.running?
-        elsif Coverage.ruby_version_greater_than_or_equal_to?('2.5.0')
-          ::Coverage.start unless ::Coverage.running?
+        if defined?(SimpleCov) && defined?(Rails) && defined?(Rails.env) && Rails.env.test?
+          puts "Coverband: detected SimpleCov in test Env, allowing it to start Coverage"
+          puts "Coverband: to ensure no error logs or missing Coverage call `SimpleCov.start` prior to requiring Coverband"
         else
-          ::Coverage.start
+          if Coverage.ruby_version_greater_than_or_equal_to?('2.6.0')
+            ::Coverage.start(oneshot_lines: Coverband.configuration.use_oneshot_lines_coverage) unless ::Coverage.running?
+          elsif Coverage.ruby_version_greater_than_or_equal_to?('2.5.0')
+            ::Coverage.start unless ::Coverage.running?
+          else
+            ::Coverage.start
+          end
         end
         reset_instance
       end

--- a/lib/coverband/collectors/delta.rb
+++ b/lib/coverband/collectors/delta.rb
@@ -44,11 +44,17 @@ module Coverband
       private
 
       def generate
+        # TODO: if we filtered before doing this we would avoid calculating the line diff on a ton of files
+        # This would be a fairly noticeable perf win
         current_coverage.each_with_object({}) do |(file, line_counts), new_results|
+          # This handles Coverage branch support, setup by default in
+          # simplecov 0.18.x
+          arr_line_counts = line_counts.is_a?(Hash) ? line_counts[:lines] : line_counts
           new_results[file] = if @@previous_coverage && @@previous_coverage[file]
-                                array_diff(line_counts, @@previous_coverage[file])
+                                prev_line_counts = @@previous_coverage[file].is_a?(Hash) ? @@previous_coverage[file][:lines] : @@previous_coverage[file]
+                                array_diff(arr_line_counts, prev_line_counts)
                               else
-                                line_counts
+                                arr_line_counts
                               end
         end
       end

--- a/lib/coverband/version.rb
+++ b/lib/coverband/version.rb
@@ -5,5 +5,5 @@
 # use format '4.2.1.rc.1' ~> 4.2.1.rc to prerelease versions like v4.2.1.rc.2 and v4.2.1.rc.3
 ###
 module Coverband
-  VERSION = '4.2.5.rc.1'
+  VERSION = '4.2.5.rc.2'
 end

--- a/test/coverband/collectors/delta_test.rb
+++ b/test/coverband/collectors/delta_test.rb
@@ -49,6 +49,21 @@ class CollectorsDeltaTest < Minitest::Test
     assert_equal(current_coverage, results)
   end
 
+  test 'Coverage has branching enabled and has gone up' do
+    current_coverage = {
+      'car.rb' => { lines: [nil, 1, 5, 1] }
+    }
+    ::Coverage.expects(:peek_result).returns(current_coverage)
+    results = Coverband::Collectors::Delta.results
+
+    current_coverage = {
+      'car.rb' => { lines: [nil, 1, 7, 1] }
+    }
+    ::Coverage.expects(:peek_result).returns(current_coverage)
+    results = Coverband::Collectors::Delta.results
+    assert_equal({ 'car.rb' => [nil, 0, 2, 0] }, results)
+  end
+
   if Coverband.configuration.one_shot_coverage_implemented_in_ruby_version?
     test 'oneshot coverage calls clear' do
       Coverband.configuration.stubs(:use_oneshot_lines_coverage).returns(true)


### PR DESCRIPTION
…8.x we will get more bug reports for projects that use both

This handles two issues:

* we need to be able to parse the new formats in stdlib Ruby Coverage 2.5 & 2.6, namely :lines which comes along with branching support, since SimpleCov 0.18.x the :lines format is a default
* also, Simplecov doesn't check if Coverage is already running, and we start Coverage first which causes an error if both are configured. I detect that case and output a warning, as Coverage will be started late and miss some files our eager_loading hook

The first fix is really valuable as anyone can configure the various Coverage format options, the simplecov specific detecting is a bit annoying and specific to if both libs are trying to run in test mode. For now, we don't really recommend running Coverband in test.

this was tested on Coverband Demo with SimpleCov 0.18 setup, resolves https://github.com/danmayer/coverband/issues/368