### PR TITLE
Fix deprecated uses of `Redis#pipelined`

### DIFF
--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -55,5 +55,5 @@ Gem::Specification.new do |spec|
   # redis now. I was reluctant to add this, but until we offer another production
   # quality adapter, I think this is more honest about requirements and reduces confusion
   # without this there was a race condition on calling coverband configure before redis was loaded
-  spec.add_runtime_dependency "redis"
+  spec.add_runtime_dependency "redis", ">= 3.0"
 end

--- a/lib/coverband/adapters/hash_redis_store.rb
+++ b/lib/coverband/adapters/hash_redis_store.rb
@@ -88,9 +88,9 @@ module Coverband
 
       def coverage(local_type = nil)
         files_set = files_set(local_type)
-        @redis.pipelined {
-          files_set.map do |key|
-            @redis.hgetall(key)
+        @redis.pipelined { |pipeline|
+          files_set.each do |key|
+            pipeline.hgetall(key)
           end
         }.each_with_object({}) do |data_from_redis, hash|
           add_coverage_for_file(data_from_redis, hash)


### PR DESCRIPTION
Context: https://github.com/redis/redis-rb/pull/1059

The following is deprecated
```ruby
redis.pipelined do
  redis.get(key)
end
```

And should be rewritten as:
```ruby
redis.pipelined do |pipeline|
  pipeline.get(key)
end
```

Functionally it makes no difference.
This API is available since Redis 3.0.