### PR TITLE
Make minor improvements to GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,17 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - run: bundle exec standardrb --format github
       - run: bundle exec rake
       - run: bundle exec rake forked_tests
       - run: bundle exec rake benchmarks
       - run: bundle exec rake benchmarks:memory
       - run: "RUBYOPT='--enable=frozen-string-literal --debug=frozen-string-literal' bundle exec rake"
+  starndardrb:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - run: bundle exec standardrb --format github

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,10 +37,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - run: bundle exec rake
-      - run: bundle exec rake forked_tests
-      - run: bundle exec rake benchmarks
-      - run: bundle exec rake benchmarks:memory
+      - run: bundle exec rake test:all
       - run: "RUBYOPT='--enable=frozen-string-literal --debug=frozen-string-literal' bundle exec rake"
   starndardrb:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - run: bundle exec standardrb
+      - run: bundle exec standardrb --format github
       - run: bundle exec rake
       - run: bundle exec rake forked_tests
       - run: bundle exec rake benchmarks


### PR DESCRIPTION
Make minor improvements to GitHub actions

- Update GitHub Actions workflow to use GitHub format for standardrb
  
![image](https://github.com/user-attachments/assets/d1ec2b43-4537-4977-af4c-216fac889d23)
- Ensure that the standardrb job is performed only once
  - This should only need to be done once, not for each matrix.
- Use rake test:all instead of `bundle exec rake bundle exec rake forked_tests bundle exec rake benchmarks bundle exec rake benchmarks:memory`