### PR TITLE
Check for Rails::Engine

### DIFF
--- a/lib/coverband/utils/railtie.rb
+++ b/lib/coverband/utils/railtie.rb
@@ -7,7 +7,7 @@ module Coverband
       super
     end
   end
-  Rails::Engine.prepend(RailsEagerLoad)
+  Rails::Engine.prepend(RailsEagerLoad) if defined? ::Rails::Engine
 
   class Railtie < Rails::Railtie
     initializer "coverband.configure" do |app|


### PR DESCRIPTION
I'm using coverband with a Padrino app that uses some Rails related gems.  A recent, non-coverband, update caused coverband to start to raise an error on this line.  Even though coverband checks for `Rails::Railtie` before requiring this file, it seems my app does have `Rails::Railtie` but does not have `Rails::Engine`.  I've confirmed this check solves the problem for me.  I can use a fork in my app, although it seems like a safe check to have in the the main repo.

I have tested this with my app, as well as run the unit tests, and benchmarks included.  It seems like an innocuous change to me, as if `Rails::Engine` isn't defined this line cannot work, but certainly open to feedback on a better way to check this.