### PR TITLE
Address Redis `exists` deprecation warning

### DIFF
--- a/lib/coverband/collectors/view_tracker.rb
+++ b/lib/coverband/collectors/view_tracker.rb
@@ -108,7 +108,7 @@ module Coverband
       end
 
       def report_views_tracked
-        redis_store.set(tracker_time_key, Time.now.to_i) unless @one_time_timestamp || redis_store.exists(tracker_time_key)
+        redis_store.set(tracker_time_key, Time.now.to_i) unless @one_time_timestamp || tracker_time_key_exists?
         @one_time_timestamp = true
         reported_time = Time.now.to_i
         views_to_record.each do |file|
@@ -143,6 +143,14 @@ module Coverband
 
       def redis_store
         store.raw_store
+      end
+
+      def tracker_time_key_exists?
+        if defined?(redis_store.exists?)
+          redis_store.exists?(tracker_time_key)
+        else
+          redis_store.exists(tracker_time_key)
+        end
       end
 
       def tracker_key


### PR DESCRIPTION
After upgrading an app that has Coverband to from Redis 4.1 to [Redis 4.2.1](https://github.com/redis/redis-rb/blob/0546fe6c62de81843e8f0e9353cafba52d76eab8/CHANGELOG.md#421) I'm seeing the following deprecation warning:

> `Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0.


To address this warning, this PR will updates the code to use the `exists?` method if it is defined otherwise it will continue to use the existing logic (`exists`).