### PR TITLE
Add support for ruby-3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         # remove until I sort out CI issues for truffle
         # truffleruby,
         # truffleruby-head,
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, jruby, jruby-head]
+        ruby: [2.4, 2.5, 2.6, 2.7, 3.0, jruby, jruby-head]
         redis-version: [5]
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/test/unique_files.rb
+++ b/test/unique_files.rb
@@ -20,10 +20,10 @@ def require_unique_file(file = "dog.rb", variables = {})
   Coverband::Utils::RelativeFileConverter.convert(File.expand_path(temp_file))
 end
 
-@@dogs = 0
 def require_class_unique_file
-  @@dogs += 1
-  require_unique_file("dog.rb.erb", dog_number: @@dogs)
+  @dogs ||= 0
+  @dogs += 1
+  require_unique_file("dog.rb.erb", dog_number: @dogs)
 end
 
 def remove_unique_files


### PR DESCRIPTION
Had to pin to master of redis-namespace to get this change:

https://github.com/resque/redis-namespace/commit/c31e63dc3cd5e59ef5ea394d4d46ac60d1e6f82e

Probably should wait until we get a version bump on that dependency before merging this in.