### PR TITLE
Fix for "Unused Views" tracking.

### DIFF
--- a/lib/coverband/collectors/view_tracker.rb
+++ b/lib/coverband/collectors/view_tracker.rb
@@ -63,18 +63,29 @@ module Coverband
         normalized_views = {}
         views.each_pair do |view, time|
           roots.each do |root|
-            view = view.gsub(/#{root}/, "")
+            view = view.gsub(root, "")
           end
           normalized_views[view] = time
         end
         normalized_views
       end
 
+      def all_views
+        all_views = []
+        target.each do |view|
+          roots.each do |root|
+            view = view.gsub(root, "")
+          end
+          all_views << view
+        end
+        all_views.uniq
+      end
+
       def unused_views
         recently_used_views = used_views.keys
-        all_views = target.reject { |view| recently_used_views.include?(view) }
+        unused_views = all_views.reject { |view| recently_used_views.include?(view) }
         # since layouts don't include format we count them used if they match with ANY formats
-        all_views.reject { |view| view.match(/\/layouts\//) && recently_used_views.any? { |used_view| view.include?(used_view) } }
+        unused_views.reject { |view| view.match(/\/layouts\//) && recently_used_views.any? { |used_view| view.include?(used_view) } }
       end
 
       def as_json

--- a/test/forked/rails_full_stack_views_test.rb
+++ b/test/forked/rails_full_stack_views_test.rb
@@ -25,6 +25,7 @@ class RailsFullStackTest < Minitest::Test
     Coverband.configuration.view_tracker&.report_views_tracked
     visit "/coverage/view_tracker"
     assert_content("Used Views: (1)")
+    assert_content("Unused Views: (2)")
     assert_selector("li.used-views", text: "dummy_view/show.html.erb")
     assert_selector("li.unused-views", text: "dummy_view/show_haml.html.haml")
     assert_selector("li.unused-views", text: "dummy_view/show_slim.html.slim")
@@ -35,6 +36,7 @@ class RailsFullStackTest < Minitest::Test
     Coverband.configuration.view_tracker&.report_views_tracked
     visit "/coverage/view_tracker"
     assert_content("Used Views: (2)")
+    assert_content("Unused Views: (1)")
     assert_selector("li.used-views", text: "dummy_view/show_haml.html.haml")
 
     visit "/dummy_view/show_slim"
@@ -43,6 +45,7 @@ class RailsFullStackTest < Minitest::Test
     Coverband.configuration.view_tracker&.report_views_tracked
     visit "/coverage/view_tracker"
     assert_content("Used Views: (3)")
+    assert_content("Unused Views: (0)")
     assert_selector("li.used-views", text: "dummy_view/show_slim.html.slim")
   end
 end


### PR DESCRIPTION
I noticed that the "Unused Views" aren't removing entries that are used when I use it, because they don't go through the same root parsing.

Steps to reproduce:
I made `rails_full_stack_views_test.rb` fail by checking for `Unused Views` count going down when `Used Views` goes up.

❤️ for coverband!