### PR TITLE
improve how we handled setting ignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ config.ignore +=  ['config/application.rb',
                    'config/boot.rb',
                    'config/puma.rb',
                    'config/schedule.rb',
-                   'bin/*',
-                   'config/environments/*',
-                   'lib/tasks/*']
+                   'bin/.*',
+                   'config/environments/.*',
+                   'lib/tasks/.*']
 ```
 
 **Ignoring Custom Gem Locations:** Note, if you have your gems in a custom location under your app folder you likely want to add them to `config.ignore`. For example, if you have your gems not in a default ignored location of `app/vendor` but have them in `app/gems` you would need to add `gems/*` to your ignore list.

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -177,7 +177,10 @@ module Coverband
     # Don't allow the ignore to override things like gem tracking
     ###
     def ignore=(ignored_array)
+      ignored_array.map { |ignore_str| Regexp.new(ignore_str) }
       @ignore = (@ignore + ignored_array).uniq
+    rescue RegexpError
+      logger.error "an invalid regular expression was passed in, ensure string are valid regex patterns #{ignored_array.join(",")}"
     end
 
     def current_root

--- a/test/coverband/configuration_test.rb
+++ b/test/coverband/configuration_test.rb
@@ -38,6 +38,16 @@ class BaseTest < Minitest::Test
     assert_equal expected, Coverband.configuration.ignore
   end
 
+  test "ignore catches regex errors" do
+    Coverband.configuration.logger.expects(:error).with("an invalid regular expression was passed in, ensure string are valid regex patterns *invalidRegex*")
+    Coverband.configure do |config|
+      config.ignore = ["*invalidRegex*"]
+    end
+    Coverband::Collectors::Coverage.instance.reset_instance
+    expected = Coverband::Configuration::IGNORE_DEFAULTS << "config/environments"
+    assert_equal expected, Coverband.configuration.ignore
+  end
+
   test "ignore" do
     Coverband::Collectors::Coverage.instance.reset_instance
     assert !Coverband.configuration.ignore.first.nil?


### PR DESCRIPTION
This is a fix for issue #464 it will log an error and ignore when an invalid regex is entered.