### PR TITLE
Add line_coverage param to /json endpoint

### DIFF
--- a/lib/coverband/reporters/web.rb
+++ b/lib/coverband/reporters/web.rb
@@ -125,7 +125,10 @@ module Coverband
       end
 
       def json
-        Coverband::Reporters::JSONReport.new(Coverband.configuration.store).report
+        Coverband::Reporters::JSONReport.new(
+          Coverband.configuration.store,
+          line_coverage: request.params["line_coverage"] == "true"
+        ).report
       end
 
       def report_json

--- a/test/coverband/reporters/web_test.rb
+++ b/test/coverband/reporters/web_test.rb
@@ -40,6 +40,11 @@ module Coverband
       post "/clear"
       assert_equal 302, last_response.status
     end
+
+    test "json endpoint accepts line_coverage parameter" do
+      get "/json?line_coverage=true"
+      assert last_response.ok?
+    end
   end
 end
 


### PR DESCRIPTION
## Summary

Add `line_coverage=true` query parameter to `/json` endpoint.

## Motivation

`JSONReport` already supports the `line_coverage` option, but it's not
accessible via HTTP. This enables AI coding assistants (like Claude Code)
and other external tools to analyze line-level coverage data programmatically.

## Usage

GET /coverage/json?line_coverage=true