### PR TITLE
Fix minitest deprecation warning (`assert_nil`)

### DIFF
--- a/test/coverband/collectors/route_tracker_test.rb
+++ b/test/coverband/collectors/route_tracker_test.rb
@@ -20,7 +20,7 @@ class RouterTrackerTest < Minitest::Test
   test "init correctly" do
     Coverband::Collectors::RouteTracker.expects(:supported_version?).returns(true)
     tracker = Coverband::Collectors::RouteTracker.new(store: fake_store, roots: "dir")
-    assert_equal nil, tracker.target.first
+    assert_nil tracker.target.first
     assert !tracker.store.nil?
     assert_equal [], tracker.target
     assert_equal [], tracker.logged_keys

--- a/test/coverband/collectors/translation_tracker_test.rb
+++ b/test/coverband/collectors/translation_tracker_test.rb
@@ -25,7 +25,7 @@ class TranslationTrackerTest < Minitest::Test
   test "init correctly" do
     Coverband::Collectors::TranslationTracker.expects(:supported_version?).returns(true)
     tracker = Coverband::Collectors::TranslationTracker.new(store: fake_store, roots: "dir")
-    assert_equal nil, tracker.target.first
+    assert_nil tracker.target.first
     assert !tracker.store.nil?
     assert_equal [], tracker.target
     assert_equal [], tracker.logged_keys


### PR DESCRIPTION
Hi there,

It seems that Minitest 6 will no longer support this idiom: `assert_equal nil, obj`:

> DEPRECATED: Use assert_nil if expecting nil from /Users/etagwerker/Projects/fastruby/coverband/test/coverband/collectors/route_tracker_test.rb:23. This will fail in Minitest 6.

So this PR fixes that problem and makes it easier to upgrade to Minitest 6.

Thank you!
