### PR TITLE
Optimize result duplication in storage adapters

### DIFF
--- a/lib/coverband/adapters/file_store.rb
+++ b/lib/coverband/adapters/file_store.rb
@@ -65,8 +65,7 @@ module Coverband
       end
 
       def save_report(report)
-        data = report.dup
-        data = merge_reports(data, coverage)
+        data = merge_reports(report, coverage)
         File.write(path, JSON.dump(data))
       end
 

--- a/lib/coverband/adapters/redis_store.rb
+++ b/lib/coverband/adapters/redis_store.rb
@@ -63,8 +63,7 @@ module Coverband
       # the Coverband 2 had the same issue,
       # and the tradeoff has always been acceptable
       def save_report(report)
-        data = report.dup
-        data = merge_reports(data, coverage(nil, skip_hash_check: true))
+        data = merge_reports(report, coverage(nil, skip_hash_check: true))
         save_coverage(data)
       end
 

--- a/lib/coverband/adapters/web_service_store.rb
+++ b/lib/coverband/adapters/web_service_store.rb
@@ -66,10 +66,9 @@ module Coverband
         # We set here vs initialize to avoid setting on the primary process vs child processes
         @pid ||= ::Process.pid
 
-        # TODO: do we need dup
         # TODO: we don't need upstream timestamps, server will track first_seen
         Thread.new do
-          data = expand_report(report.dup)
+          data = expand_report(report)
           full_package = {
             collection_type: "coverage_delta",
             collection_data: {


### PR DESCRIPTION
Optimize memory usage by removing redundant `dup` calls in storage adapters.

The original task pointed to `lib/coverband/utils/result.rb`, but verification confirmed that `Coverband::Utils::Result.add_not_loaded_files` is already optimized and modifies the result in-place without `dup`.

Further analysis revealed that `RedisStore`, `FileStore`, and `WebServiceStore` were unnecessarily duplicating the `report` hash before processing it. The `merge_reports` and `expand_report` methods create new hash structures, so the initial `dup` is redundant and wastes memory. These calls have been removed.

---
*PR created automatically by Jules for task [17703321544784342160](https://jules.google.com/task/17703321544784342160) started by @danmayer*