### PR TITLE
Add rake task to clear all coverband data

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,12 +305,10 @@ Now that Coverband uses MD5 hashes there should be no reason to manually clear c
 
 `rake coverband:clear`
 
-This can also be done through the web if `config.web_enable_clear` is enabled.
+This will clear both the coverage and trackers data. It can also be done through the web if `config.web_enable_clear` is enabled.
 
-**NOTE**: The previous task does not clear the trackers data (views, routes, translations, etc).
-To clear trackers data, run
-
-`rake coverband:clear_tracker`
+To clear only coverage data, run `rake coverband:clear_coverage`.
+To clear only trackers data, run `rake coverband:clear_tracker`.
 
 ### Adding Rake Tasks outside of Rails
 

--- a/lib/coverband/utils/tasks.rb
+++ b/lib/coverband/utils/tasks.rb
@@ -129,10 +129,16 @@ namespace :coverband do
   end
 
   ###
-  # clear data helpful for development or after configuration issues
+  # clear all coverband data
+  ###
+  desc "reset Coverband coverage and trackers data, helpful for development, debugging, etc"
+  task clear: [:clear_coverage, :clear_tracker]
+
+  ###
+  # clear coverband coverage data
   ###
   desc "reset Coverband coverage data, helpful for development, debugging, etc"
-  task :clear do
+  task :clear_coverage do
     Coverband.configuration.store.clear!
   end
 


### PR DESCRIPTION
Follow up to https://github.com/danmayer/coverband/pull/562#issuecomment-2423713132.

Now,
`coverband:clear_coverage` - clears only coverage data
`coverband:clear_tracker` - clears only trackers data
`coverage:clear`  - clears all data