### PR TITLE
Load trackers for `clear_tracker` rake task

### DIFF
--- a/lib/coverband/utils/tasks.rb
+++ b/lib/coverband/utils/tasks.rb
@@ -141,6 +141,9 @@ namespace :coverband do
   ###
   desc "reset Coverband trackers data (view, routes, translations, etc), helpful for development, debugging, etc"
   task :clear_tracker do
+    # Load rails-related trackers, if the gem is used in a rails app.
+    Coverband.configuration.railtie! if defined?(Rails::Railtie)
+
     trackers = Coverband.configuration.trackers
     trackers.each(&:reset_recordings)
   end


### PR DESCRIPTION
Currently, `clear_tracker` task is a no-op, because `Coverband.configuration.trackers` returns an empty array.
We need to explicitly load rails-related trackers. 