### PR TITLE
Add a known issue for the Elastic APM ruby agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,9 @@ If you submit a change please make sure the tests and benchmarks are passing.
 - **Coverage does NOT work when used alongside Scout APM Auto Instrumentation**
   - In an environment that uses Scout's `AUTO_INSTRUMENT=true` (usually production or staging) it stops reporting any coverage, it will show one or two files that have been loaded at the start but everything else will show up as having 0% coverage
   - Bug tracked here: https://github.com/scoutapp/scout_apm_ruby/issues/343
+- **Coverband, [Elastic APM](https://github.com/elastic/apm-agent-ruby) and resque**
+  - In an environment that uses the Elastic APM ruby agent, resque jobs will fail with `Transactions may not be nested. Already inside #<ElasticAPM::Transaction>` if the `elastic-apm` gem is loaded _before_ the `coverband` gem
+  - Put `coverage` ahead of `elastic-apm` in your Gemfile
 
 ### Debugging Redis Store
 


### PR DESCRIPTION
I've just started using Coverband on a project which also uses [Elastic APM](https://github.com/elastic/apm-agent-ruby) and resque, and my jobs were failing. Presumably being caused by a similar problem as the Scout APM issue, and I got a hint from the readme section about Working with environment variables.

Loading coverage before elastic-apm appears to fix the issue.

Thanks for coverband, it's awesome ❤️