### PR TITLE
Fix disabling views tracking

### DIFF
--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -147,7 +147,9 @@ module Coverband
     end
 
     def track_views
-      @track_views ||= service_disabled_dev_test_env? ? false : true
+      return false if service_disabled_dev_test_env?
+
+      @track_views
     end
 
     ###


### PR DESCRIPTION
If I set `config.track_views = false` in configuration, `track_views` method still returns `true`. 

The issue was introduced with this commit: https://github.com/danmayer/coverband/commit/0d82c5cc12449fbfa9f5577b7cea31243a9e3460
