### PR TITLE
Test against Redis 4 and Redis 6 in addition to 5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         # truffleruby,
         # truffleruby-head,
         ruby: [2.4, 2.5, 2.6, 2.7, 3.0, jruby, jruby-head]
-        redis-version: [5]
+        redis-version: [4, 5, 6]
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The `redis` gem should allow us to support all of them.