### PR TITLE
Override default Configuration root with an env var

### DIFF
--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -60,7 +60,7 @@ module Coverband
     end
 
     def reset
-      @root = Dir.pwd
+      @root = ENV["COVERBAND_ROOT"] || Dir.pwd
       @root_paths = []
       @ignore = IGNORE_DEFAULTS.dup
       @search_paths = TRACKED_DEFAULT_PATHS.dup


### PR DESCRIPTION
First off, thank you for maintaining this project. It has been extremely valuable for our organization in removing dead code from legacy applications.

We are currently integrating `coverband` with a Sinatra app and ran into a blocker. Due to a pile of shell scripts and symbolic links in our infrastructure, we need to be able to set the configuration `root` via an environment variable. This PR will set the configuration root to the value of the environment variable "COVERBAND_ROOT" and fall back to the previous behavior when it is not set.

For some additional context, our applications are deployed using conventions similar to [Capistrano](https://capistranorb.com/documentation/getting-started/structure/). 

The live code is referenced via a symbolic link `current` pointing to the directory where the code actually lives.