### PR TITLE
Do not swallow `config.ignore` regexp errors

### DIFF
--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -224,8 +224,6 @@ module Coverband
     def ignore=(ignored_array)
       ignored_array = ignored_array.map { |ignore_str| Regexp.new(ignore_str) }
       @ignore |= ignored_array
-    rescue RegexpError
-      logger.error "an invalid regular expression was passed in, ensure string are valid regex patterns #{ignored_array.join(",")}"
     end
 
     def current_root

--- a/test/coverband/configuration_test.rb
+++ b/test/coverband/configuration_test.rb
@@ -38,16 +38,6 @@ class BaseTest < Minitest::Test
     assert_equal expected, Coverband.configuration.ignore
   end
 
-  test "ignore catches regex errors" do
-    Coverband.configuration.logger.expects(:error).with("an invalid regular expression was passed in, ensure string are valid regex patterns *invalidRegex*")
-    Coverband.configure do |config|
-      config.ignore = ["*invalidRegex*"]
-    end
-    Coverband::Collectors::Coverage.instance.reset_instance
-    expected = (Coverband::Configuration::IGNORE_DEFAULTS << "config/environments").map { |str| Regexp.new(str) }
-    assert_equal expected, Coverband.configuration.ignore
-  end
-
   test "ignore" do
     Coverband::Collectors::Coverage.instance.reset_instance
     assert !Coverband.configuration.ignore.first.nil?


### PR DESCRIPTION
Currently, when someone passes an invalid regexp string to `config.ignore`, the error is "silently" ignored and reported to the logger. But this is a programmer error and a small chance anyone will look into the log file and notice this error line there.

Better is to loudly raise and fail.