### PR TITLE
Require Ruby 2.3 or later

### DIFF
--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = %w[lib]
+  
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_development_dependency "benchmark-ips"
   spec.add_development_dependency "capybara"


### PR DESCRIPTION
The gem is incompatible with Ruby 2.2 because it uses the safe-navigation operator that was introduced in Ruby 2.3. Support for Ruby 2.2 and older was dropped in v3.0.