### PR TITLE
Bump required_ruby_version from 2.3 to 2.7

### DIFF
--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  spec.required_ruby_version = ">= 2.3"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.metadata = {
     "homepage_uri" => "https://github.com/danmayer/coverband",


### PR DESCRIPTION
Follow up: https://github.com/ydah/coverband/commit/3b162b3f2841ff21899282bee9ca4d4ada48ff35