### PR TITLE
fix for #367 issue when multiple things patch resque in different ways

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -9,6 +9,7 @@ ignore: # default: []
       - Style/IdenticalConditionalBranches # these are just easier to read sometimes
       - Style/IfInsideElse # these are just easier to read sometimes
       - Standard/SemanticBlocks # not valid in older Ruby
+      - Style/Alias # This isn't always right and alias and alias_method can have different usage
       - Style/RedundantRegexpEscape # fix later, enforcement changed
       - Layout/ArrayAlignment # WTF all of master broken from a few changes in rubo
       - Performance/RegexpMatch # Rubocop / standardrb have this WRONG for Ruby 2.3/2.4 not compatiable

--- a/README.md
+++ b/README.md
@@ -312,6 +312,22 @@ Note: To debug issues getting Coverband working. I recommend running in developm
 
 If you are trying to debug locally wondering what code is being run during a request. The verbose modes `config.verbose = true` && `Rails.logger.level = :debug`. With true set it will output the number of lines executed per file, to the passed in log.
 
+### Solving: stack level too deep errors
+
+If you start seeing SystemStackError: stack level too deep errors from background jobs after installing Coverband, this means there is another patch for ResqueWorker that conflicts with Coverband's patch in your application. To fix this, change coverband gem line in your Gemfile to the following:
+
+```
+gem 'coverband', require: ['alternative_coverband_patch', 'coverband']
+```
+
+If you currently have require: false, remove the 'coverband' string from the require array above so the gem line becomes like this:
+
+```
+gem 'coverband', require: ['alternative_coverband_patch']
+```
+
+This conflict happens when a ruby method is patched twice, once using module prepend, and once using method aliasing. See this ruby issue for details. The fix is to apply all patches the same way. Coverband by default will apply its patch using prepend, but you can change that to  method aliasing by adding require: ['alternative_coverband_patch'] to the gem line as shown above.
+
 # Prerequisites
 
 - Coverband 3.0.X+ requires Ruby 2.3+

--- a/lib/alternative_coverband_patch.rb
+++ b/lib/alternative_coverband_patch.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Coverband
+  COVERBAND_ALTERNATE_PATCH = true
+end

--- a/lib/coverband/integrations/resque.rb
+++ b/lib/coverband/integrations/resque.rb
@@ -29,8 +29,8 @@ if defined?(Coverband::COVERBAND_ALTERNATE_PATCH)
     ensure
       Coverband.report_coverage
     end
-    alias_method perform_without_coverband perform
-    alias_method perform perform_with_coverband
+    alias perform_without_coverband perform
+    alias perform perform_with_coverband
   end
 else
   Resque::Job.prepend(Coverband::ResqueWorker)

--- a/lib/coverband/integrations/resque.rb
+++ b/lib/coverband/integrations/resque.rb
@@ -22,4 +22,16 @@ module Coverband
   end
 end
 
-Resque::Job.prepend(Coverband::ResqueWorker)
+if defined?(Coverband::COVERBAND_ALTERNATE_PATCH)
+  Resque::Job.class_eval do
+    def perform_with_coverband
+      perform_without_coverband
+    ensure
+      Coverband.report_coverage
+    end
+    alias_method perform_without_coverband perform
+    alias_method perform perform_with_coverband
+  end
+else
+  Resque::Job.prepend(Coverband::ResqueWorker)
+end


### PR DESCRIPTION
this basically takes the approach of how rack mini profiler deals with these kinds of same issues

https://github.com/MiniProfiler/rack-mini-profiler#nethttp-stack-level-too-deep-errors

We allow users to opt into alternative patching mechanisms 