### PR TITLE
Refactor filling zero coverage for not loaded files

### DIFF
--- a/lib/coverband/utils/result.rb
+++ b/lib/coverband/utils/result.rb
@@ -55,7 +55,7 @@ module Coverband
           Dir[tracked_files].each do |file|
             absolute = File.expand_path(file)
             result[absolute] ||= {
-              "data" => Array.new(File.foreach(absolute).count) { 0 },
+              "data" => [],
               "never_loaded" => true
             }
           end

--- a/lib/coverband/utils/source_file.rb
+++ b/lib/coverband/utils/source_file.rb
@@ -139,7 +139,7 @@ module Coverband
         coverage_exceeding_source_warn if coverage.size > src.size
 
         lines = src.map.with_index(1) { |src, i|
-          Coverband::Utils::SourceFile::Line.new(src, i, coverage[i - 1])
+          Coverband::Utils::SourceFile::Line.new(src, i, never_loaded ? 0 : coverage[i - 1])
         }
 
         process_skipped_lines(lines)


### PR DESCRIPTION
`Coverband::Utils::Result.add_not_loaded_files` method counts number of lines of not loaded files and fill zero as coverage.
However, `File.foreach(absolute).count` would be same result of `Coverband::Utils::SourceFile#src`'s number of lines.
`File.foreach` or `File.read` are heavy processes. This results too slow response when app has some not loaded files.

This PR fix that duplicated processes. 