### PR TITLE
reduce the memory footprint when not using webreporter

### DIFF
--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -13,18 +13,10 @@ require "coverband/adapters/redis_store"
 require "coverband/adapters/hash_redis_store"
 require "coverband/adapters/file_store"
 require "coverband/utils/file_hasher"
-require "coverband/utils/html_formatter"
-require "coverband/utils/result"
-require "coverband/utils/file_list"
-require "coverband/utils/source_file"
-require "coverband/utils/lines_classifier"
-require "coverband/utils/results"
 require "coverband/collectors/coverage"
 require "coverband/collectors/view_tracker"
 require "coverband/reporters/base"
-require "coverband/reporters/html_report"
 require "coverband/reporters/console_report"
-require "coverband/reporters/web"
 require "coverband/integrations/background"
 require "coverband/integrations/background_middleware"
 require "coverband/integrations/rack_server_check"
@@ -111,6 +103,26 @@ module Coverband
     rescue Redis::CannotConnectError => error
       Coverband.configuration.logger.info "Redis is not available (#{error}), Coverband not configured"
       Coverband.configuration.logger.info "If this is a setup task like assets:precompile feel free to ignore"
+    end
+  end
+
+  module Reporters
+    class Web
+      ###
+      # NOTE: if the user doesn't setup the webreporter
+      # we don't need any of the below files loaded or using memory
+      ###
+      def initialize
+        require "coverband/reporters/web"
+        require "coverband/utils/html_formatter"
+        require "coverband/utils/result"
+        require "coverband/utils/file_list"
+        require "coverband/utils/source_file"
+        require "coverband/utils/lines_classifier"
+        require "coverband/utils/results"
+        require "coverband/reporters/html_report"
+        init_web
+      end
     end
   end
 end

--- a/lib/coverband/reporters/web.rb
+++ b/lib/coverband/reporters/web.rb
@@ -12,6 +12,10 @@ module Coverband
       attr_reader :request
 
       def initialize
+        init_web
+      end
+
+      def init_web
         full_path = Gem::Specification.find_by_name("coverband").full_gem_path
         @static = Rack::Static.new(self,
           root: File.expand_path("public", full_path),

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,17 @@ require "ostruct"
 require "json"
 require "redis"
 require "resque"
+
+require "coverband"
+require "coverband/reporters/web"
+require "coverband/utils/html_formatter"
+require "coverband/utils/result"
+require "coverband/utils/file_list"
+require "coverband/utils/source_file"
+require "coverband/utils/lines_classifier"
+require "coverband/utils/results"
+require "coverband/reporters/html_report"
+
 # require 'pry-byebug' unless ENV['CI'] # Ruby 2.3 on CI crashes on pry & JRuby doesn't support it
 require_relative "unique_files"
 $VERBOSE = original_verbosity


### PR DESCRIPTION
* as we offer other reporter options we don't want to load files for users that don't need them
* part of the process of ensuring optimal performance