### PR TITLE
Improve ViewTracker performance

### DIFF
--- a/lib/coverband/collectors/view_tracker.rb
+++ b/lib/coverband/collectors/view_tracker.rb
@@ -90,16 +90,17 @@ module Coverband
         all_views.uniq
       end
 
-      def unused_views
-        recently_used_views = used_views.keys
-        unused_views = all_views.reject { |view| recently_used_views.include?(view) }
+      def unused_views(used_views = nil)
+        recently_used_views = (used_views || self.used_views).keys
+        unused_views = all_views - recently_used_views
         # since layouts don't include format we count them used if they match with ANY formats
         unused_views.reject { |view| view.match(/\/layouts\//) && recently_used_views.any? { |used_view| view.include?(used_view) } }
       end
 
       def as_json
+        used_views = self.used_views
         {
-          unused_views: unused_views,
+          unused_views: unused_views(used_views),
           used_views: used_views
         }.to_json
       end

--- a/lib/coverband/collectors/view_tracker_service.rb
+++ b/lib/coverband/collectors/view_tracker_service.rb
@@ -8,8 +8,8 @@ module Coverband
     class ViewTrackerService < ViewTracker
       def report_views_tracked
         reported_time = Time.now.to_i
-        if views_to_record.any?
-          relative_views = views_to_record.map! do |view|
+        if @views_to_record.any?
+          relative_views = @views_to_record.map! do |view|
             roots.each do |root|
               view = view.gsub(/#{root}/, "")
             end
@@ -17,7 +17,7 @@ module Coverband
           end
           save_tracked_views(views: relative_views, reported_time: reported_time)
         end
-        self.views_to_record = []
+        @views_to_record = []
       rescue => e
         # we don't want to raise errors if Coverband can't reach the service
         logger&.error "Coverband: view_tracker failed to store, error #{e.class.name}" if Coverband.configuration.verbose || Coverband.configuration.service_dev_mode


### PR DESCRIPTION
Improve performance of `ViewTracker` by using sets to back its implementation.

Although they may be slightly slower to add keys, they are quicker to check the existence of keys (in `newly_seen_file?`), which should make it faster overall (since keys are added once and checked every time a view is rendered).

This change only affects the inner implementation of the `ViewTracker`. The exposed interface still returns an `Array`.