### PR TITLE
Fix route tracker

### DIFF
--- a/lib/coverband/collectors/route_tracker.rb
+++ b/lib/coverband/collectors/route_tracker.rb
@@ -27,6 +27,8 @@ module Coverband
       def track_key(payload)
         route = if payload.key?(:location)
           # For redirect.action_dispatch
+          return unless Coverband.configuration.track_redirect_routes
+
           {
             controller: nil,
             action: nil,

--- a/lib/coverband/collectors/route_tracker.rb
+++ b/lib/coverband/collectors/route_tracker.rb
@@ -44,11 +44,10 @@ module Coverband
             verb: payload[:method]
           }
         end
-        if route
-          if newly_seen_key?(route)
-            @logged_keys << route
-            @keys_to_record << route if track_key?(route)
-          end
+
+        if newly_seen_key?(route)
+          @logged_keys << route
+          @keys_to_record << route if track_key?(route)
         end
       end
 

--- a/lib/coverband/collectors/route_tracker.rb
+++ b/lib/coverband/collectors/route_tracker.rb
@@ -25,7 +25,8 @@ module Coverband
       # and ensure high performance
       ###
       def track_key(payload)
-        route = if payload[:request]
+        route = if payload.key?(:location)
+          # For redirect.action_dispatch
           {
             controller: nil,
             action: nil,
@@ -33,6 +34,7 @@ module Coverband
             verb: payload[:request].method
           }
         else
+          # For start_processing.action_controller
           {
             controller: payload[:params]["controller"],
             action: payload[:action],

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -9,7 +9,7 @@ module Coverband
       :test_env, :web_enable_clear, :gem_details, :web_debug, :report_on_exit,
       :simulate_oneshot_lines_coverage,
       :view_tracker, :defer_eager_loading_data,
-      :track_routes, :route_tracker,
+      :track_routes, :track_redirect_routes, :route_tracker,
       :track_translations, :translations_tracker,
       :trackers, :csp_policy, :hide_settings
 
@@ -74,6 +74,7 @@ module Coverband
       @track_views = true
       @view_tracker = nil
       @track_routes = false
+      @track_redirect_routes = true
       @route_tracker = nil
       @track_translations = false
       @translations_tracker = nil

--- a/test/coverband/collectors/route_tracker_test.rb
+++ b/test/coverband/collectors/route_tracker_test.rb
@@ -42,6 +42,22 @@ class RouterTrackerTest < Minitest::Test
     assert_equal [route_hash], tracker.logged_keys
   end
 
+  test "track redirect routes when track_redirect_routes is false" do
+    Coverband.configuration.track_redirect_routes = false
+
+    store = fake_store
+    tracker = Coverband::Collectors::RouteTracker.new(store: store, roots: "dir")
+
+    payload = {
+      request: Payload.new("path", "GET"),
+      status: 302,
+      location: 'https://coverband.dev/'
+    }
+    tracker.track_key(payload)
+    tracker.save_report
+    assert_equal [], tracker.logged_keys
+  end
+
   test "track controller routes in Rails < 6.1" do
     store = fake_store
     route_hash = {controller: "some/controller", action: "index", url_path: nil, verb: "GET"}


### PR DESCRIPTION
The routes_tracker had a bug that caused a significant increase in the number of keys, which has been fixed in this PR.

- At least in the Rails 7.0, `payload[:request]` is always true. And if the value of `url_path: payload[:request].path` contained an id, there was a bug that generated a large number of keys for each target id.
  - Perhaps this code expects to branch on redirect. Therefore, it was modified to `payload.key?(:location)`.
- Added option to not track all redirects.
  - For redirects, using conditions such as `get '*pages', redirect: '/'` in `routes.rb` could lead to a huge number of keys. By choosing not to track redirects, a significant increase in the number of keys can be prevented.
- Tiny refactoring. Removed `if route` because of it is always true.

---

Thanks for this great gem! Our application has reduced our code by a few percent 👍 