### PR TITLE
this will initialize after the bundle require step, but before all in…

### DIFF
--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -99,9 +99,14 @@ module Coverband
     begin
       # Coverband should be setup as early as possible
       # to capture usage of things loaded by initializers or other Rails engines
-      configure
-      start
-      require "coverband/utils/railtie" if defined? ::Rails::Railtie
+      # but after gems are loaded to avoid slowing down gem usage
+      # best is in application.rb after the bundler line but we get close with Railtie
+      if defined? ::Rails::Railtie
+        require "coverband/utils/railtie"
+      else
+        configure
+        start
+      end
       require "coverband/integrations/resque" if defined? ::Resque
     rescue Redis::CannotConnectError => error
       Coverband.configuration.logger.info "Redis is not available (#{error}), Coverband not configured"

--- a/lib/coverband/adapters/file_store.rb
+++ b/lib/coverband/adapters/file_store.rb
@@ -5,7 +5,7 @@ module Coverband
     ###
     # FilesStore store a merged coverage file to local disk
     # Generally this is for testing and development
-    # Not recommended for production deployment
+    # Not recommended for production deployment, as it doesn't handle concurrency
     ###
     class FileStore < Base
       def initialize(path, _opts = {})

--- a/lib/coverband/adapters/hash_redis_store.rb
+++ b/lib/coverband/adapters/hash_redis_store.rb
@@ -33,6 +33,9 @@ module Coverband
 
       def supported?
         Gem::Version.new(@redis.info["redis_version"]) >= Gem::Version.new("2.6.0")
+      rescue Redis::CannotConnectError => error
+        Coverband.configuration.logger.info "Redis is not available (#{error}), Coverband not configured"
+        Coverband.configuration.logger.info "If this is a setup task like assets:precompile feel free to ignore"
       end
 
       def clear!

--- a/lib/coverband/utils/railtie.rb
+++ b/lib/coverband/utils/railtie.rb
@@ -38,8 +38,13 @@ module Coverband
 
     config.before_configuration do
       unless ENV["COVERBAND_DISABLE_AUTO_START"]
-        Coverband.configure
-        Coverband.start
+        begin
+          Coverband.configure
+          Coverband.start
+        rescue Redis::CannotConnectError => error
+          Coverband.configuration.logger.info "Redis is not available (#{error}), Coverband not configured"
+          Coverband.configuration.logger.info "If this is a setup task like assets:precompile feel free to ignore"
+        end
       end
     end
 

--- a/lib/coverband/utils/railtie.rb
+++ b/lib/coverband/utils/railtie.rb
@@ -36,6 +36,13 @@ module Coverband
       end
     end
 
+    config.before_configuration do
+      unless ENV["COVERBAND_DISABLE_AUTO_START"]
+        Coverband.configure
+        Coverband.start
+      end
+    end
+
     rake_tasks do
       load "coverband/utils/tasks.rb"
     end

--- a/lib/coverband/version.rb
+++ b/lib/coverband/version.rb
@@ -5,5 +5,5 @@
 # use format '4.2.1.rc.1' ~> 4.2.1.rc to prerelease versions like v4.2.1.rc.2 and v4.2.1.rc.3
 ###
 module Coverband
-  VERSION = "5.0.0.rc.1"
+  VERSION = "5.0.0.rc.2"
 end


### PR DESCRIPTION
…itializers.... which is the earliest point after bundler that I could find...

At work to keep memory and CPU under control all apps have moved to `gem 'coverband', require: false` then adding a require in the `application.rb`

```
Bundler.require(*Rails.groups)
require 'coverband'
```

This means that Coverage won't track any gems but will track all app code including railtie integrations...

I can't hit that exact point with a Railtie, but very very close... so before railties run initialize they run config, so that means we should still get mot initialize code, but we can't get everything.... but this is a much better default since the other has shown on large apps to use dangerous amounts of memory.