### PR TITLE
Only print "using default configuration" in verbose mode

### DIFF
--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -51,7 +51,7 @@ module Coverband
     elsif File.exist?(configuration_file)
       load configuration_file
     else
-      configuration.logger.debug("using default configuration")
+      configuration.logger.debug("using default configuration") if Coverband.configuration.verbose
     end
     @@configured = true
     coverage_instance.reset_instance


### PR DESCRIPTION
This gets printed every time I start a rails process, and creates noise without any value.

Every other call to log is covered by this condition (some have others) so let's do that here too.