### PR TITLE
Enable or disable Coverband through option in Configuration

### DIFF
--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -103,7 +103,7 @@ module Coverband
     Coverband::Collectors::Coverage.instance
   end
 
-  unless ENV["COVERBAND_DISABLE_AUTO_START"]
+  if Coverband.configuration.enabled
     begin
       # Coverband should be setup as early as possible
       # to capture usage of things loaded by initializers or other Rails engines

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -11,7 +11,7 @@ module Coverband
       :view_tracker, :defer_eager_loading_data,
       :track_routes, :route_tracker,
       :track_translations, :translations_tracker,
-      :trackers, :csp_policy
+      :trackers, :csp_policy, :enabled
 
     attr_writer :logger, :s3_region, :s3_bucket, :s3_access_key_id,
       :s3_secret_access_key, :password, :api_key, :service_url, :coverband_timeout, :service_dev_mode,
@@ -56,6 +56,7 @@ module Coverband
     end
 
     def reset
+      @enabled = ENV["COVERBAND_DISABLE_AUTO_START"] ? false : true
       @root = Dir.pwd
       @root_paths = []
       @ignore = IGNORE_DEFAULTS.dup


### PR DESCRIPTION
Hello folks, and thank you for such a great piece of software.

In our project, we don't use ENV variables for configuration. But we want to enable Coverband only for the production environment and disable it for development and test environments. 

As I understand, in the Rails world, it's pretty common to have configuration files where we can use something like this:

```
GemName.configure do |config|
  config.enable = Rails.env.production? || Rails.env.staging?
end
```