### PR TITLE
Support haml slim by default address issue #399

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,7 @@ else
 end
 
 gem "rails", "~>5"
+gem "haml"
+gem "slim"
 # these gems are used for testing gem tracking
 gem "irb", require: false

--- a/Gemfile.rails4
+++ b/Gemfile.rails4
@@ -5,3 +5,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in coverband.gemspec
 gemspec
 gem 'rails', '~>4'
+gem "haml"
+gem "slim"

--- a/Gemfile.rails6
+++ b/Gemfile.rails6
@@ -5,3 +5,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in coverband.gemspec
 gemspec
 gem 'rails', '~>6'
+gem "haml"
+gem "slim"

--- a/lib/coverband/collectors/view_tracker.rb
+++ b/lib/coverband/collectors/view_tracker.rb
@@ -10,11 +10,8 @@ module Coverband
     # This is a port of Flatfoot, a project I open sourced years ago,
     # but am now rolling into Coverband
     # https://github.com/livingsocial/flatfoot
-    #
-    # TODO: test and ensure slim, haml, and other support
     ###
     class ViewTracker
-      DEFAULT_TARGET = Dir.glob("app/views/**/*.html.erb").reject { |file| file.match(/(_mailer)/) }
       attr_accessor :target, :logged_views, :views_to_record
       attr_reader :logger, :roots, :store, :ignore_patterns
 
@@ -26,7 +23,7 @@ module Coverband
         @ignore_patterns = Coverband.configuration.ignore
         @store = options.fetch(:store) { Coverband.configuration.store }
         @logger = options.fetch(:logger) { Coverband.configuration.logger }
-        @target = options.fetch(:target) { DEFAULT_TARGET }
+        @target = options.fetch(:target) { Dir.glob("#{@project_directory}/app/views/**/*.html.{erb,haml,slim}").reject { |file| file.match(/(_mailer)/) }.freeze }
 
         @roots = options.fetch(:roots) { Coverband.configuration.all_root_patterns }
         @roots = @roots.split(",") if @roots.is_a?(String)

--- a/lib/coverband/collectors/view_tracker.rb
+++ b/lib/coverband/collectors/view_tracker.rb
@@ -20,6 +20,7 @@ module Coverband
 
       def initialize(options = {})
         raise NotImplementedError, "View Tracker requires Rails 4 or greater" unless self.class.supported_version?
+        raise "Coverband: view tracker initialized before configuration!" if !Coverband.configured? && ENV["COVERBAND_TEST"] == "test"
 
         @project_directory = File.expand_path(Coverband.configuration.root)
         @ignore_patterns = Coverband.configuration.ignore

--- a/test/forked/rails_full_stack_test.rb
+++ b/test/forked/rails_full_stack_test.rb
@@ -35,7 +35,7 @@ class RailsFullStackTest < Minitest::Test
       end
 
       # Test eager load data stored separately
-      dummy_controller = "./test/rails#{Rails::VERSION::MAJOR}_dummy/app/controllers/dummy_controller.rb"
+      dummy_controller = "./app/controllers/dummy_controller.rb"
       store.type = :eager_loading
       eager_expected = [1, 1, 0, nil, nil]
       results = store.coverage[dummy_controller]["data"]
@@ -45,15 +45,6 @@ class RailsFullStackTest < Minitest::Test
       runtime_expected = [0, 0, 1, nil, nil]
       results = store.coverage[dummy_controller]["data"]
       assert_equal(runtime_expected, results)
-    end
-
-    test "check view tracker" do
-      visit "/dummy_view/show"
-      assert page.body.match(/rendered view/)
-      assert page.body.match(/I am no dummy view tracker text/)
-      Coverband.configuration.view_tracker&.report_views_tracked
-      visit "/coverage/view_tracker"
-      assert_selector("div", text: /These views have been rendered at least once.*\/app\/views\/dummy_view\/show\.html\.erb/)
     end
   end
 

--- a/test/forked/rails_full_stack_test.rb
+++ b/test/forked/rails_full_stack_test.rb
@@ -46,6 +46,15 @@ class RailsFullStackTest < Minitest::Test
       results = store.coverage[dummy_controller]["data"]
       assert_equal(runtime_expected, results)
     end
+
+    test "check view tracker" do
+      visit "/dummy_view/show"
+      assert page.body.match(/rendered view/)
+      assert page.body.match(/I am no dummy view tracker text/)
+      Coverband.configuration.view_tracker&.report_views_tracked
+      visit "/coverage/view_tracker"
+      assert_selector("div", text: /These views have been rendered at least once.*\/app\/views\/dummy_view\/show\.html\.erb/)
+    end
   end
 
   ###

--- a/test/forked/rails_full_stack_views_test.rb
+++ b/test/forked/rails_full_stack_views_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require File.expand_path("../rails_test_helper", File.dirname(__FILE__))
+
+class RailsFullStackTest < Minitest::Test
+  include Capybara::DSL
+  include Capybara::Minitest::Assertions
+
+  def setup
+    super
+    rails_setup
+    Coverband.report_coverage
+  end
+
+  def teardown
+    super
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
+  end
+
+  test "verify erb haml slim support" do
+    visit "/dummy_view/show"
+    assert_content("I am no dummy view tracker text")
+    Coverband.report_coverage
+    Coverband.configuration.view_tracker&.report_views_tracked
+    visit "/coverage/view_tracker"
+    assert_content("Used Views: (1)")
+    assert_selector("li.used-views", text: "dummy_view/show.html.erb")
+    assert_selector("li.unused-views", text: "dummy_view/show_haml.html.haml")
+    assert_selector("li.unused-views", text: "dummy_view/show_slim.html.slim")
+
+    visit "/dummy_view/show_haml"
+    assert_content("I am haml text")
+    Coverband.report_coverage
+    Coverband.configuration.view_tracker&.report_views_tracked
+    visit "/coverage/view_tracker"
+    assert_content("Used Views: (2)")
+    assert_selector("li.used-views", text: "dummy_view/show_haml.html.haml")
+
+    visit "/dummy_view/show_slim"
+    assert_content("I am slim text")
+    Coverband.report_coverage
+    Coverband.configuration.view_tracker&.report_views_tracked
+    visit "/coverage/view_tracker"
+    assert_content("Used Views: (3)")
+    assert_selector("li.used-views", text: "dummy_view/show_slim.html.slim")
+  end
+end

--- a/test/forked/rails_view_tracker_stack_test.rb
+++ b/test/forked/rails_view_tracker_stack_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require File.expand_path("../rails_test_helper", File.dirname(__FILE__))
+
+class RailsWithoutConfigStackTest < Minitest::Test
+  def setup
+    super
+    setup_server
+  end
+
+  def teardown
+    super
+    shutdown_server
+  end
+
+  test "check view tracker" do
+    output = `sleep 7 && curl http://localhost:9999/dummy_view/show`
+    assert output.match(/rendered view/)
+    assert output.match(/I am no dummy view tracker text/)
+    output = `sleep 1 && curl http://localhost:9999/coverage/view_tracker`
+    assert output.match(/Used Views: \(1\)/)
+    assert output.match(/dummy_view\/show/)
+  end
+
+  private
+
+  # NOTE: We aren't leveraging Capybara because it loads all of our other test helpers and such,
+  # which in turn Configures coverband making it impossible to test the configuration error
+  def setup_server
+    ENV["RAILS_ENV"] = "test"
+    require "rails"
+    fork do
+      exec "cd test/rails#{Rails::VERSION::MAJOR}_dummy && COVERBAND_TEST=test bundle exec rackup config.ru -p 9999 --pid /tmp/testrack.pid"
+    end
+  end
+
+  def shutdown_server
+    if File.exist?("/tmp/testrack.pid")
+      pid = `cat /tmp/testrack.pid`&.strip&.to_i
+      Process.kill("HUP", pid)
+      sleep 1
+    end
+  end
+end

--- a/test/rails4_dummy/app/controllers/dummy_view_controller.rb
+++ b/test/rails4_dummy/app/controllers/dummy_view_controller.rb
@@ -1,0 +1,6 @@
+class DummyViewController < ActionController::Base
+  def show
+    @text = "I am no dummy view tracker text"
+    render layout: false
+  end
+end

--- a/test/rails4_dummy/app/controllers/dummy_view_controller.rb
+++ b/test/rails4_dummy/app/controllers/dummy_view_controller.rb
@@ -3,4 +3,14 @@ class DummyViewController < ActionController::Base
     @text = "I am no dummy view tracker text"
     render layout: false
   end
+
+  def show_haml
+    @text = "I am haml text"
+    render layout: false
+  end
+
+  def show_slim
+    @text = "I am slim text"
+    render layout: false
+  end
 end

--- a/test/rails4_dummy/app/views/dummy_view/show.html.erb
+++ b/test/rails4_dummy/app/views/dummy_view/show.html.erb
@@ -1,0 +1,5 @@
+rendered view
+
+<div>
+  <%= @text %>
+</div>

--- a/test/rails4_dummy/app/views/dummy_view/show_haml.html.haml
+++ b/test/rails4_dummy/app/views/dummy_view/show_haml.html.haml
@@ -1,0 +1,4 @@
+rendered haml view
+
+#foo
+  = @text

--- a/test/rails4_dummy/app/views/dummy_view/show_slim.html.slim
+++ b/test/rails4_dummy/app/views/dummy_view/show_slim.html.slim
@@ -1,0 +1,4 @@
+rendered slim view
+
+#content
+  = @text

--- a/test/rails4_dummy/config/application.rb
+++ b/test/rails4_dummy/config/application.rb
@@ -10,5 +10,6 @@ Bundler.require(*Rails.groups)
 module Rails4Dummy
   class Application < Rails::Application
     config.eager_load = true
+    config.consider_all_requests_local = true
   end
 end

--- a/test/rails4_dummy/config/routes.rb
+++ b/test/rails4_dummy/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   get "dummy/show"
   get "dummy_view/show", to: "dummy_view#show"
+  get "dummy_view/show_haml", to: "dummy_view#show_haml"
+  get "dummy_view/show_slim", to: "dummy_view#show_slim"
   mount Coverband::Reporters::Web.new, at: "/coverage"
 end

--- a/test/rails4_dummy/config/routes.rb
+++ b/test/rails4_dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   get "dummy/show"
+  get "dummy_view/show", to: "dummy_view#show"
   mount Coverband::Reporters::Web.new, at: "/coverage"
 end

--- a/test/rails5_dummy/app/controllers/dummy_view_controller.rb
+++ b/test/rails5_dummy/app/controllers/dummy_view_controller.rb
@@ -1,0 +1,6 @@
+class DummyViewController < ActionController::Base
+  def show
+    @text = "I am no dummy view tracker text"
+    render layout: false
+  end
+end

--- a/test/rails5_dummy/app/controllers/dummy_view_controller.rb
+++ b/test/rails5_dummy/app/controllers/dummy_view_controller.rb
@@ -3,4 +3,14 @@ class DummyViewController < ActionController::Base
     @text = "I am no dummy view tracker text"
     render layout: false
   end
+
+  def show_haml
+    @text = "I am haml text"
+    render layout: false
+  end
+
+  def show_slim
+    @text = "I am slim text"
+    render layout: false
+  end
 end

--- a/test/rails5_dummy/app/views/dummy_view/show.html.erb
+++ b/test/rails5_dummy/app/views/dummy_view/show.html.erb
@@ -1,0 +1,5 @@
+rendered view
+
+<div>
+  <%= @text %>
+</div>

--- a/test/rails5_dummy/app/views/dummy_view/show_haml.html.haml
+++ b/test/rails5_dummy/app/views/dummy_view/show_haml.html.haml
@@ -1,0 +1,4 @@
+rendered haml view
+
+#foo
+  = @text

--- a/test/rails5_dummy/app/views/dummy_view/show_slim.html.slim
+++ b/test/rails5_dummy/app/views/dummy_view/show_slim.html.slim
@@ -1,0 +1,4 @@
+rendered slim view
+
+#content
+  = @text

--- a/test/rails5_dummy/config/application.rb
+++ b/test/rails5_dummy/config/application.rb
@@ -2,11 +2,13 @@
 
 require "rails"
 require "action_controller/railtie"
+require "action_view/railtie"
 require "coverband"
 Bundler.require(*Rails.groups)
 
 module Rails5Dummy
   class Application < Rails::Application
     config.eager_load = true
+    config.consider_all_requests_local = true
   end
 end

--- a/test/rails5_dummy/config/coverband.rb
+++ b/test/rails5_dummy/config/coverband.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 Coverband.configure do |config|
-  config.root = Dir.pwd
+  # NOTE: we reuse this config in each of the fake rails projects
+  # the below ensures the root is set to the correct fake project
+  config.root = ::File.expand_path("../../../", __FILE__).to_s + "/rails#{Rails::VERSION::MAJOR}_dummy"
   config.store = Coverband::Adapters::RedisStore.new(Redis.new(db: 2, url: ENV["REDIS_URL"]), redis_namespace: "coverband_test") if defined? Redis
   config.ignore = %w[.erb$ .slim$]
   config.root_paths = []

--- a/test/rails5_dummy/config/routes.rb
+++ b/test/rails5_dummy/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   get "dummy/show"
   get "dummy_view/show", to: "dummy_view#show"
+  get "dummy_view/show_haml", to: "dummy_view#show_haml"
+  get "dummy_view/show_slim", to: "dummy_view#show_slim"
   mount Coverband::Reporters::Web.new, at: "/coverage"
 end

--- a/test/rails5_dummy/config/routes.rb
+++ b/test/rails5_dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   get "dummy/show"
+  get "dummy_view/show", to: "dummy_view#show"
   mount Coverband::Reporters::Web.new, at: "/coverage"
 end

--- a/test/rails6_dummy/app/controllers/dummy_view_controller.rb
+++ b/test/rails6_dummy/app/controllers/dummy_view_controller.rb
@@ -1,0 +1,6 @@
+class DummyViewController < ActionController::Base
+  def show
+    @text = "I am no dummy view tracker text"
+    render layout: false
+  end
+end

--- a/test/rails6_dummy/app/controllers/dummy_view_controller.rb
+++ b/test/rails6_dummy/app/controllers/dummy_view_controller.rb
@@ -3,4 +3,14 @@ class DummyViewController < ActionController::Base
     @text = "I am no dummy view tracker text"
     render layout: false
   end
+
+  def show_haml
+    @text = "I am haml text"
+    render layout: false
+  end
+
+  def show_slim
+    @text = "I am slim text"
+    render layout: false
+  end
 end

--- a/test/rails6_dummy/app/views/dummy_view/show.html.erb
+++ b/test/rails6_dummy/app/views/dummy_view/show.html.erb
@@ -1,0 +1,5 @@
+rendered view
+
+<div>
+  <%= @text %>
+</div>

--- a/test/rails6_dummy/app/views/dummy_view/show_haml.html.haml
+++ b/test/rails6_dummy/app/views/dummy_view/show_haml.html.haml
@@ -1,0 +1,4 @@
+rendered haml view
+
+#foo
+  = @text

--- a/test/rails6_dummy/app/views/dummy_view/show_slim.html.slim
+++ b/test/rails6_dummy/app/views/dummy_view/show_slim.html.slim
@@ -1,0 +1,4 @@
+rendered slim view
+
+#content
+  = @text

--- a/test/rails6_dummy/config/application.rb
+++ b/test/rails6_dummy/config/application.rb
@@ -10,5 +10,6 @@ Bundler.require(*Rails.groups)
 module Rails6Dummy
   class Application < Rails::Application
     config.eager_load = true
+    config.consider_all_requests_local = true
   end
 end

--- a/test/rails6_dummy/config/routes.rb
+++ b/test/rails6_dummy/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   get "dummy/show"
   get "dummy_view/show", to: "dummy_view#show"
+  get "dummy_view/show_haml", to: "dummy_view#show_haml"
+  get "dummy_view/show_slim", to: "dummy_view#show_slim"
   mount Coverband::Reporters::Web.new, at: "/coverage"
 end

--- a/test/rails6_dummy/config/routes.rb
+++ b/test/rails6_dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   get "dummy/show"
+  get "dummy_view/show", to: "dummy_view#show"
   mount Coverband::Reporters::Web.new, at: "/coverage"
 end

--- a/views/view_tracker.erb
+++ b/views/view_tracker.erb
@@ -26,7 +26,7 @@
         <p>These views have not been rendered since recording started at <%= tracker.tracking_since %></p>
         <ul>
         <% tracker.unused_views.each do |view_file| %>
-          <li><%= view_file %></li>
+          <li class="unused-views"><%= view_file %></li>
         <% end %>
         </ul>
 
@@ -34,7 +34,7 @@
         <p>These views have been rendered at least once</p>
         <ul>
         <% tracker.used_views.each_pair do |view_file, time_at| %>
-          <li>
+          <li class="used-views">
             <%= view_file %>
             <span class="last_seen_at">last activity recorded <%= Time.at(time_at.to_i)%></span>
             <% if Coverband.configuration.web_enable_clear %>


### PR DESCRIPTION
Ok, yeah basically I have one off set this up in a couple apps but not supported it out of the box until now...

If you setup your own view tracker you can pass in your own 'target' set of files: https://github.com/danmayer/coverband/blob/master/lib/coverband/collectors/view_tracker.rb#L28

Which allows you to go beyond the default ERB, that being said HAML and Slim are really common, so it would be good to support them out of the box.

This builds on another PR which made it easier to test the view tracker... most of this code is testing the real diff is basically

```
- Dir.glob("app/views/**/*.html.erb").reject { |file| file.match(/(_mailer)/) }
+ Dir.glob("#{@project_directory}/app/views/**/*.html.{erb,haml,slim}").reject { |file| file.match(/(_mailer)/) }
```

take a look @jagthedrummer @markshawtoronto @ChristopherHelgeson