### PR TITLE
Fix service_test_mode configuration

### DIFF
--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -272,7 +272,7 @@ module Coverband
     end
 
     def service_test_mode
-      @service_dev_mode ||= ENV["COVERBAND_ENABLE_TEST_MODE"] || false
+      @service_test_mode ||= ENV["COVERBAND_ENABLE_TEST_MODE"] || false
     end
 
     def process_type


### PR DESCRIPTION
~`service_disabled_dev_test_env?` should return true if there is no service.~

~We've noticed an influx of Coverband errors in our test suite since this was added. - `ERROR -- : Coverband: view_tracker~ ~failed to store, error NoMethodError`~

~I believe this check should return true. If there is no service, it can be considered disabled. Is my thinking correct on this?~


Fixes `@service_test_mode` configuration