### PR TITLE
Change style for 0 missed lines

### DIFF
--- a/lib/coverband/utils/html_formatter.rb
+++ b/lib/coverband/utils/html_formatter.rb
@@ -150,6 +150,14 @@ module Coverband
         end
       end
 
+      def missed_lines_css_class(count)
+        if count == 0
+          "green"
+        else
+          "red"
+        end
+      end
+
       # Return a (kind of) unique id for the source file given. Uses SHA1 on path for the id
       def id(source_file)
         Digest::SHA1.hexdigest(source_file.filename)

--- a/views/source_file.erb
+++ b/views/source_file.erb
@@ -27,7 +27,7 @@
       <b><%= source_file.lines_of_code %></b> relevant lines.
       <b><%= result.runtime_relavent_lines(source_file) %></b> runtime relevant lines.
       <span class="green"><b><%= source_file.covered_lines.count %></b> lines covered</span> and
-      <span class="red"><b><%= source_file.missed_lines.count %></b> lines missed.</span>
+      <span class="<%= missed_lines_css_class(source_file.missed_lines.count) %>"><b><%= source_file.missed_lines.count %></b> lines missed.</span>
     </div>
     <div>
       Coverage first seen: <%= source_file.first_updated_at %>, last activity recorded:


### PR DESCRIPTION
When there is 0 missed lines, it is displayed in red in the UI. This is at least distracting.

Before
<img width="505" alt="Screenshot 2024-10-12 at 15 57 13" src="https://github.com/user-attachments/assets/e88a5226-1635-418a-9029-d583445b47bc">


After
<img width="521" alt="Screenshot 2024-10-12 at 15 55 12" src="https://github.com/user-attachments/assets/60d2f2a7-3c16-4899-89a1-21f030c7fc9a">
