### PR TITLE
Add a JSON Reporter

### DIFF
--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -137,6 +137,7 @@ module Coverband
         require "coverband/utils/lines_classifier"
         require "coverband/utils/results"
         require "coverband/reporters/html_report"
+        require "coverband/reporters/json_report"
         init_web
       end
     end

--- a/lib/coverband/reporters/json_report.rb
+++ b/lib/coverband/reporters/json_report.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Outputs data in json format similar to what is shown in the HTML page
+# Top level and file level coverage numbers
+module Coverband
+  module Reporters
+    class JSONReport < Base
+      attr_accessor :filtered_report_files
+
+      def initialize(store, options = {})
+        coverband_reports = Coverband::Reporters::Base.report(store, options)
+        self.filtered_report_files = self.class.fix_reports(coverband_reports)
+      end
+
+      def report
+        report_as_json
+      end
+
+      private
+
+      def report_as_json
+        result = Coverband::Utils::Results.new(filtered_report_files)
+        source_files = result.source_files
+        {
+          **coverage_totals(source_files),
+          files: coverage_files(result, source_files)
+        }.to_json
+      end
+
+      def coverage_totals(source_files)
+        {
+          total_files: source_files.length,
+          lines_of_code: source_files.lines_of_code,
+          lines_covered: source_files.covered_lines,
+          lines_missed: source_files.missed_lines,
+          covered_strength: source_files.covered_strength,
+          covered_percent: source_files.covered_percent
+        }
+      end
+
+      # Using a hash indexed by file name for quick lookups
+      def coverage_files(result, source_files)
+        source_files.each_with_object({}) do |source_file, hash|
+          hash[source_file.short_name] = {
+            never_loaded: source_file.never_loaded,
+            runtime_percentage: result.runtime_relevant_coverage(source_file),
+            lines_of_code: source_file.lines.count,
+            lines_covered: source_file.covered_lines.count,
+            lines_missed: source_file.missed_lines.count,
+            covered_percent: source_file.covered_percent,
+            covered_strength: source_file.covered_strength
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/coverband/reporters/web.rb
+++ b/lib/coverband/reporters/web.rb
@@ -90,6 +90,8 @@ module Coverband
               [200, coverband_headers(content_type: "text/json"), [debug_data]]
             when %r{\/load_file_details}
               [200, coverband_headers(content_type: "text/json"), [load_file_details]]
+            when %r{\/json}
+              [200, coverband_headers(content_type: "text/json"), [json]]
             when %r{\/$}
               [200, coverband_headers, [index]]
             else
@@ -107,6 +109,10 @@ module Coverband
           base_path: base_path,
           notice: notice,
           open_report: false).report
+      end
+
+      def json
+        Coverband::Reporters::JSONReport.new(Coverband.configuration.store).report
       end
 
       def settings

--- a/test/coverband/reporters/json_test.rb
+++ b/test/coverband/reporters/json_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../test_helper", File.dirname(__FILE__))
+
+class ReportJSONTest < Minitest::Test
+  def setup
+    super
+    @store = Coverband.configuration.store
+    Coverband.configure do |config|
+      config.store = @store
+      config.root = fixtures_root
+      config.ignore = ["notsomething.rb", "lib/*"]
+    end
+    mock_file_hash
+  end
+
+  test "includes totals" do
+    @store.send(:save_report, basic_coverage)
+
+    json = Coverband::Reporters::JSONReport.new(@store).report
+    parsed = JSON.parse(json)
+    expected_keys = ["total_files", "lines_of_code", "lines_covered", "lines_missed", "covered_strength", "covered_percent"] 
+    assert expected_keys - parsed.keys == []
+  end
+
+  test "honors ignore list" do
+    @store.send(:save_report, basic_coverage)
+
+    json = Coverband::Reporters::JSONReport.new(@store).report
+    parsed = JSON.parse(json)
+    expected_files = ["app/controllers/sample_controller.rb", "app/models/user.rb"]
+    assert_equal parsed["files"].keys, expected_files
+  end
+
+  test "includes metrics for files" do
+    @store.send(:save_report, basic_coverage)
+
+    json = Coverband::Reporters::JSONReport.new(@store).report
+    parsed = JSON.parse(json)
+
+    expected_keys = ["never_loaded", "runtime_percentage", "lines_of_code", "lines_covered", "lines_missed", "covered_percent", "covered_strength"]
+
+    assert_equal parsed["files"].length, 2
+    parsed["files"].keys.each do |file|
+      assert_equal parsed["files"][file].keys, expected_keys
+    end
+  end
+end

--- a/test/coverband/reporters/json_test.rb
+++ b/test/coverband/reporters/json_test.rb
@@ -19,7 +19,7 @@ class ReportJSONTest < Minitest::Test
 
     json = Coverband::Reporters::JSONReport.new(@store).report
     parsed = JSON.parse(json)
-    expected_keys = ["total_files", "lines_of_code", "lines_covered", "lines_missed", "covered_strength", "covered_percent"] 
+    expected_keys = ["total_files", "lines_of_code", "lines_covered", "lines_missed", "covered_strength", "covered_percent"]
     assert expected_keys - parsed.keys == []
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -95,8 +95,8 @@ def test(name, &block)
   test_name = "test_#{name.gsub(/\s+/, "_")}".to_sym
   defined = begin
     instance_method(test_name)
-  rescue
-    false
+            rescue
+              false
   end
   raise "#{test_name} is already defined in #{self}" if defined
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,6 +33,7 @@ require "coverband/utils/source_file"
 require "coverband/utils/lines_classifier"
 require "coverband/utils/results"
 require "coverband/reporters/html_report"
+require "coverband/reporters/json_report"
 require "webmock/minitest"
 
 require_relative "unique_files"
@@ -93,13 +94,13 @@ Mocha::Configuration.prevent(:stubbing_non_existent_method)
 def test(name, &block)
   test_name = "test_#{name.gsub(/\s+/, "_")}".to_sym
   defined = begin
-              instance_method(test_name)
-            rescue
-              false
-            end
+    instance_method(test_name)
+  rescue
+    false
+  end
   raise "#{test_name} is already defined in #{self}" if defined
 
-  if block_given?
+  if block
     define_method(test_name, &block)
   else
     define_method(test_name) do


### PR DESCRIPTION
I'm proposing adding a JSON route and reporter. This can be used by systems to pull a structured view of the data and then can be easily processed. 

I based this off of what was in the html file view. 

In my use case I'd like to be able to hit this end point periodically and then store the results to process locally and give feedback during dev about usage of a file that's in production, but having this structured set available for systems to use could be valuable for other use cases as well. 

Example output (truncated): 
```
{
  "total_files": 17,
  "lines_of_code": 242,
  "lines_covered": 38,
  "lines_missed": 204,
  "covered_strength": 1.4223140495867765,
  "covered_percent": 15.702479338842975,
  "files": {
    "app/controllers/application_controller.rb": {
      "file_name": "app/controllers/application_controller.rb",
      "never_loaded": false,
      "runtime_percentage": 33.33,
      "lines_of_code": 11,
      "lines_covered": 2,
      "lines_missed": 1,
      "covered_percent": 66.66666666666667,
      "covered_strength": 3.0
    },
    "app/controllers/home_controller.rb": {
      "file_name": "app/controllers/home_controller.rb",
      "never_loaded": false,
      "runtime_percentage": 28.57,
      "lines_of_code": 35,
      "lines_covered": 10,
      "lines_missed": 10,
      "covered_percent": 50.0,
      "covered_strength": 1.6
    }
    .....
  }
}

