### PR TITLE
Add Coverband.track_key method

### DIFF
--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -100,6 +100,32 @@ module Coverband
     coverage_instance.runtime!
   end
 
+  # Track a key with the specified tracker.
+  # @param tracker_type [Symbol] The type of tracker to use (e.g., :view_tracker, :translations_tracker, :routes_tracker)
+  # @param key [String] The key to track
+  # @return [Boolean] True if tracking was successful, false otherwise
+  # @raise [ArgumentError] If the tracker_type is not supported
+  def self.track_key(tracker_type, key)
+    return false unless key
+    
+    supported_trackers = [:view_tracker, :translations_tracker, :routes_tracker]
+    
+    unless supported_trackers.include?(tracker_type)
+      raise ArgumentError, "Unsupported tracker type: #{tracker_type}. Must be one of: #{supported_trackers.join(', ')}"
+    end
+    
+    begin
+      tracker = configuration.send(tracker_type)
+      return false unless tracker && tracker.respond_to?(:track_key)
+
+      tracker.track_key(key)
+      true
+    rescue => e
+      configuration.logger.error "Coverband: Failed to track key '#{key}' with tracker '#{tracker_type}'. Error: #{e.message}"
+      false
+    end
+  end
+
   private_class_method def self.coverage_instance
     Coverband::Collectors::Coverage.instance
   end

--- a/test/coverband/track_key_test.rb
+++ b/test/coverband/track_key_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require File.expand_path("../test_helper", File.dirname(__FILE__))
+
+class TrackKeyTest < Minitest::Test
+  test "track_key accepts supported tracker types" do
+    mock_view_tracker = mock
+    mock_view_tracker.expects(:track_key).with("view/path/index.html.erb").returns(true)
+    Coverband.configuration.expects(:view_tracker).returns(mock_view_tracker)
+    
+    assert Coverband.track_key(:view_tracker, "view/path/index.html.erb")
+  end
+
+  test "track_key raises ArgumentError for unsupported tracker type" do
+    assert_raises ArgumentError do
+      Coverband.track_key(:unsupported_tracker, "some_key")
+    end
+  end
+
+  test "track_key returns false for nil key" do
+    assert_equal false, Coverband.track_key(:view_tracker, nil)
+  end
+
+  test "track_key handles missing trackers" do
+    Coverband.configuration.expects(:view_tracker).returns(nil)
+    
+    assert_equal false, Coverband.track_key(:view_tracker, "some_view")
+  end
+
+  test "track_key handles trackers without track_key method" do
+    mock_invalid_tracker = mock
+    mock_invalid_tracker.expects(:respond_to?).with(:track_key).returns(false)
+    Coverband.configuration.expects(:view_tracker).returns(mock_invalid_tracker)
+    
+    assert_equal false, Coverband.track_key(:view_tracker, "some_view")
+  end
+
+  test "track_key with translations_tracker" do
+    mock_translations_tracker = mock
+    mock_translations_tracker.expects(:track_key).with("translation.key").returns(true)
+    Coverband.configuration.expects(:translations_tracker).returns(mock_translations_tracker)
+    
+    assert Coverband.track_key(:translations_tracker, "translation.key")
+  end
+
+  test "track_key with routes_tracker" do
+    mock_routes_tracker = mock
+    mock_routes_tracker.expects(:track_key).with("index#show").returns(true)
+    Coverband.configuration.expects(:routes_tracker).returns(mock_routes_tracker)
+    
+    assert Coverband.track_key(:routes_tracker, "index#show")
+  end
+
+  test "track_key logs error when tracking fails" do
+    mock_logger = mock
+    mock_logger.expects(:error).with(regexp_matches(/Failed to track key/))
+    
+    mock_tracker = mock
+    mock_tracker.expects(:track_key).with("test_key").raises(StandardError.new("Test error"))
+    
+    Coverband.configuration.expects(:translations_tracker).returns(mock_tracker)
+    Coverband.configuration.expects(:logger).returns(mock_logger)
+    
+    assert_equal false, Coverband.track_key(:translations_tracker, "test_key")
+  end
+end


### PR DESCRIPTION
This adds a top-level method for manually tracking keys with supported trackers. It addresses GitHub issue #549 by providing a public API to track translation keys.

- Adds Coverband.track_key(tracker_type, key) method
- Validates tracker type (view_tracker, translations_tracker, routes_tracker)
- Includes comprehensive test coverage
- Handles error conditions gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)

---

Title: Add Coverband.track_key method

  Body:
  ## Summary
  - Adds `Coverband.track_key(tracker_type, key)` method for manually tracking keys with supported trackers
  - Addresses GitHub issue #549 by providing a public API to track translation keys from JavaScript

  ## Implementation Details
  - Supports `:view_tracker`, `:translations_tracker`, and `:routes_tracker` tracker types
  - Validates tracker type and raises ArgumentError for unsupported types
  - Includes comprehensive test coverage
  - Handles error conditions gracefully with appropriate logging

  ## Example Usage
  ```ruby
  # Track a translation key
  Coverband.track_key(:translations_tracker, "some.translation.key")

  # Track a view
  Coverband.track_key(:view_tracker, "app/views/posts/index.html.erb")

  # Track a route
  Coverband.track_key(:routes_tracker, "posts#index")

  Test Plan

  - Automated tests verify all supported tracker types work correctly
  - Error conditions are properly handled and tested
  - Tests pass with bundle exec ruby -I test test/coverband/track_key_test.rb

  Closes #549