### PR TITLE
[Proposal] On HashRedisStore, when loading coverage, get the latest report from a cache and defer current report generation to a background thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,11 @@ Coverband on very high volume sites with many server processes reporting can hav
 
 See more discussion [here](https://github.com/danmayer/coverband/issues/384).
 
+Please note that with the Redis Hash Store, everytime you load the full report, Coverband will execute `HGETALL` queries in your Redis server twice for every file in the project (once for runtime coverage and once for eager loading coverage). This shouldn't have a big impact in small to medium projects, but can be quite a hassle if your project has a few thousand files.
+To help reduce the extra redis load when getting the coverage report, you can enable `get_coverage_cache` (but note that when doing that, you will always get a previous version of the report, while a cache is re-populated with a newer version).
+
+- Use Hash Redis Store with _get coverage cache_: `config.store = Coverband::Adapters::HashRedisStore.new(redis, get_coverage_cache: true)`
+
 ### Clear Coverage
 
 Now that Coverband uses MD5 hashes there should be no reason to manually clear coverage unless one is testing, changing versions, possibly debugging Coverband itself.

--- a/test/coverband/adapters/hash_redis_store_test.rb
+++ b/test/coverband/adapters/hash_redis_store_test.rb
@@ -192,4 +192,52 @@ class HashRedisStoreTest < Minitest::Test
     @store.clear_file!("app_path/dog.rb")
     assert_nil @store.get_coverage_report[:merged]["./dog.rb"]
   end
+
+  def test_get_coverage_cache
+    @store = Coverband::Adapters::HashRedisStore.new(
+      @redis,
+      redis_namespace: "coverband_test",
+      relative_file_converter: MockRelativeFileConverter,
+      get_coverage_cache: true
+    )
+    @store.get_coverage_cache.stubs(:deferred_time).returns(0)
+    @store.get_coverage_cache.clear!
+    mock_file_hash
+    yesterday = DateTime.now.prev_day.to_time
+    mock_time(yesterday)
+    @store.save_report(
+      "app_path/dog.rb" => [0, 1, 2]
+    )
+    assert_equal(
+      {
+        "first_updated_at" => yesterday.to_i,
+        "last_updated_at" => yesterday.to_i,
+        "file_hash" => "abcd",
+        "data" => [0, 1, 2]
+      },
+      @store.coverage["./dog.rb"]
+    )
+    @store.save_report(
+      "app_path/dog.rb" => [0, 1, 2]
+    )
+    assert_equal(
+      {
+        "first_updated_at" => yesterday.to_i,
+        "last_updated_at" => yesterday.to_i,
+        "file_hash" => "abcd",
+        "data" => [0, 1, 2]
+      },
+      @store.coverage["./dog.rb"]
+    )
+    sleep 0.1 # wait caching thread finish
+    assert_equal(
+      {
+        "first_updated_at" => yesterday.to_i,
+        "last_updated_at" => yesterday.to_i,
+        "file_hash" => "abcd",
+        "data" => [0, 2, 4]
+      },
+      @store.coverage["./dog.rb"]
+    )
+  end
 end


### PR DESCRIPTION
Running Coverband with HashRedisStore with a significantly big project (~4600 files) has proven difficult, as everytime we try to load the coverage page, Coverband does a lot of Redis HGETALL commands (2 per file) and blocks the request until the commands return.

This PR aims to mitigate the hit HashRedisStore has on Redis when generating the coverage report by introducing a caching layer to, so the HGETALL commands used to build the coverage report run inside background threads, in batches of a 250 (per file type, concurrently). All following requests will then receive the latest cache result, while a new cache is re-populated in the background.

This optimization improved load times of the report page from 30-40 seconds to 15-20 seconds (on a 2GB redis server with about 40% memory left). Tested with:
```ruby
Benchmark.measure do
  Coverband::Reporters::Web.new.tap do |cov|
    cov.instance_variable_set(:@request,Rack::Request.new(Rack::MockRequest.env_for("/")))
  end.index
  nil
end

# worst case i.e. without any cache
# => #<Benchmark::Tms:0x00007f082f4ddee0 @cstime=0.0, @cutime=0.0, @label="", @real=36.507868222999605, @stime=2.697597, @total=36.615393, @utime=33.917795999999996>

# with a cache
# => #<Benchmark::Tms:0x00007f081aaf1558 @cstime=0.0, @cutime=0.0, @label="", @real=16.935891766999703, @stime=0.9192540000000005, @total=16.973998, @utime=16.054744>
```