### PR TITLE
Deferred loading data

### DIFF
--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -8,7 +8,7 @@ module Coverband
       :background_reporting_enabled,
       :test_env, :web_enable_clear, :gem_details, :web_debug, :report_on_exit,
       :simulate_oneshot_lines_coverage,
-      :view_tracker
+      :view_tracker, :defer_eager_loading_data
     attr_writer :logger, :s3_region, :s3_bucket, :s3_access_key_id,
       :s3_secret_access_key, :password, :api_key, :service_url, :coverband_timeout, :service_dev_mode,
       :service_test_mode, :process_type, :track_views, :redis_url,
@@ -62,6 +62,7 @@ module Coverband
       @store = nil
       @background_reporting_enabled = true
       @background_reporting_sleep_seconds = nil
+      @defer_eager_loading_data = false
       @test_env = nil
       @web_enable_clear = false
       @track_views = true
@@ -241,6 +242,10 @@ module Coverband
 
     def service?
       Coverband.coverband_service? || !api_key.nil?
+    end
+
+    def defer_eager_loading_data?
+      @defer_eager_loading_data
     end
 
     def service_disabled_dev_test_env?

--- a/test/integration/full_stack_deferred_eager_test.rb
+++ b/test/integration/full_stack_deferred_eager_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require File.expand_path("../test_helper", File.dirname(__FILE__))
+require "rack"
+
+class FullStackDeferredEagerTest < Minitest::Test
+  REDIS_STORAGE_FORMAT_VERSION = Coverband::Adapters::RedisStore::REDIS_STORAGE_FORMAT_VERSION
+  TEST_RACK_APP = "../fake_app/basic_rack.rb"
+
+  def setup
+    super
+    Coverband::Collectors::Coverage.instance.reset_instance
+    Coverband.configure do |config|
+      config.background_reporting_enabled = false
+      config.track_gems = true
+      config.defer_eager_loading_data = true
+    end
+    Coverband.start
+    Coverband::Collectors::Coverage.instance.eager_loading!
+    @rack_file = require_unique_file "fake_app/basic_rack.rb"
+    Coverband.report_coverage
+    Coverband::Collectors::Coverage.instance.runtime!
+  end
+
+  test "call app" do
+    # eager loaded class coverage starts empty
+    Coverband.eager_loading_coverage!
+    expected = {}
+    assert_equal expected, Coverband.configuration.store.coverage
+
+    Coverband::Collectors::Coverage.instance.runtime!
+    request = Rack::MockRequest.env_for("/anything.json")
+    middleware = Coverband::BackgroundMiddleware.new(fake_app_with_lines)
+    results = middleware.call(request)
+    assert_equal "Hello Rack!", results.last
+    Coverband.report_coverage
+    expected = [nil, nil, 0, nil, 0, 0, 1, nil, nil]
+    assert_equal expected, Coverband.configuration.store.coverage[@rack_file]["data"]
+
+    # eager loaded class coverage is saved at first normal coverage report
+    Coverband.eager_loading_coverage!
+    expected = [nil, nil, 1, nil, 1, 1, 0, nil, nil]
+    assert_equal expected, Coverband.configuration.store.coverage[@rack_file]["data"]
+  end
+
+  private
+
+  def fake_app_with_lines
+    @fake_app_with_lines ||= ::HelloWorld.new
+  end
+end


### PR DESCRIPTION
Support deferred eager loading of data and also do not immediately spike redis with all servers connecting.

This should support the most recent issue #428 