### PR TITLE
Add MCP server for AI assistant integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,129 @@ A few folks have asked about what size of Redis is needed to run Coverband. I ha
 
 # Newer Features
 
+### MCP Server for AI Assistants
+
+Coverband includes an optional MCP (Model Context Protocol) server that allows AI assistants like Claude to query your production coverage data directly. This enables AI-powered code analysis, dead code detection, and coverage insights.
+
+#### Installation
+
+Add the MCP gem to your Gemfile:
+
+```ruby
+gem 'mcp'
+```
+
+#### Available Tools
+
+The MCP server provides the following tools:
+
+| Tool | Description |
+|------|-------------|
+| `get_coverage_summary` | Get overall coverage statistics |
+| `get_file_coverage` | Get detailed coverage for a specific file |
+| `get_uncovered_files` | List files with no coverage data |
+| `get_dead_methods` | Find methods that are never called |
+| `get_view_tracker_data` | Get view/template usage data |
+| `get_route_tracker_data` | Get route usage statistics |
+| `get_translation_tracker_data` | Get translation key usage data |
+
+#### Running the MCP Server
+
+**Standalone (stdio transport):**
+
+```bash
+bundle exec coverband-mcp
+```
+
+**With a rake task:**
+
+```bash
+bundle exec rake coverband:mcp
+```
+
+**HTTP mode (for remote access):**
+
+```bash
+COVERBAND_MCP_HTTP=true COVERBAND_MCP_PORT=9023 bundle exec rake coverband:mcp
+```
+
+#### Configuring Claude Desktop
+
+Add to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+**Option 1: Stdio transport (recommended for local development)**
+
+```json
+{
+  "mcpServers": {
+    "coverband": {
+      "command": "bundle",
+      "args": ["exec", "coverband-mcp"],
+      "cwd": "/path/to/your/rails/app"
+    }
+  }
+}
+```
+
+**Option 2: HTTP transport (for remote access or shared servers)**
+
+First, start the MCP server in HTTP mode:
+
+```bash
+COVERBAND_MCP_HTTP=true bundle exec rake coverband:mcp
+```
+
+Then configure Claude Desktop to connect via `mcp-remote`:
+
+```json
+{
+  "mcpServers": {
+    "coverband": {
+      "command": "npx",
+      "args": ["mcp-remote", "http://localhost:9023"]
+    }
+  }
+}
+```
+
+#### Configuring Claude Code
+
+Add a `.mcp.json` file to your project root:
+
+**Option 1: Stdio transport (recommended)**
+
+```json
+{
+  "mcpServers": {
+    "coverband": {
+      "command": "bundle",
+      "args": ["exec", "coverband-mcp"]
+    }
+  }
+}
+```
+
+**Option 2: HTTP transport**
+
+```json
+{
+  "mcpServers": {
+    "coverband": {
+      "command": "npx",
+      "args": ["mcp-remote", "http://localhost:9023"]
+    }
+  }
+}
+```
+
+#### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `COVERBAND_MCP_HTTP` | Enable HTTP transport instead of stdio | `false` |
+| `COVERBAND_MCP_PORT` | Port for HTTP server | `9023` |
+| `COVERBAND_REDIS_URL` | Redis URL for coverage data | `localhost:6379` |
+
 ### Dead Method Scanning (ruby 2.6+)
 
 Rake task that outputs dead methods based on current coverage data:

--- a/bin/coverband-mcp
+++ b/bin/coverband-mcp
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "coverband/mcp"
+
+# Ensure Coverband is configured
+Coverband.configure unless Coverband.configured?
+
+# Start the MCP server with stdio transport
+server = Coverband::MCP::Server.new
+server.run_stdio

--- a/coverband.gemspec
+++ b/coverband.gemspec
@@ -56,6 +56,7 @@ Gem::Specification.new do |spec|
   # spec.add_development_dependency "minitest-profile"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "dalli" # Default memcached adapter
+  spec.add_development_dependency "mcp" # For MCP server support testing
 
   # TODO: Remove when other production adapters exist
   # because the default configuration of redis store, we really do require

--- a/lib/coverband/mcp.rb
+++ b/lib/coverband/mcp.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+begin
+  require "mcp"
+rescue LoadError
+  raise LoadError, <<~MSG
+    The 'mcp' gem is required for MCP server support.
+    Add `gem 'mcp'` to your Gemfile and run `bundle install`.
+  MSG
+end
+
+require "coverband"
+require "coverband/utils/html_formatter"
+require "coverband/utils/result"
+require "coverband/utils/file_list"
+require "coverband/utils/source_file"
+require "coverband/utils/lines_classifier"
+require "coverband/utils/results"
+require "coverband/reporters/json_report"
+
+# Load dead methods support if available
+if defined?(RubyVM::AbstractSyntaxTree)
+  require "coverband/utils/dead_methods"
+end
+
+require_relative "mcp/server"
+require_relative "mcp/http_handler"

--- a/lib/coverband/mcp/http_handler.rb
+++ b/lib/coverband/mcp/http_handler.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Coverband
+  module MCP
+    # Rack middleware that adds MCP HTTP endpoint support.
+    # Can be used to wrap the existing Coverband::Reporters::Web app
+    # or mounted standalone.
+    #
+    # Usage with existing web UI:
+    #   map "/coverage" do
+    #     run Coverband::MCP::HttpHandler.new(Coverband::Reporters::Web.new)
+    #   end
+    #   # MCP endpoint available at POST /coverage/mcp
+    #
+    # Usage standalone:
+    #   map "/mcp" do
+    #     run Coverband::MCP::HttpHandler.new
+    #   end
+    #
+    class HttpHandler
+      MCP_PATH = "/mcp"
+
+      def initialize(app = nil)
+        @app = app
+        @server = nil
+      end
+
+      def call(env)
+        request = Rack::Request.new(env)
+
+        if mcp_request?(request)
+          handle_mcp_request(request)
+        elsif @app
+          @app.call(env)
+        else
+          not_found_response
+        end
+      end
+
+      private
+
+      def mcp_request?(request)
+        request.post? && request.path_info.end_with?(MCP_PATH)
+      end
+
+      def handle_mcp_request(request)
+        body = request.body.read
+        json_request = JSON.parse(body)
+        response = mcp_server.handle_json(json_request)
+
+        [
+          200,
+          {
+            "content-type" => "application/json",
+            "access-control-allow-origin" => "*",
+            "access-control-allow-methods" => "POST, OPTIONS",
+            "access-control-allow-headers" => "Content-Type"
+          },
+          [response.to_json]
+        ]
+      rescue JSON::ParserError => e
+        error_response(400, "Invalid JSON: #{e.message}")
+      rescue => e
+        error_response(500, "Server error: #{e.message}")
+      end
+
+      def mcp_server
+        @server ||= Server.new
+      end
+
+      def error_response(status, message)
+        [
+          status,
+          {"content-type" => "application/json"},
+          [{error: message}.to_json]
+        ]
+      end
+
+      def not_found_response
+        [404, {"content-type" => "text/plain"}, ["Not Found"]]
+      end
+    end
+  end
+end

--- a/lib/coverband/mcp/server.rb
+++ b/lib/coverband/mcp/server.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require_relative "tools/get_coverage_summary"
+require_relative "tools/get_file_coverage"
+require_relative "tools/get_uncovered_files"
+require_relative "tools/get_dead_methods"
+require_relative "tools/get_view_tracker_data"
+require_relative "tools/get_route_tracker_data"
+require_relative "tools/get_translation_tracker_data"
+
+module Coverband
+  module MCP
+    class Server
+      attr_reader :mcp_server
+
+      DEFAULT_HTTP_PORT = 9023
+
+      def initialize
+        # Ensure Coverband is configured
+        Coverband.configure unless Coverband.configured?
+
+        @mcp_server = ::MCP::Server.new(
+          name: "coverband",
+          version: Coverband::VERSION,
+          instructions: "Coverband production code coverage MCP server. " \
+                        "Query coverage data, find dead code, and analyze view/route/translation usage.",
+          tools: tools
+        )
+      end
+
+      def run_stdio
+        transport = ::MCP::Server::Transports::StdioTransport.new(@mcp_server)
+        transport.open
+      end
+
+      def run_http(port: DEFAULT_HTTP_PORT, host: "localhost")
+        require "rack"
+        require "rackup"
+
+        transport = ::MCP::Server::Transports::StreamableHTTPTransport.new(@mcp_server)
+        @mcp_server.transport = transport
+
+        app = create_rack_app(transport)
+
+        puts <<~MESSAGE
+          === Coverband MCP Server (HTTP) ===
+
+          Server running at http://#{host}:#{port}
+
+          Available tools:
+            - get_coverage_summary
+            - get_file_coverage
+            - get_uncovered_files
+            - get_dead_methods
+            - get_view_tracker_data
+            - get_route_tracker_data
+            - get_translation_tracker_data
+
+          For Claude Desktop, configure with:
+            {
+              "mcpServers": {
+                "coverband": {
+                  "command": "npx",
+                  "args": ["mcp-remote", "http://#{host}:#{port}"]
+                }
+              }
+            }
+
+          Press Ctrl+C to stop the server
+        MESSAGE
+
+        Rackup::Handler.get("puma").run(app, Port: port, Host: host, Silent: true)
+      end
+
+      def handle_json(json_request)
+        @mcp_server.handle_json(json_request)
+      end
+
+      private
+
+      def create_rack_app(transport)
+        Rack::Builder.new do
+          use Rack::CommonLogger
+
+          run lambda { |env|
+            request = Rack::Request.new(env)
+            transport.handle_request(request)
+          }
+        end
+      end
+
+      def tools
+        [
+          Tools::GetCoverageSummary,
+          Tools::GetFileCoverage,
+          Tools::GetUncoveredFiles,
+          Tools::GetDeadMethods,
+          Tools::GetViewTrackerData,
+          Tools::GetRouteTrackerData,
+          Tools::GetTranslationTrackerData
+        ]
+      end
+    end
+  end
+end

--- a/lib/coverband/mcp/tools/get_coverage_summary.rb
+++ b/lib/coverband/mcp/tools/get_coverage_summary.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Coverband
+  module MCP
+    module Tools
+      class GetCoverageSummary < ::MCP::Tool
+        title "Get Coverage Summary"
+        description "Get overall production code coverage statistics including total files, " \
+                    "lines of code, lines covered, and coverage percentage."
+
+        input_schema(
+          type: "object",
+          properties: {},
+          required: []
+        )
+
+        def self.call(server_context:, **)
+          store = Coverband.configuration.store
+          report = Coverband::Reporters::JSONReport.new(store)
+          data = JSON.parse(report.report)
+
+          summary = {
+            total_files: data["total_files"],
+            lines_of_code: data["lines_of_code"],
+            lines_covered: data["lines_covered"],
+            lines_missed: data["lines_missed"],
+            covered_percent: data["covered_percent"],
+            covered_strength: data["covered_strength"]
+          }
+
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: JSON.pretty_generate(summary)
+          }])
+        rescue => e
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: "Error getting coverage summary: #{e.message}"
+          }], is_error: true)
+        end
+      end
+    end
+  end
+end

--- a/lib/coverband/mcp/tools/get_dead_methods.rb
+++ b/lib/coverband/mcp/tools/get_dead_methods.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Coverband
+  module MCP
+    module Tools
+      class GetDeadMethods < ::MCP::Tool
+        title "Get Dead Methods"
+        description "Analyze code coverage to find methods that have never been executed in production. " \
+                    "Requires Ruby 2.6+ with RubyVM::AbstractSyntaxTree support."
+
+        input_schema(
+          type: "object",
+          properties: {
+            file_pattern: {
+              type: "string",
+              description: "Optional glob pattern to filter files (e.g., 'app/models/**/*.rb')"
+            }
+          },
+          required: []
+        )
+
+        def self.call(file_pattern: nil, server_context:, **)
+          unless defined?(RubyVM::AbstractSyntaxTree)
+            return ::MCP::Tool::Response.new([{
+              type: "text",
+              text: "Dead method detection requires Ruby 2.6+ with RubyVM::AbstractSyntaxTree support."
+            }], is_error: true)
+          end
+
+          dead_methods = Coverband::Utils::DeadMethods.scan_all
+
+          if file_pattern
+            dead_methods = dead_methods.select do |method|
+              File.fnmatch(file_pattern, method[:file_path], File::FNM_PATHNAME)
+            end
+          end
+
+          # Group by file for easier reading
+          grouped = dead_methods.group_by { |m| m[:file_path] }
+
+          result = grouped.map do |file_path, methods|
+            {
+              file: file_path,
+              dead_methods: methods.map do |m|
+                {
+                  class_name: m[:class_name],
+                  method_name: m[:method_name],
+                  line_number: m[:line_number]
+                }
+              end
+            }
+          end
+
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: JSON.pretty_generate({
+              total_dead_methods: dead_methods.length,
+              files_with_dead_methods: grouped.keys.length,
+              file_pattern: file_pattern,
+              results: result
+            })
+          }])
+        rescue => e
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: "Error analyzing dead methods: #{e.message}"
+          }], is_error: true)
+        end
+      end
+    end
+  end
+end

--- a/lib/coverband/mcp/tools/get_file_coverage.rb
+++ b/lib/coverband/mcp/tools/get_file_coverage.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Coverband
+  module MCP
+    module Tools
+      class GetFileCoverage < ::MCP::Tool
+        title "Get File Coverage"
+        description "Get detailed line-by-line coverage data for a specific file. " \
+                    "Returns coverage percentage, lines covered/missed, and per-line hit counts."
+
+        input_schema(
+          type: "object",
+          properties: {
+            filename: {
+              type: "string",
+              description: "Full or partial path to the file (e.g., 'app/models/user.rb')"
+            }
+          },
+          required: ["filename"]
+        )
+
+        def self.call(filename:, server_context:, **)
+          store = Coverband.configuration.store
+          report = Coverband::Reporters::JSONReport.new(store, {
+            filename: filename,
+            line_coverage: true
+          })
+
+          data = JSON.parse(report.report)
+
+          if data["files"].nil? || data["files"].empty?
+            return ::MCP::Tool::Response.new([{
+              type: "text",
+              text: "No coverage data found for file: #{filename}"
+            }])
+          end
+
+          # Find matching file(s)
+          matching_files = data["files"].select { |path, _| path.include?(filename) }
+
+          if matching_files.empty?
+            return ::MCP::Tool::Response.new([{
+              type: "text",
+              text: "No coverage data found for file matching: #{filename}"
+            }])
+          end
+
+          result = matching_files.transform_values do |file_data|
+            {
+              filename: file_data["filename"],
+              covered_percent: file_data["covered_percent"],
+              lines_of_code: file_data["lines_of_code"],
+              lines_covered: file_data["lines_covered"],
+              lines_missed: file_data["lines_missed"],
+              runtime_percentage: file_data["runtime_percentage"],
+              never_loaded: file_data["never_loaded"],
+              coverage: file_data["coverage"]
+            }
+          end
+
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: JSON.pretty_generate(result)
+          }])
+        rescue => e
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: "Error getting file coverage: #{e.message}"
+          }], is_error: true)
+        end
+      end
+    end
+  end
+end

--- a/lib/coverband/mcp/tools/get_route_tracker_data.rb
+++ b/lib/coverband/mcp/tools/get_route_tracker_data.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Coverband
+  module MCP
+    module Tools
+      class GetRouteTrackerData < ::MCP::Tool
+        title "Get Route Tracker Data"
+        description "Get Rails route usage tracking data. Shows which routes have been hit " \
+                    "in production and which have never been accessed."
+
+        input_schema(
+          type: "object",
+          properties: {
+            show_unused_only: {
+              type: "boolean",
+              description: "Only return unused routes (default: false)"
+            }
+          },
+          required: []
+        )
+
+        def self.call(show_unused_only: false, server_context:, **)
+          tracker = Coverband.configuration.route_tracker
+
+          unless tracker
+            return ::MCP::Tool::Response.new([{
+              type: "text",
+              text: "Route tracking is not enabled. Enable it with `config.track_routes = true` in your coverband configuration."
+            }])
+          end
+
+          data = JSON.parse(tracker.as_json)
+
+          result = if show_unused_only
+            {
+              tracking_since: tracker.tracking_since,
+              unused_routes: data["unused_keys"],
+              total_unused: data["unused_keys"]&.length || 0
+            }
+          else
+            {
+              tracking_since: tracker.tracking_since,
+              used_routes: data["used_keys"],
+              unused_routes: data["unused_keys"],
+              total_used: data["used_keys"]&.length || 0,
+              total_unused: data["unused_keys"]&.length || 0
+            }
+          end
+
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: JSON.pretty_generate(result)
+          }])
+        rescue => e
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: "Error getting route tracker data: #{e.message}"
+          }], is_error: true)
+        end
+      end
+    end
+  end
+end

--- a/lib/coverband/mcp/tools/get_translation_tracker_data.rb
+++ b/lib/coverband/mcp/tools/get_translation_tracker_data.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Coverband
+  module MCP
+    module Tools
+      class GetTranslationTrackerData < ::MCP::Tool
+        title "Get Translation Tracker Data"
+        description "Get i18n translation key usage tracking data. Shows which translation keys " \
+                    "have been used in production and which have never been accessed."
+
+        input_schema(
+          type: "object",
+          properties: {
+            show_unused_only: {
+              type: "boolean",
+              description: "Only return unused translation keys (default: false)"
+            }
+          },
+          required: []
+        )
+
+        def self.call(show_unused_only: false, server_context:, **)
+          tracker = Coverband.configuration.translations_tracker
+
+          unless tracker
+            return ::MCP::Tool::Response.new([{
+              type: "text",
+              text: "Translation tracking is not enabled. Enable it with `config.track_translations = true` in your coverband configuration."
+            }])
+          end
+
+          data = JSON.parse(tracker.as_json)
+
+          result = if show_unused_only
+            {
+              tracking_since: tracker.tracking_since,
+              unused_translations: data["unused_keys"],
+              total_unused: data["unused_keys"]&.length || 0
+            }
+          else
+            {
+              tracking_since: tracker.tracking_since,
+              used_translations: data["used_keys"],
+              unused_translations: data["unused_keys"],
+              total_used: data["used_keys"]&.length || 0,
+              total_unused: data["unused_keys"]&.length || 0
+            }
+          end
+
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: JSON.pretty_generate(result)
+          }])
+        rescue => e
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: "Error getting translation tracker data: #{e.message}"
+          }], is_error: true)
+        end
+      end
+    end
+  end
+end

--- a/lib/coverband/mcp/tools/get_uncovered_files.rb
+++ b/lib/coverband/mcp/tools/get_uncovered_files.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Coverband
+  module MCP
+    module Tools
+      class GetUncoveredFiles < ::MCP::Tool
+        title "Get Uncovered Files"
+        description "Get files with coverage below a specified threshold. " \
+                    "Useful for finding code that may need more production testing or could be dead code."
+
+        input_schema(
+          type: "object",
+          properties: {
+            threshold: {
+              type: "number",
+              description: "Coverage percentage threshold (default: 50). Files below this are returned."
+            },
+            include_never_loaded: {
+              type: "boolean",
+              description: "Include files that were never loaded in production (default: true)"
+            }
+          },
+          required: []
+        )
+
+        def self.call(threshold: 50, include_never_loaded: true, server_context:, **)
+          store = Coverband.configuration.store
+          report = Coverband::Reporters::JSONReport.new(store, line_coverage: false)
+          data = JSON.parse(report.report)
+
+          files = data["files"] || {}
+
+          uncovered = files.select do |_path, file_data|
+            percent = file_data["covered_percent"] || 0
+            never_loaded = file_data["never_loaded"]
+
+            if include_never_loaded
+              percent < threshold || never_loaded
+            else
+              percent < threshold && !never_loaded
+            end
+          end
+
+          # Sort by coverage percentage ascending (least covered first)
+          sorted = uncovered.sort_by { |_path, data| data["covered_percent"] || 0 }
+
+          result = sorted.map do |path, file_data|
+            {
+              file: path,
+              covered_percent: file_data["covered_percent"],
+              lines_of_code: file_data["lines_of_code"],
+              lines_covered: file_data["lines_covered"],
+              lines_missed: file_data["lines_missed"],
+              never_loaded: file_data["never_loaded"]
+            }
+          end
+
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: JSON.pretty_generate({
+              threshold: threshold,
+              include_never_loaded: include_never_loaded,
+              total_uncovered_files: result.length,
+              files: result
+            })
+          }])
+        rescue => e
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: "Error getting uncovered files: #{e.message}"
+          }], is_error: true)
+        end
+      end
+    end
+  end
+end

--- a/lib/coverband/mcp/tools/get_view_tracker_data.rb
+++ b/lib/coverband/mcp/tools/get_view_tracker_data.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Coverband
+  module MCP
+    module Tools
+      class GetViewTrackerData < ::MCP::Tool
+        title "Get View Tracker Data"
+        description "Get view file usage tracking data. Shows which view templates (ERB, Haml, Slim) " \
+                    "have been rendered in production and which have never been used."
+
+        input_schema(
+          type: "object",
+          properties: {
+            show_unused_only: {
+              type: "boolean",
+              description: "Only return unused views (default: false)"
+            }
+          },
+          required: []
+        )
+
+        def self.call(show_unused_only: false, server_context:, **)
+          tracker = Coverband.configuration.view_tracker
+
+          unless tracker
+            return ::MCP::Tool::Response.new([{
+              type: "text",
+              text: "View tracking is not enabled. Enable it with `config.track_views = true` in your coverband configuration."
+            }])
+          end
+
+          data = JSON.parse(tracker.as_json)
+
+          result = if show_unused_only
+            {
+              tracking_since: tracker.tracking_since,
+              unused_views: data["unused_keys"],
+              total_unused: data["unused_keys"]&.length || 0
+            }
+          else
+            {
+              tracking_since: tracker.tracking_since,
+              used_views: data["used_keys"],
+              unused_views: data["unused_keys"],
+              total_used: data["used_keys"]&.length || 0,
+              total_unused: data["unused_keys"]&.length || 0
+            }
+          end
+
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: JSON.pretty_generate(result)
+          }])
+        rescue => e
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: "Error getting view tracker data: #{e.message}"
+          }], is_error: true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

  This PR adds an optional MCP (Model Context Protocol) server that allows AI assistants like Claude to query Coverband's production coverage data directly. This enables AI-powered code analysis, dead code detection, and coverage insights without leaving the development environment.

  ## Features

  - **7 MCP tools** for querying coverage data:
    - `get_coverage_summary` - Overall coverage statistics
    - `get_file_coverage` - Detailed line-by-line coverage for specific files
    - `get_uncovered_files` - List files with no coverage data
    - `get_dead_methods` - Find methods that are never called
    - `get_view_tracker_data` - View/template usage data
    - `get_route_tracker_data` - Route usage statistics
    - `get_translation_tracker_data` - Translation key usage data

  - **Two transport modes:**
    - Stdio (default) - For local development with Claude Desktop/Claude Code
    - HTTP with Streamable HTTP transport - For remote access or shared servers

  - **Standalone executable:** `bin/coverband-mcp`
  - **Rake task:** `bundle exec rake coverband:mcp`

  ## Usage

  Add `gem 'mcp'` to your Gemfile, then run:

  ```bash
  # Stdio mode (default)
  bundle exec coverband-mcp

  # HTTP mode
  COVERBAND_MCP_HTTP=true bundle exec rake coverband:mcp
```

  Dependencies

  - Requires the mcp gem (optional dependency, not auto-required)
  - HTTP mode additionally requires rack and rackup

  Documentation

  Full documentation added to README including configuration example for Claude Code.