### PR TITLE
⚡ Optimize FileList#first_seen_at to eliminate allocations

### DIFF
--- a/lib/coverband/utils/file_list.rb
+++ b/lib/coverband/utils/file_list.rb
@@ -74,10 +74,13 @@ module Coverband
       end
 
       def first_seen_at
-        filter_map { |f|
+        min = nil
+        each do |f|
           val = f.first_updated_at
-          val unless val.is_a?(String)
-        }.min
+          next if val.is_a?(String)
+          min = val if min.nil? || val < min
+        end
+        min
       end
     end
   end

--- a/test/benchmarks/benchmark_file_list.rb
+++ b/test/benchmarks/benchmark_file_list.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "benchmark/ips"
+require "memory_profiler"
+
+# Mock SourceFile
+class MockSourceFile
+  attr_reader :first_updated_at
+
+  def initialize(first_updated_at)
+    @first_updated_at = first_updated_at
+  end
+end
+
+class FileList < Array
+  def first_seen_at_current
+    filter_map { |f|
+      val = f.first_updated_at
+      val unless val.is_a?(String)
+    }.min
+  end
+
+  def first_seen_at_original
+    map(&:first_updated_at).reject { |el| el.is_a?(String) }.min
+  end
+
+  def first_seen_at_each
+    min = nil
+    each do |f|
+      val = f.first_updated_at
+      next if val.is_a?(String)
+      min = val if min.nil? || val < min
+    end
+    min
+  end
+end
+
+# Generate data: 10,000 files
+files_mixed = Array.new(10000) { |i|
+  val = (i % 5 == 0) ? "not available" : (Time.now - i)
+  MockSourceFile.new(val)
+}
+list_mixed = FileList.new(files_mixed)
+
+puts "---------------------------------------------------"
+puts "Memory Profiling: FileList#first_seen_at"
+
+puts "\nOriginal (map+reject):"
+report = MemoryProfiler.report { list_mixed.first_seen_at_original }
+puts "  Total allocated: #{report.total_allocated_memsize} bytes (#{report.total_allocated} objects)"
+
+puts "\nCurrent (filter_map):"
+report = MemoryProfiler.report { list_mixed.first_seen_at_current }
+puts "  Total allocated: #{report.total_allocated_memsize} bytes (#{report.total_allocated} objects)"
+
+puts "\nOptimized (each):"
+report = MemoryProfiler.report { list_mixed.first_seen_at_each }
+puts "  Total allocated: #{report.total_allocated_memsize} bytes (#{report.total_allocated} objects)"


### PR DESCRIPTION
💡 **What:** Replaced the `filter_map` implementation in `Coverband::Utils::FileList#first_seen_at` with an imperative `each` loop to find the minimum `first_updated_at` timestamp.

🎯 **Why:** The previous implementation (and the one suggested in the task description) allocated intermediate arrays. Even `filter_map`, while efficient, creates a new array. By using `each` and tracking the minimum value manually, we eliminate these allocations entirely.

📊 **Measured Improvement:**
Benchmark results for 10,000 files:
*   **Original (`map` + `reject`)**: ~169 KB allocated
*   **Previous (`filter_map`)**: ~89 KB allocated
*   **New (`each`)**: **0 bytes allocated**

CPU performance is comparable (slightly faster in some runs, but within margin of error). This change significantly reduces memory pressure for large file lists.

---
*PR created automatically by Jules for task [3731001549367096294](https://jules.google.com/task/3731001549367096294) started by @danmayer*