### PR TITLE
docs: Update URL and change from dotenv-rails to dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,10 @@ end
 
 Do you use figaro, mc-settings, dotenv or something else to inject environment variables into your app? If so ensure you have that done BEFORE Coverband is required.
 
-For example if you use dotenv, you need to do this, see https://github.com/bkeepers/dotenv#note-on-load-order
+For example if you use dotenv, you need to do this, see https://github.com/bkeepers/dotenv#load-order
 
 ```
-gem 'dotenv-rails', require: 'dotenv/load'
+gem 'dotenv', require: 'dotenv/load'
 gem 'coverband'
 gem 'other-gem-that-requires-env-variables'
 ```


### PR DESCRIPTION
Fixed as the link has been changed.
dotenv-rails has been fixed as it has been integrated into dotenv.