### PR TITLE
catch if we attempted to send metrics before connfiguring

### DIFF
--- a/lib/coverband/collectors/view_tracker.rb
+++ b/lib/coverband/collectors/view_tracker.rb
@@ -20,6 +20,7 @@ module Coverband
 
       def initialize(options = {})
         raise NotImplementedError, "View Tracker requires Rails 4 or greater" unless self.class.supported_version?
+        raise "Coverband: view tracker initialized before configuration!" if !Coverband.configured? && ENV["COVERBAND_TEST"] == "test"
 
         @project_directory = File.expand_path(Coverband.configuration.root)
         @ignore_patterns = Coverband.configuration.ignore

--- a/test/forked/rails_full_stack_test.rb
+++ b/test/forked/rails_full_stack_test.rb
@@ -46,6 +46,15 @@ class RailsFullStackTest < Minitest::Test
       results = store.coverage[dummy_controller]["data"]
       assert_equal(runtime_expected, results)
     end
+
+    test "check view tracker" do
+      visit "/dummy_view/show"
+      assert page.body.match(/rendered view/)
+      assert page.body.match(/I am no dummy view tracker text/)
+      Coverband.configuration.view_tracker&.report_views_tracked
+      visit "/coverage/view_tracker"
+      assert_selector("div", text: /These views have been rendered at least once.*\/app\/views\/dummy_view\/show\.html\.erb/)
+    end
   end
 
   ###

--- a/test/forked/rails_view_tracker_stack_test.rb
+++ b/test/forked/rails_view_tracker_stack_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require File.expand_path("../rails_test_helper", File.dirname(__FILE__))
+
+class RailsWithoutConfigStackTest < Minitest::Test
+  def setup
+    super
+    setup_server
+  end
+
+  def teardown
+    super
+    shutdown_server
+  end
+
+  test "check view tracker" do
+    output = `sleep 7 && curl http://localhost:9999/dummy_view/show`
+    assert output.match(/rendered view/)
+    assert output.match(/I am no dummy view tracker text/)
+    output = `sleep 1 && curl http://localhost:9999/coverage/view_tracker`
+    assert output.match(/Used Views: \(1\)/)
+    assert output.match(/dummy_view\/show/)
+  end
+
+  private
+
+  # NOTE: We aren't leveraging Capybara because it loads all of our other test helpers and such,
+  # which in turn Configures coverband making it impossible to test the configuration error
+  def setup_server
+    ENV["RAILS_ENV"] = "test"
+    require "rails"
+    fork do
+      exec "cd test/rails#{Rails::VERSION::MAJOR}_dummy && COVERBAND_TEST=test bundle exec rackup config.ru -p 9999 --pid /tmp/testrack.pid"
+    end
+  end
+
+  def shutdown_server
+    if File.exist?("/tmp/testrack.pid")
+      pid = `cat /tmp/testrack.pid`&.strip&.to_i
+      Process.kill("HUP", pid)
+      sleep 1
+    end
+  end
+end

--- a/test/rails4_dummy/app/controllers/dummy_view_controller.rb
+++ b/test/rails4_dummy/app/controllers/dummy_view_controller.rb
@@ -1,0 +1,6 @@
+class DummyViewController < ActionController::Base
+  def show
+    @text = "I am no dummy view tracker text"
+    render layout: false
+  end
+end

--- a/test/rails4_dummy/app/views/dummy_view/show.html.erb
+++ b/test/rails4_dummy/app/views/dummy_view/show.html.erb
@@ -1,0 +1,5 @@
+rendered view
+
+<div>
+  <%= @text %>
+</div>

--- a/test/rails4_dummy/config/application.rb
+++ b/test/rails4_dummy/config/application.rb
@@ -10,5 +10,6 @@ Bundler.require(*Rails.groups)
 module Rails4Dummy
   class Application < Rails::Application
     config.eager_load = true
+    config.consider_all_requests_local = true
   end
 end

--- a/test/rails4_dummy/config/routes.rb
+++ b/test/rails4_dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   get "dummy/show"
+  get "dummy_view/show", to: "dummy_view#show"
   mount Coverband::Reporters::Web.new, at: "/coverage"
 end

--- a/test/rails5_dummy/app/controllers/dummy_view_controller.rb
+++ b/test/rails5_dummy/app/controllers/dummy_view_controller.rb
@@ -1,0 +1,6 @@
+class DummyViewController < ActionController::Base
+  def show
+    @text = "I am no dummy view tracker text"
+    render layout: false
+  end
+end

--- a/test/rails5_dummy/app/views/dummy_view/show.html.erb
+++ b/test/rails5_dummy/app/views/dummy_view/show.html.erb
@@ -1,0 +1,5 @@
+rendered view
+
+<div>
+  <%= @text %>
+</div>

--- a/test/rails5_dummy/config/application.rb
+++ b/test/rails5_dummy/config/application.rb
@@ -2,11 +2,13 @@
 
 require "rails"
 require "action_controller/railtie"
+require "action_view/railtie"
 require "coverband"
 Bundler.require(*Rails.groups)
 
 module Rails5Dummy
   class Application < Rails::Application
     config.eager_load = true
+    config.consider_all_requests_local = true
   end
 end

--- a/test/rails5_dummy/config/routes.rb
+++ b/test/rails5_dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   get "dummy/show"
+  get "dummy_view/show", to: "dummy_view#show"
   mount Coverband::Reporters::Web.new, at: "/coverage"
 end

--- a/test/rails6_dummy/app/controllers/dummy_view_controller.rb
+++ b/test/rails6_dummy/app/controllers/dummy_view_controller.rb
@@ -1,0 +1,6 @@
+class DummyViewController < ActionController::Base
+  def show
+    @text = "I am no dummy view tracker text"
+    render layout: false
+  end
+end

--- a/test/rails6_dummy/app/views/dummy_view/show.html.erb
+++ b/test/rails6_dummy/app/views/dummy_view/show.html.erb
@@ -1,0 +1,5 @@
+rendered view
+
+<div>
+  <%= @text %>
+</div>

--- a/test/rails6_dummy/config/application.rb
+++ b/test/rails6_dummy/config/application.rb
@@ -10,5 +10,6 @@ Bundler.require(*Rails.groups)
 module Rails6Dummy
   class Application < Rails::Application
     config.eager_load = true
+    config.consider_all_requests_local = true
   end
 end

--- a/test/rails6_dummy/config/routes.rb
+++ b/test/rails6_dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   get "dummy/show"
+  get "dummy_view/show", to: "dummy_view#show"
   mount Coverband::Reporters::Web.new, at: "/coverage"
 end


### PR DESCRIPTION
add a test that would have caught the view tracker race condition

# How to test fully isolated Coverband Rails Initialization

Follow up on the previous [race condition fix](https://github.com/danmayer/coverband/commit/08726b583181767717c6c3580848b7efdc90bf8b).

I found that I couldn't test the Coverband configuration in full isolation with Capybara... I still built off the forked tests which should help keep the test code isolated, but I ended up forking off an entire server and then testing against that server. 

* This is a bit complicated
* I tried a few other paths, but wasn't able to find anything that would have caught the race condition bug
* This should be a pretty re-usable pattern that we could write similar tests to verify coverage with multiple redises available.

### Error Output

If I run this code against Coverband before the fix was committed this is how the test fails...

```
 bundle exec ruby test/forked/rails_view_tracker_stack_test.rb
D, [2020-09-19T16:04:40.642761 #28774] DEBUG -- : using default configuration
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Run options: --seed 46770

# Running:

Traceback (most recent call last):
	36: from /Users/danmayer/.rvm/gems/ruby-2.5.3/bin/ruby_executable_hooks:24:in `<main>'
	35: from /Users/danmayer/.rvm/gems/ruby-2.5.3/bin/ruby_executable_hooks:24:in `eval'
	34: from /Users/danmayer/.rvm/gems/ruby-2.5.3/bin/rackup:23:in `<main>'
	33: from /Users/danmayer/.rvm/gems/ruby-2.5.3/bin/rackup:23:in `load'
	32: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/rack-2.0.6/bin/rackup:4:in `<top (required)>'
	31: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/rack-2.0.6/lib/rack/server.rb:148:in `start'
	30: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/rack-2.0.6/lib/rack/server.rb:283:in `start'
	29: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/rack-2.0.6/lib/rack/server.rb:354:in `wrapped_app'
	28: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/rack-2.0.6/lib/rack/server.rb:219:in `app'
	27: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/rack-2.0.6/lib/rack/server.rb:319:in `build_app_and_options_from_config'
	26: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/rack-2.0.6/lib/rack/builder.rb:40:in `parse_file'
	25: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/rack-2.0.6/lib/rack/builder.rb:49:in `new_from_string'
	24: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/rack-2.0.6/lib/rack/builder.rb:49:in `eval'
	23: from /Users/danmayer/projects/coverband/test/rails5_dummy/config.ru:in `<main>'
	22: from /Users/danmayer/projects/coverband/test/rails5_dummy/config.ru:in `new'
	21: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/rack-2.0.6/lib/rack/builder.rb:55:in `initialize'
	20: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/rack-2.0.6/lib/rack/builder.rb:55:in `instance_eval'
	19: from /Users/danmayer/projects/coverband/test/rails5_dummy/config.ru:1:in `block in <main>'
	18: from /Users/danmayer/projects/coverband/test/rails5_dummy/config.ru:1:in `require_relative'
	17: from /Users/danmayer/projects/coverband/test/rails5_dummy/config/environment.rb:2:in `<top (required)>'
	16: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/railties-5.2.2/lib/rails/application.rb:361:in `initialize!'
	15: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/railties-5.2.2/lib/rails/initializable.rb:60:in `run_initializers'
	14: from /Users/danmayer/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/tsort.rb:205:in `tsort_each'
	13: from /Users/danmayer/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/tsort.rb:226:in `tsort_each'
	12: from /Users/danmayer/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/tsort.rb:347:in `each_strongly_connected_component'
	11: from /Users/danmayer/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/tsort.rb:347:in `call'
	10: from /Users/danmayer/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/tsort.rb:347:in `each'
	 9: from /Users/danmayer/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/tsort.rb:349:in `block in each_strongly_connected_component'
	 8: from /Users/danmayer/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/tsort.rb:431:in `each_strongly_connected_component_from'
	 7: from /Users/danmayer/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	 6: from /Users/danmayer/.rvm/rubies/ruby-2.5.3/lib/ruby/2.5.0/tsort.rb:228:in `block in tsort_each'
	 5: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/railties-5.2.2/lib/rails/initializable.rb:61:in `block in run_initializers'
	 4: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/railties-5.2.2/lib/rails/initializable.rb:32:in `run'
	 3: from /Users/danmayer/.rvm/gems/ruby-2.5.3/gems/railties-5.2.2/lib/rails/initializable.rb:32:in `instance_exec'
	 2: from /Users/danmayer/projects/coverband/lib/coverband/utils/railtie.rb:21:in `block in <class:Railtie>'
	 1: from /Users/danmayer/projects/coverband/lib/coverband/utils/railtie.rb:21:in `new'
/Users/danmayer/projects/coverband/lib/coverband/collectors/view_tracker.rb:23:in `initialize': Coverband: view tracker initialized before configuration! (RuntimeError)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (7) Failed to connect to localhost port 9999: Connection refused
F

Failure:
RailsWithoutConfigStackTest#test_check_view_tracker [test/forked/rails_view_tracker_stack_test.rb:18]:
Expected nil to be truthy.


bin/rails test test/forked/rails_view_tracker_stack_test.rb:16
```