### PR TITLE
Allow YAML alias in translation

### DIFF
--- a/lib/coverband/collectors/translation_tracker.rb
+++ b/lib/coverband/collectors/translation_tracker.rb
@@ -36,7 +36,7 @@ module Coverband
           app_translation_keys = []
           app_translation_files = ::I18n.load_path.select { |f| f.match(/config\/locales/) }
           app_translation_files.each do |file|
-            app_translation_keys += flatten_hash(YAML.load_file(file)).keys
+            app_translation_keys += flatten_hash(YAML.load_file(file, aliases: true)).keys
           end
           app_translation_keys.uniq
         else


### PR DESCRIPTION
The following error occurred when the translation file contained a YAML alias:

```
$ bin/rails s 
D, [2024-02-04T15:55:01.732775 #2748152] DEBUG -- : using default configuration
=> Booting Puma
=> Rails 7.1.3 application starting in development 
=> Run `bin/rails server --help` for more startup options
Exiting
/home/ursm/.local/share/mise/installs/ruby/3.3.0/lib/ruby/3.3.0/psych/visitors/to_ruby.rb:432:in `visit_Psych_Nodes_Alias': Alias parsing was not enabled. To enable it, pass `aliases: true` to `Psych::load` or `Psych::safe_load`. (Psych::AliasesNotEnabled)
```
