### PR TITLE
Fix specs for Ruby 3.1 by skipping Simplecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         # remove until I sort out CI issues for truffle
         # truffleruby,
         # truffleruby-head,
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, "3.0", jruby, jruby-head]
+        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, "3.0", "3.1", jruby, jruby-head]
         redis-version: [4, 5, 6]
     runs-on: ${{ matrix.os }}-latest
     steps:

--- a/lib/coverband/adapters/hash_redis_store.rb
+++ b/lib/coverband/adapters/hash_redis_store.rb
@@ -119,7 +119,7 @@ module Coverband
 
         data = coverage_data_from_redis(data_from_redis)
         hash[file] = data_from_redis.select { |meta_data_key, _value| META_DATA_KEYS.include?(meta_data_key) }.merge!("data" => data)
-        hash[file][LAST_UPDATED_KEY] = hash[file][LAST_UPDATED_KEY].blank? ? nil : hash[file][LAST_UPDATED_KEY].to_i
+        hash[file][LAST_UPDATED_KEY] = (hash[file][LAST_UPDATED_KEY].nil? || hash[file][LAST_UPDATED_KEY] == '') ? nil : hash[file][LAST_UPDATED_KEY].to_i
         hash[file].merge!(LAST_UPDATED_KEY => hash[file][LAST_UPDATED_KEY], FIRST_UPDATED_KEY => hash[file][FIRST_UPDATED_KEY].to_i)
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,11 +1,22 @@
 # frozen_string_literal: true
 
+require 'bigdecimal'
+
 original_verbosity = $VERBOSE
 $VERBOSE = nil
+
+if ENV['SKIP_SIMPLECOV'] || BigDecimal(RUBY_VERSION[0, 3]) >= BigDecimal('3.1')
+  $SKIP_SIMPLECOV = true
+end
+
 require "rubygems"
 require "pry-byebug" unless ENV["CI"]
-require "simplecov"
-require "coveralls"
+
+unless $SKIP_SIMPLECOV
+  require "simplecov"
+  require "coveralls"
+end
+
 require "minitest/autorun"
 require "minitest/stub_const"
 require "mocha/minitest"
@@ -29,7 +40,7 @@ require "webmock/minitest"
 require_relative "unique_files"
 $VERBOSE = original_verbosity
 
-unless ENV["ONESHOT"] || ENV["SIMULATE_ONESHOT"]
+unless ENV["ONESHOT"] || ENV["SIMULATE_ONESHOT"] || $SKIP_SIMPLECOV
   SimpleCov.formatter = Coveralls::SimpleCov::Formatter
   SimpleCov.start do
     add_filter "test/forked"


### PR DESCRIPTION
Ruby 3.1 has made some [breaking changes](https://bugs.ruby-lang.org/issues/18176) to Coverage API, which causes Simplecov to not work well with Coverband together.

This PR:

- skips Simplecov for any Ruby >= 3.1 as a temporary fix.
- patches `HashRedisStore` for using ActiveSupport's `blank?` method, which somehow does not get loaded in Ruby 3.1. This is not a proper solution but I do think it would be nice to not use any ActiveSupport/Rails APIs unless necessary.
- Add ruby 3.1 to CI test matrix.
