### PR TITLE
Fix coverband:coverage_server rake task not being compatible with Rack 3 / Rackup

### DIFF
--- a/lib/coverband/utils/tasks.rb
+++ b/lib/coverband/utils/tasks.rb
@@ -113,7 +113,16 @@ namespace :coverband do
     if Coverband.configuration.store.is_a?(Coverband::Adapters::FileStore)
       Coverband.configuration.store.merge_mode = true
     end
-    Rack::Server.start app: Coverband::Reporters::Web.new,
+
+    begin
+      require 'rackup/server'
+      server_class = Rackup::Server
+    rescue LoadError
+      require 'rack/server'
+      server_class = Rack::Server
+    end
+
+    server_class.start app: Coverband::Reporters::Web.new,
       Port: ENV.fetch("COVERBAND_COVERAGE_PORT", 9022).to_i
   end
 


### PR DESCRIPTION
`Rack::Server` was extracted into a separate gem named `rackup`: https://github.com/rack/rack/pull/1937

In this gem, `Rack::Server` is now `Rackup::Server`, which breaks the `coverband:coverage_server` rake task: https://github.com/danmayer/coverband/blob/edd2a906e6f1f765e9cdb7c1ddac4d2ce884f28f/lib/coverband/utils/tasks.rb#L116

This makes the current version of coverband incompatible with applications that use Rack 3.  In addition to this fix, users must add `rackup` as a gem dependency if it's not already included in their gemset.

I've updated coverband to attempt to load either `rackup/server` or `rack/server`, preferring the former since this is what's expected for the latest version of Rack.

I wasn't sure what you might want to have in place in terms of tests, so that's a possible TODO here.