### PR TITLE
Consider eager loaded code too when detecting dead methods

### DIFF
--- a/lib/coverband/utils/dead_methods.rb
+++ b/lib/coverband/utils/dead_methods.rb
@@ -37,7 +37,11 @@ module Coverband
       end
 
       def self.scan_all
-        coverage = Coverband.configuration.store.coverage
+        # If the file was loaded during eager loading and then its code is never executed
+        # during runtime, then it will not have any runtime coverage. When reporting
+        # dead methods, we need to look at all the files discovered during the eager loading
+        # and runtime phases.
+        coverage = Coverband.configuration.store.get_coverage_report[Coverband::MERGED_TYPE]
         coverage.flat_map do |file_path, coverage|
           scan(file_path: file_path, coverage: coverage["data"])
         end

--- a/test/coverband/utils/dead_methods_test.rb
+++ b/test/coverband/utils/dead_methods_test.rb
@@ -36,6 +36,18 @@ if defined?(RubyVM::AbstractSyntaxTree)
           assert_equal(6, dead_method.last_line_number)
         end
 
+        def test_all_dead_methods_on_runtime
+          @coverband.eager_loading!
+          require_unique_file
+          @coverband.report_coverage
+          @coverband.runtime!
+          dead_methods = DeadMethods.scan_all
+          dead_method = dead_methods.find { |method| method.class_name == :Dog }
+          assert(dead_method)
+          assert_equal(4, dead_method.first_line_number)
+          assert_equal(6, dead_method.last_line_number)
+        end
+
         def test_output_all
           require_unique_file
           @coverband.report_coverage


### PR DESCRIPTION
Currently, if the file was loaded during eager loading and then its code is never executed during runtime, then it will not have any runtime coverage and when printing dead methods, this file will be missed. 

When reporting dead methods, we need to look at all the files discovered during the eager loading and runtime phases.