### PR TITLE
Improve View tracker to track render collection too

### DIFF
--- a/lib/coverband/utils/railtie.rb
+++ b/lib/coverband/utils/railtie.rb
@@ -37,7 +37,7 @@ module Coverband
 
           Coverband.configuration.view_tracker = COVERBAND_VIEW_TRACKER
 
-          ActiveSupport::Notifications.subscribe(/render_partial.action_view|render_template.action_view/) do |name, start, finish, id, payload|
+          ActiveSupport::Notifications.subscribe(/render_(template|partial|collection).action_view/) do |name, start, finish, id, payload|
             COVERBAND_VIEW_TRACKER.track_views(name, start, finish, id, payload) unless name.include?("!")
           end
         end


### PR DESCRIPTION
Coverband should track render template, partial and collection, each of these would push message `render_template.action_view`, `render_partial.action_view`, `render_collection.action_view`