### PR TITLE
Reduce memory allocated when rendering the index page

### DIFF
--- a/lib/coverband/collectors/abstract_tracker.rb
+++ b/lib/coverband/collectors/abstract_tracker.rb
@@ -127,7 +127,8 @@ module Coverband
       end
 
       def track_key?(key, options = {})
-        @ignore_patterns.none? { |pattern| key.to_s.include?(pattern) }
+        key = key.to_s
+        @ignore_patterns.none? { |pattern| key.match?(pattern) }
       end
 
       private

--- a/lib/coverband/collectors/view_tracker.rb
+++ b/lib/coverband/collectors/view_tracker.rb
@@ -84,8 +84,8 @@ module Coverband
         recently_used_views = used_keys.keys
         unused_views = all_keys - recently_used_views
         # since layouts don't include format we count them used if they match with ANY formats
-        unused_views.reject { |view| view.match(/\/layouts\//) && recently_used_views.any? { |used_view| view.include?(used_view) } }
-        unused_views.reject { |view| @ignore_patterns.any? { |pattern| view.include?(pattern) } }
+        unused_views.reject { |view| view.include?("/layouts/") && recently_used_views.any? { |used_view| view.include?(used_view) } }
+        unused_views.reject { |view| @ignore_patterns.any? { |pattern| view.match?(pattern) } }
       end
 
       def clear_key!(filename)
@@ -100,7 +100,7 @@ module Coverband
 
       def track_file?(file, options = {})
         (file.start_with?(@project_directory) || options[:layout]) &&
-          @ignore_patterns.none? { |pattern| file.include?(pattern) }
+          @ignore_patterns.none? { |pattern| file.match?(pattern) }
       end
 
       def concrete_target

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -61,7 +61,7 @@ module Coverband
     def reset
       @root = Dir.pwd
       @root_paths = []
-      @ignore = IGNORE_DEFAULTS.dup
+      @ignore = IGNORE_DEFAULTS.map { |ignore_str| Regexp.new(ignore_str) }
       @search_paths = TRACKED_DEFAULT_PATHS.dup
       @verbose = false
       @reporter = "scov"
@@ -222,8 +222,8 @@ module Coverband
     # Don't allow the ignore to override things like gem tracking
     ###
     def ignore=(ignored_array)
-      ignored_array.map { |ignore_str| Regexp.new(ignore_str) }
-      @ignore = (@ignore + ignored_array).uniq
+      ignored_array = ignored_array.map { |ignore_str| Regexp.new(ignore_str) }
+      @ignore |= ignored_array
     rescue RegexpError
       logger.error "an invalid regular expression was passed in, ensure string are valid regex patterns #{ignored_array.join(",")}"
     end

--- a/lib/coverband/reporters/base.rb
+++ b/lib/coverband/reporters/base.rb
@@ -37,7 +37,7 @@ module Coverband
 
             # apply coverband filters
             report_files.each_pair do |file, data|
-              next if Coverband.configuration.ignore.any? { |i| file.match(i) }
+              next if Coverband.configuration.ignore.any? { |i| file.match?(i) }
 
               filtered_report_files[report_name][file] = data
             end
@@ -93,7 +93,7 @@ module Coverband
           scov_style_report = {}
           store.get_coverage_report(options).each_pair do |name, data|
             data.each_pair do |key, line_data|
-              next if Coverband.configuration.ignore.any? { |i| key.match(i) }
+              next if Coverband.configuration.ignore.any? { |i| key.match?(i) }
               next unless line_data
 
               scov_style_report[name] = {} unless scov_style_report.key?(name)

--- a/lib/coverband/utils/source_file.rb
+++ b/lib/coverband/utils/source_file.rb
@@ -191,7 +191,9 @@ module Coverband
       end
 
       def lines_strength
-        lines.map(&:coverage).compact.reduce(:+)
+        lines.sum do |line|
+          line.coverage || 0
+        end
       end
 
       def relevant_lines
@@ -256,8 +258,7 @@ module Coverband
       # was at the start of the file name
       # I had previously patched this in my local Rails app
       def short_name
-        filename.sub(/^#{Coverband.configuration.root}/, ".")
-          .gsub(%r{^\.\/}, "")
+        filename.delete_prefix("#{Coverband.configuration.root}/")
       end
 
       def relative_path

--- a/test/coverband/configuration_test.rb
+++ b/test/coverband/configuration_test.rb
@@ -18,7 +18,7 @@ class BaseTest < Minitest::Test
 
   test "ignore works with equal" do
     Coverband::Collectors::Coverage.instance.reset_instance
-    expected = ["vendor/", ".erb$", ".slim$", "/tmp", "internal:prelude", "db/schema.rb", "config/environments"]
+    expected = ["vendor/", ".erb$", ".slim$", "/tmp", "internal:prelude", "db/schema.rb", "config/environments"].map { |str| Regexp.new(str) }
     assert_equal expected, Coverband.configuration.ignore
   end
 
@@ -34,7 +34,7 @@ class BaseTest < Minitest::Test
       "internal:prelude",
       "db/schema.rb",
       "config/environments",
-      "config/initializers"]
+      "config/initializers"].map { |str| Regexp.new(str) }
     assert_equal expected, Coverband.configuration.ignore
   end
 
@@ -44,7 +44,7 @@ class BaseTest < Minitest::Test
       config.ignore = ["*invalidRegex*"]
     end
     Coverband::Collectors::Coverage.instance.reset_instance
-    expected = Coverband::Configuration::IGNORE_DEFAULTS << "config/environments"
+    expected = (Coverband::Configuration::IGNORE_DEFAULTS << "config/environments").map { |str| Regexp.new(str) }
     assert_equal expected, Coverband.configuration.ignore
   end
 


### PR DESCRIPTION
When rendering an index page, coverband makes a lot of unneeded allocations.

Before
```
Total allocated: 349.10 MB (1788664 objects)
```

After
```
Total allocated: 212.79 MB (1134381 objects)
```

So, it is now 40% less in my case.