### PR TITLE
Truncate long file names in web ui

### DIFF
--- a/lib/coverband/utils/html_formatter.rb
+++ b/lib/coverband/utils/html_formatter.rb
@@ -169,7 +169,16 @@ module Coverband
 
       def link_to_source_file(source_file)
         data_loader_url = "#{base_path}load_file_details?filename=#{source_file.filename}"
-        %(<a href="##{id source_file}" class="src_link" title="#{shortened_filename source_file}" data-loader-url="#{data_loader_url}" onclick="src_link_click(this)">#{shortened_filename source_file}</a>)
+        %(<a href="##{id source_file}" class="src_link" title="#{shortened_filename source_file}" data-loader-url="#{data_loader_url}" onclick="src_link_click(this)">#{truncate(shortened_filename(source_file))}</a>)
+      end
+
+      def truncate(text, length: 50)
+        if text.length <= length
+          text
+        else
+          omission = "..."
+          "#{text[0, length - omission.length]}#{omission}"
+        end
       end
     end
   end


### PR DESCRIPTION
We have some long file paths and it is not looking nice in the UI.

<img width="1273" alt="Screenshot 2024-10-10 at 16 18 58" src="https://github.com/user-attachments/assets/beb79085-d264-43d2-ab91-58c1d97716e3">
