### PR TITLE
Use explicit paths and follow symlinks

### DIFF
--- a/lib/coverband/collectors/view_tracker.rb
+++ b/lib/coverband/collectors/view_tracker.rb
@@ -108,7 +108,7 @@ module Coverband
 
       def concrete_target
         if defined?(Rails.application)
-          Dir.glob("#{@project_directory}/**/app/{views,components}/**/*.html.{erb,haml,slim}")
+          Dir.glob("#{@project_directory}/{,packs,engines/*}/app/{views,components}/**/*.html.{erb,haml,slim}")
         else
           []
         end


### PR DESCRIPTION
Fixes the deteroration of performance reported here: https://github.com/danmayer/coverband/issues/596


In this PR,
- change from `**` to explicit paths so we don't end up traversing the whole codebase
- use the following folders for now: _no-folder_, `packs` and `engines`
- the additional `/*/` is used to follow symlink. Our engine folder is symlinked. This causes ruby to follow symlink and get the actual files.


Please guide me if I need to update any tests. I have tested it on our project and it seems to pick up all the views there. This fix has also returned the boot time for our application back to within normal parameters.