### PR TITLE
cleanup configuration options, ensure all env options can be set via …

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -13,6 +13,7 @@ ignore: # default: []
       - Style/RedundantRegexpEscape # fix later, enforcement changed
       - Layout/ArrayAlignment # WTF all of master broken from a few changes in rubo
       - Performance/RegexpMatch # Rubocop / standardrb have this WRONG for Ruby 2.3/2.4 not compatiable
+      - Style/GlobalStdStream # Rubocop / standardrb have this WRONG for Ruby 2.3/2.4 not compatiable
   - "vendor/**/*"
   - "pkg/**/*"
   - "test/**/*":

--- a/changes.md
+++ b/changes.md
@@ -61,7 +61,11 @@ Will be the fully modern release that drops maintenance legacy support in favor 
   - drops static report support
   - drops gem support
   - only loaded web reporter files when required
-- improved load order allowing more time for ENV vars (better dotenv, figaro, rails secrets support)
+- configuration improvements
+	- improved load order allowing more time for ENV vars (better dotenv, figaro, rails secrets support)
+	- all config options can be set via coverband config, not requiring ENV var support
+	- deprecation notices on soon to be removed config options
+	- config exceptions on invalid configuration combinations
 - improved resque patching pattern
 - improved default ignores
 - additional adapters

--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "resque"
-  spec.add_development_dependency "standard", "= 0.4.6"
+  spec.add_development_dependency "standard", "= 0.2.5"
   spec.add_development_dependency "standardrb"
 
   spec.add_development_dependency "coveralls"

--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "resque"
-  spec.add_development_dependency "standard", "~> 0.4.6"
+  spec.add_development_dependency "standard", "= 0.4.6"
   spec.add_development_dependency "standardrb"
 
   spec.add_development_dependency "coveralls"

--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "resque"
+  spec.add_development_dependency "standard", "~> 0.4.6"
   spec.add_development_dependency "standardrb"
 
   spec.add_development_dependency "coveralls"

--- a/lib/coverband/adapters/web_service_store.rb
+++ b/lib/coverband/adapters/web_service_store.rb
@@ -55,8 +55,7 @@ module Coverband
         res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
           http.request(req)
         end
-        coverage_data = JSON.parse(res.body)
-        coverage_data
+        JSON.parse(res.body)
       rescue => e
         logger&.error "Coverband: Error while retrieving coverage #{e}" if Coverband.configuration.verbose || Coverband.configuration.service_dev_mode
       end

--- a/lib/coverband/adapters/web_service_store.rb
+++ b/lib/coverband/adapters/web_service_store.rb
@@ -3,8 +3,7 @@
 module Coverband
   module Adapters
     ###
-    # WebServiceStore store a merged coverage file to local disk
-    # TODO: add webmock tests
+    # WebServiceStore: store a checkpoint of coverage to a remote service
     ###
     class WebServiceStore < Base
       attr_reader :coverband_url, :process_type, :runtime_env, :hostname, :pid

--- a/lib/coverband/reporters/base.rb
+++ b/lib/coverband/reporters/base.rb
@@ -101,8 +101,7 @@ module Coverband
             end
           end
 
-          scov_style_report = fix_file_names(scov_style_report, roots)
-          scov_style_report
+          fix_file_names(scov_style_report, roots)
         end
       end
     end

--- a/lib/coverband/reporters/html_report.rb
+++ b/lib/coverband/reporters/html_report.rb
@@ -7,6 +7,7 @@ module Coverband
         :base_path, :filename
 
       def initialize(store, options = {})
+        super
         coverband_reports = Coverband::Reporters::Base.report(store, options)
         self.open_report = options.fetch(:open_report) { true }
         # TODO: refactor notice out to top level of web only

--- a/lib/coverband/reporters/html_report.rb
+++ b/lib/coverband/reporters/html_report.rb
@@ -7,7 +7,6 @@ module Coverband
         :base_path, :filename
 
       def initialize(store, options = {})
-        super(store, options = {})
         coverband_reports = Coverband::Reporters::Base.report(store, options)
         self.open_report = options.fetch(:open_report) { true }
         # TODO: refactor notice out to top level of web only

--- a/lib/coverband/reporters/html_report.rb
+++ b/lib/coverband/reporters/html_report.rb
@@ -7,7 +7,7 @@ module Coverband
         :base_path, :filename
 
       def initialize(store, options = {})
-        super
+        super(store, options = {})
         coverband_reports = Coverband::Reporters::Base.report(store, options)
         self.open_report = options.fetch(:open_report) { true }
         # TODO: refactor notice out to top level of web only

--- a/test/coverband/integrations/background_test.rb
+++ b/test/coverband/integrations/background_test.rb
@@ -12,18 +12,29 @@ class BackgroundTest < Minitest::Test
     end
   end
 
+  def setup
+    Coverband.configuration.reset
+    super
+    Coverband.configure do |config|
+      config.background_reporting_sleep_seconds = 60
+      Coverband.configuration.reporting_wiggle = 0
+    end
+  end
+
   def test_start
+    sleep_seconds = Coverband.configuration.background_reporting_sleep_seconds.to_i
     Thread.expects(:new).yields.returns(ThreadDouble.new(true))
     Coverband::Background.expects(:loop).yields
-    Coverband::Background.expects(:sleep).with(60)
+    Coverband::Background.expects(:sleep).with(sleep_seconds)
     Coverband::Collectors::Coverage.instance.expects(:report_coverage).once
     2.times { Coverband::Background.start }
   end
 
   def test_start_with_wiggle
+    sleep_seconds = Coverband.configuration.background_reporting_sleep_seconds.to_i
     Thread.expects(:new).yields.returns(ThreadDouble.new(true))
     Coverband::Background.expects(:loop).yields
-    Coverband::Background.expects(:sleep).with(65)
+    Coverband::Background.expects(:sleep).with(sleep_seconds + 5)
     Coverband::Background.expects(:rand).with(10).returns(5)
     Coverband.configuration.reporting_wiggle = 10
     Coverband::Collectors::Coverage.instance.expects(:report_coverage).once

--- a/test/jruby_check.rb
+++ b/test/jruby_check.rb
@@ -2,7 +2,7 @@ require "coverage"
 
 Coverage.start
 
-require "./test/dog.rb"
+require "./test/dog"
 
 puts Coverage.peek_result
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,6 +45,7 @@ module Coverband
     end
 
     def self.reset
+      Coverband.configuration.reset
       Coverband.configuration.redis_namespace = "coverband_test"
       Coverband.configuration.store.instance_variable_set(:@redis_namespace, "coverband_test")
       Coverband.configuration.store.class.class_variable_set(:@@path_cache, {})


### PR DESCRIPTION
…config, add tests for invalid configuration options...

I think this covers most fo the really bad cases...

1. by default all old configs will still work and default to redis
2. improved detection of coverband service
   * by either using config/coverband_service.rb (to not break some of our alpha users we setup this way)
   * or just setting `config.api_key`