### PR TITLE
fix for #489 not loading the route tracking in some apps

### DIFF
--- a/lib/coverband/collectors/route_tracker.rb
+++ b/lib/coverband/collectors/route_tracker.rb
@@ -76,6 +76,11 @@ module Coverband
 
       def concrete_target
         if defined?(Rails.application)
+          if Rails.application.respond_to?(:reload_routes!) && Rails.application.routes.empty?
+            # NOTE: depending on eager loading etc, routes may not be loaded
+            # so load them if they aren't
+            Rails.application.reload_routes!
+          end
           Rails.application.routes.routes.map do |route|
             {
               controller: route.defaults[:controller],


### PR DESCRIPTION
this fixes an issue where the unused routes list is empty for an app even when it does show and list routes it does track.

fixes
https://github.com/danmayer/coverband/issues/489