### PR TITLE
Add ruby 2.3 back

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         # remove until I sort out CI issues for truffle
         # truffleruby,
         # truffleruby-head,
-        ruby: [2.4, 2.5, 2.6, 2.7, 3.0, jruby, jruby-head]
+        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0, jruby, jruby-head]
         redis-version: [5]
     runs-on: ${{ matrix.os }}-latest
     steps:


### PR DESCRIPTION
I'm not sure why I removed ruby 2.3 from the build. Seems to work fine.