### PR TITLE
Fix CI setting for Ruby 3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         # remove until I sort out CI issues for truffle
         # truffleruby,
         # truffleruby-head,
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0, jruby, jruby-head]
+        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, "3.0", jruby, jruby-head]
         redis-version: [4, 5, 6]
     runs-on: ${{ matrix.os }}-latest
     steps:


### PR DESCRIPTION
 Due to https://github.com/actions/runner/issues/849, we have to use quotes for 3.0.
Currently CI runs against latest 3 series, 3.1.