### PR TITLE
Handling overridden Web Reporter class

### DIFF
--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -140,6 +140,11 @@ module Coverband
         require "coverband/reporters/json_report"
         init_web
       end
+
+      def self.call(env)
+        @app ||= new
+        @app.call(env)
+      end
     end
   end
 end


### PR DESCRIPTION
@danmayer Turns out, I missed out on the overridden implementation of Reporters::Web class after all.

This did not show up earlier but here is quick patch for it.
