### PR TITLE
Add sidekiq swarm integration

### DIFF
--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -117,6 +117,7 @@ module Coverband
         start
       end
       require "coverband/integrations/resque" if defined? ::Resque
+      require "coverband/integrations/sidekiq_swarm" if defined? ::Sidekiq::Enterprise::Swarm
     rescue Redis::CannotConnectError => error
       Coverband.configuration.logger.info "Redis is not available (#{error}), Coverband not configured"
       Coverband.configuration.logger.info "If this is a setup task like assets:precompile feel free to ignore"

--- a/lib/coverband/integrations/sidekiq_swarm.rb
+++ b/lib/coverband/integrations/sidekiq_swarm.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Sidekiq.configure_server do |config|
+  config.on(:fork) do
+    Coverband.start
+    Coverband.runtime_coverage!
+  end
+end


### PR DESCRIPTION
We use sidekiq enterprise, which has a swarm feature (https://github.com/sidekiq/sidekiq/wiki/Ent-Multi-Process).
It has a master process, which preloads the gems and application and forks child processes. When master preloads the gems, it also loads coverband. Coverband sets `at_exit` hook and a background thread (`Coverband::Background`) in the master. But when it forks the child processes, only the `at_exit` hook remains in the child, but the background thread is not working anymore (in the dead state).

I spent a good amount of time to figure out why we have some coverage missed, even though the code is clearly running in production.

I propose to add a simple integration for sidekiq swarm to make future people lifes easier.

Maybe it is also a good idea to make the solution more generic by somehow identifying when the process was forked and recreate the background thread? 🤔 