### PR TITLE
Fix unused views report

### DIFF
--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -5,7 +5,6 @@ require "json"
 require "redis"
 require "coverband/version"
 require "coverband/at_exit"
-require "coverband/configuration"
 require "coverband/utils/relative_file_converter"
 require "coverband/utils/absolute_file_converter"
 require "coverband/adapters/base"
@@ -27,6 +26,7 @@ require "coverband/reporters/console_report"
 require "coverband/integrations/background"
 require "coverband/integrations/background_middleware"
 require "coverband/integrations/rack_server_check"
+require "coverband/configuration"
 
 Coverband::Adapters::RedisStore = Coverband::Adapters::HashRedisStore if ENV["COVERBAND_HASH_REDIS_STORE"]
 

--- a/lib/coverband/collectors/view_tracker.rb
+++ b/lib/coverband/collectors/view_tracker.rb
@@ -17,6 +17,7 @@ module Coverband
 
       REPORT_ROUTE = "views_tracker"
       TITLE = "Views"
+      VIEWS_PATTERNS = %w[.erb$ .haml$ .slim$]
 
       def initialize(options = {})
         @project_directory = File.expand_path(Coverband.configuration.root)
@@ -24,6 +25,8 @@ module Coverband
         @roots = @roots.split(",") if @roots.is_a?(String)
 
         super
+
+        @ignore_patterns -= VIEWS_PATTERNS.map { |ignore_str| Regexp.new(ignore_str) }
       end
 
       def railtie!
@@ -84,7 +87,7 @@ module Coverband
         recently_used_views = used_keys.keys
         unused_views = all_keys - recently_used_views
         # since layouts don't include format we count them used if they match with ANY formats
-        unused_views.reject { |view| view.include?("/layouts/") && recently_used_views.any? { |used_view| view.include?(used_view) } }
+        unused_views = unused_views.reject { |view| view.include?("/layouts/") && recently_used_views.any? { |used_view| view.include?(used_view) } }
         unused_views.reject { |view| @ignore_patterns.any? { |pattern| view.match?(pattern) } }
       end
 

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -48,7 +48,7 @@ module Coverband
     # Heroku when building assets runs code from a dynamic directory
     # /tmp was added to avoid coverage from /tmp/build directories during
     # heroku asset compilation
-    IGNORE_DEFAULTS = %w[vendor/ .erb$ .slim$ /tmp internal:prelude db/schema.rb]
+    IGNORE_DEFAULTS = %w[vendor/ /tmp internal:prelude db/schema.rb] + Collectors::ViewTracker::VIEWS_PATTERNS
 
     # Add in missing files which were never loaded
     # we need to know what all paths to check for unloaded files

--- a/test/coverband/collectors/view_tracker_test.rb
+++ b/test/coverband/collectors/view_tracker_test.rb
@@ -88,22 +88,22 @@ class ViewTrackerTest < Minitest::Test
     Coverband::Collectors::ViewTracker.expects(:supported_version?).returns(true)
     store = fake_store
     file_path = "#{File.expand_path(Coverband.configuration.root)}/file"
-    target = [file_path, "not_used"]
+    target = [file_path, "not_used.html.erb"]
     tracker = Coverband::Collectors::ViewTracker.new(store: store, roots: "dir", target: target)
     tracker.track_key(identifier: file_path)
     tracker.save_report
-    assert_equal ["not_used"], tracker.unused_keys
+    assert_equal ["not_used.html.erb"], tracker.unused_keys
   end
 
   test "report hides partials marked in ignore config" do
     Coverband::Collectors::ViewTracker.expects(:supported_version?).returns(true)
     store = fake_store
     file_path = "#{File.expand_path(Coverband.configuration.root)}/app/views/anything/ignore_me.html.erb"
-    target = [file_path, "not_used"]
+    target = [file_path, "not_used.html.erb"]
     tracker = Coverband::Collectors::ViewTracker.new(store: store, roots: "dir", target: target)
     tracker.track_key(identifier: file_path)
     tracker.save_report
-    assert_equal ["not_used"], tracker.unused_keys
+    assert_equal ["not_used.html.erb"], tracker.unused_keys
     assert_equal [], tracker.used_keys.keys
   end
 

--- a/test/coverband/configuration_test.rb
+++ b/test/coverband/configuration_test.rb
@@ -18,7 +18,7 @@ class BaseTest < Minitest::Test
 
   test "ignore works with equal" do
     Coverband::Collectors::Coverage.instance.reset_instance
-    expected = ["vendor/", ".erb$", ".slim$", "/tmp", "internal:prelude", "db/schema.rb", "config/environments"].map { |str| Regexp.new(str) }
+    expected = ["vendor/", "/tmp", "internal:prelude", "db/schema.rb", ".erb$", ".haml$", ".slim$", "config/environments"].map { |str| Regexp.new(str) }
     assert_equal expected, Coverband.configuration.ignore
   end
 
@@ -28,11 +28,12 @@ class BaseTest < Minitest::Test
     end
     Coverband::Collectors::Coverage.instance.reset_instance
     expected = ["vendor/",
-      ".erb$",
-      ".slim$",
       "/tmp",
       "internal:prelude",
       "db/schema.rb",
+      ".erb$",
+      ".haml$",
+      ".slim$",
       "config/environments",
       "config/initializers"].map { |str| Regexp.new(str) }
     assert_equal expected, Coverband.configuration.ignore


### PR DESCRIPTION
Currently, the "Unused Views" report is broken, because it always shows 0. This is because we ignore view files for coverage https://github.com/danmayer/coverband/blob/b9d98e7aefc955a749bd3f0230c28049d90c30c6/lib/coverband/configuration.rb#L51 and when rendering the "Unused Views" report we check if the view is not ignored in https://github.com/danmayer/coverband/blob/b9d98e7aefc955a749bd3f0230c28049d90c30c6/lib/coverband/collectors/view_tracker.rb#L88 And they are, because of the mentioned ignoring view files in the `@ignore_patterns`. 

<img width="421" alt="Screenshot 2024-10-18 at 17 48 29" src="https://github.com/user-attachments/assets/9c376350-624c-4716-b720-79a46ac070cf">
