### PR TITLE
Add memcached adapter

### DIFF
--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -44,7 +44,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "resque"
   spec.add_development_dependency "standard", "~> 1.34.0"
-  spec.add_development_dependency "standardrb"
+  # breaking changes in various rubocop versions
+  spec.add_development_dependency "rubocop", "~> 1.61.0"
 
   spec.add_development_dependency "coveralls"
   # minitest-profile is not compatible with Rails 7.1.0 setup... dropping it for now

--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -43,9 +43,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "resque"
-  spec.add_development_dependency "standard", "~> 1.34.0"
+  spec.add_development_dependency "standard", "= 1.34.0"
   # breaking changes in various rubocop versions
-  spec.add_development_dependency "rubocop", "~> 1.61.0"
+  spec.add_development_dependency "rubocop", "= 1.60.0"
 
   spec.add_development_dependency "coveralls"
   # minitest-profile is not compatible with Rails 7.1.0 setup... dropping it for now

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -91,8 +91,8 @@ module Coverband
     coverage_instance.eager_loading!
   end
 
-  def self.eager_loading_coverage(&block)
-    coverage_instance.eager_loading(&block)
+  def self.eager_loading_coverage(...)
+    coverage_instance.eager_loading(...)
   end
 
   def self.runtime_coverage!

--- a/lib/coverband/adapters/memcached_store.rb
+++ b/lib/coverband/adapters/memcached_store.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Coverband
+  module Adapters
+    class MemcachedStore < Base
+      STORAGE_FORMAT_VERSION = 'coverband_3_2'
+
+      attr_reader :memcached_namespace
+
+      def initialize(memcached, opts = {})
+        super()
+        @memcached = memcached
+        @memcached_namespace = opts[:memcached_namespace]
+        @format_version = STORAGE_FORMAT_VERSION
+        @keys = {}
+        Coverband::TYPES.each do |type|
+          @keys[type] = [@format_version, @memcached_namespace, type].compact.join('.')
+        end
+      end
+
+      def clear!
+        Coverband::TYPES.each do |type|
+          @memcached.delete(type_base_key(type))
+        end
+      end
+
+      def clear_file!(filename)
+        Coverband::TYPES.each do |type|
+          data = coverage(type)
+          data.delete(filename)
+          save_coverage(data, type)
+        end
+      end
+
+      def size
+        @memcached.read(base_key) ? @memcached.read(base_key).bytesize : 'N/A'
+      end
+
+      def migrate!
+        raise NotImplementedError, "MemcachedStore doesn't support migrations"
+      end
+
+      def type=(type)
+        super
+        reset_base_key
+      end
+
+      def coverage(local_type = nil, opts = {})
+        local_type ||= opts.key?(:override_type) ? opts[:override_type] : type
+        data = memcached.read(type_base_key(local_type))
+        data = data ? JSON.parse(data) : {}
+        data.delete_if { |file_path, file_data| file_hash(file_path) != file_data['file_hash'] } unless opts[:skip_hash_check]
+        data
+      end
+
+      def save_report(report)
+        data = report.dup
+        data = merge_reports(data, coverage(nil, skip_hash_check: true))
+        save_coverage(data)
+      end
+
+      def raw_store
+        raise NotImplementedError, "MemcachedStore doesn't support raw_store"
+      end
+
+      attr_reader :memcached
+
+      private
+
+      def reset_base_key
+        @base_key = nil
+      end
+
+      def base_key
+        @base_key ||= [@format_version, @memcached_namespace, type].compact.join('.')
+      end
+
+      def type_base_key(local_type)
+        @keys[local_type]
+      end
+
+      def save_coverage(data, local_type = nil)
+        local_type ||= type
+        key = type_base_key(local_type)
+        memcached.write(key, data.to_json)
+      end
+    end
+  end
+end

--- a/lib/coverband/adapters/memcached_store.rb
+++ b/lib/coverband/adapters/memcached_store.rb
@@ -3,7 +3,7 @@
 module Coverband
   module Adapters
     class MemcachedStore < Base
-      STORAGE_FORMAT_VERSION = 'coverband_3_2'
+      STORAGE_FORMAT_VERSION = "coverband_3_2"
 
       attr_reader :memcached_namespace
 
@@ -14,7 +14,7 @@ module Coverband
         @format_version = STORAGE_FORMAT_VERSION
         @keys = {}
         Coverband::TYPES.each do |type|
-          @keys[type] = [@format_version, @memcached_namespace, type].compact.join('.')
+          @keys[type] = [@format_version, @memcached_namespace, type].compact.join(".")
         end
       end
 
@@ -33,7 +33,7 @@ module Coverband
       end
 
       def size
-        @memcached.read(base_key) ? @memcached.read(base_key).bytesize : 'N/A'
+        @memcached.read(base_key) ? @memcached.read(base_key).bytesize : "N/A"
       end
 
       def migrate!
@@ -49,7 +49,7 @@ module Coverband
         local_type ||= opts.key?(:override_type) ? opts[:override_type] : type
         data = memcached.read(type_base_key(local_type))
         data = data ? JSON.parse(data) : {}
-        data.delete_if { |file_path, file_data| file_hash(file_path) != file_data['file_hash'] } unless opts[:skip_hash_check]
+        data.delete_if { |file_path, file_data| file_hash(file_path) != file_data["file_hash"] } unless opts[:skip_hash_check]
         data
       end
 
@@ -72,7 +72,7 @@ module Coverband
       end
 
       def base_key
-        @base_key ||= [@format_version, @memcached_namespace, type].compact.join('.')
+        @base_key ||= [@format_version, @memcached_namespace, type].compact.join(".")
       end
 
       def type_base_key(local_type)


### PR DESCRIPTION
# Description
This pull request introduces a new adapter for Coverband, enabling the use of Memcached as a storage backend. This addition allows users of Coverband to leverage the distributed memory object caching system, which can be particularly useful for applications that are already using Memcached for other forms of caching. This can help in maintaining consistency in the tools used across an application and can potentially improve performance for coverage data storage and retrieval.

# Changes
- New File: `lib/coverband/adapters/memcached_store.rb`

# Usage
To use the Memcached adapter, users need to initialize it with a Memcached client instance and optionally specify a namespace for the keys. This flexibility allows for easy integration into existing projects that might already be using Memcached.

```
Coverband.configure do |config|
    memcached = Memcached.new([...])
    config.store = Coverband::Adapters::MemcachedStore.new(memcached, memcached_namespace: 'my_app_coverband')
           
    config.track_views = false
end
```

# Notes
Unsupported Operations: raw_store and migrate