### PR TITLE
Do not mark single-line and empty methods as dead

### DIFF
--- a/lib/coverband/utils/method_definition_scanner.rb
+++ b/lib/coverband/utils/method_definition_scanner.rb
@@ -32,11 +32,23 @@ if defined?(RubyVM::AbstractSyntaxTree)
           private
 
           def first_line_number
-            @method_definition.first_line_number + 1
+            if multiline?
+              @method_definition.first_line_number + 1
+            else
+              @method_definition.first_line_number
+            end
           end
 
           def last_line_number
-            @method_definition.last_line_number - 1
+            if multiline?
+              @method_definition.last_line_number - 1
+            else
+              @method_definition.last_line_number
+            end
+          end
+
+          def multiline?
+            @method_definition.last_line_number - @method_definition.first_line_number > 1
           end
         end
 

--- a/test/coverband/collectors/coverage_test.rb
+++ b/test/coverband/collectors/coverage_test.rb
@@ -23,7 +23,7 @@ class CollectorsCoverageTest < Minitest::Test
     file = require_unique_file
     coverband.report_coverage
     coverage = Coverband.configuration.store.coverage
-    assert_equal(coverage[file]["data"], [nil, nil, 1, 1, 0, nil, nil])
+    assert_equal(coverage[file]["data"], [nil, nil, 1, 1, 0, nil, nil, 1, nil, 1, nil, nil])
   end
 
   test "Dog method and class coverage" do
@@ -31,7 +31,7 @@ class CollectorsCoverageTest < Minitest::Test
     Dog.new.bark
     coverband.report_coverage
     coverage = Coverband.configuration.store.coverage
-    assert_equal(coverage["./test/dog.rb"]["data"], [nil, nil, 1, 1, 1, nil, nil])
+    assert_equal(coverage["./test/dog.rb"]["data"], [nil, nil, 1, 1, 1, nil, nil, 1, nil, 1, nil, nil])
   end
 
   test "Dog eager load coverage" do
@@ -45,7 +45,7 @@ class CollectorsCoverageTest < Minitest::Test
     coverband.eager_loading!
     coverage = Coverband.configuration.store.coverage[file]
     refute_nil coverage, "Eager load coverage is present"
-    assert_equal(coverage["data"], [nil, nil, 1, 1, 0, nil, nil])
+    assert_equal(coverage["data"], [nil, nil, 1, 1, 0, nil, nil, 1, nil, 1, nil, nil])
   end
 
   test "gets coverage instance" do

--- a/test/coverband/utils/dead_methods_test.rb
+++ b/test/coverband/utils/dead_methods_test.rb
@@ -16,7 +16,7 @@ if defined?(RubyVM::AbstractSyntaxTree)
 
         def test_dog_dead_methods
           file_path = require_unique_file
-          coverage = [nil, nil, 1, 1, 0, nil, nil]
+          coverage = [nil, nil, 1, 1, 0, nil, nil, 1, nil, 1, nil, nil]
           dead_methods =
             DeadMethods.scan(file_path: file_path, coverage: coverage)
           assert_equal(1, dead_methods.length)
@@ -56,7 +56,7 @@ if defined?(RubyVM::AbstractSyntaxTree)
 
         def test_dog_methods_not_dead
           file = require_unique_file
-          coverage = [nil, nil, 1, 1, 1, nil, nil]
+          coverage = [nil, nil, 1, 1, 1, nil, nil, 1, nil, 1, nil, nil]
           assert_empty(DeadMethods.scan(file_path: file, coverage: coverage))
         end
       end

--- a/test/coverband/utils/method_definition_scanner_test.rb
+++ b/test/coverband/utils/method_definition_scanner_test.rb
@@ -40,7 +40,7 @@ if defined?(RubyVM::AbstractSyntaxTree)
         def test_scan
           method_definitions = MethodDefinitionScanner.scan("./test/dog.rb")
           assert(method_definitions)
-          assert_equal(1, method_definitions.length)
+          assert_equal(3, method_definitions.length)
           method_definition = method_definitions.first # assert_equal(4, method.first_line)
           assert_equal(4, method_definition.first_line_number)
           assert_equal(6, method_definition.last_line_number)

--- a/test/dog.rb
+++ b/test/dog.rb
@@ -4,4 +4,9 @@ class Dog
   def bark
     "woof"
   end
+
+  def single_line; end # rubocop:disable Style
+
+  def empty
+  end
 end


### PR DESCRIPTION
Coverband is currently annoyingly marks single-line or empty methods as dead. I think, we can safely just ignore these.