### PR TITLE
Skip missing files in dead method scans

### DIFF
--- a/lib/coverband/utils/dead_methods.rb
+++ b/lib/coverband/utils/dead_methods.rb
@@ -43,7 +43,11 @@ module Coverband
         # and runtime phases.
         coverage = Coverband.configuration.store.get_coverage_report[Coverband::MERGED_TYPE]
         coverage.flat_map do |file_path, coverage|
+          next [] unless File.exist?(file_path)
+
           scan(file_path: file_path, coverage: coverage["data"])
+        rescue Errno::ENOENT
+          []
         end
       end
 

--- a/test/coverband/utils/dead_methods_test.rb
+++ b/test/coverband/utils/dead_methods_test.rb
@@ -48,6 +48,26 @@ if defined?(RubyVM::AbstractSyntaxTree)
           assert_equal(6, dead_method.last_line_number)
         end
 
+        def test_scan_all_skips_missing_files
+          missing_file = "./test/fixtures/missing_file.rb"
+          existing_file = "./test/dog.rb"
+          coverage_report = {
+            Coverband::MERGED_TYPE => {
+              missing_file => { "data" => [] },
+              existing_file => { "data" => [] }
+            }
+          }
+          dead_method = Object.new
+
+          Coverband.configuration.stubs(:store).returns(
+            stub(get_coverage_report: coverage_report)
+          )
+          DeadMethods.expects(:scan).with(file_path: existing_file, coverage: []).returns([dead_method])
+          DeadMethods.expects(:scan).with(file_path: missing_file, coverage: []).never
+
+          assert_equal [dead_method], DeadMethods.scan_all
+        end
+
         def test_output_all
           require_unique_file
           @coverband.report_coverage


### PR DESCRIPTION
## Summary
- skip missing files during `Coverband::Utils::DeadMethods.scan_all`
- rescue `Errno::ENOENT` so one stale coverage path does not abort the entire dead-method run
- add a regression test covering a missing file alongside a valid file

## Why
Coverband dead-method scans currently trust every file path in the persisted coverage report. If one of those stored paths points at a file that no longer exists, `scan_all` aborts instead of returning results for the remaining files.

This shows up especially clearly through MCP `get_dead_methods`, where a single stale path prevents any dead-method response from being returned.

## Testing
- `docker run --rm -v /private/tmp/coverband-upstream.bEzwtd/repo:/repo -w /repo ruby:3.3 bash -lc 'apt-get update >/tmp/apt.log && apt-get install -y redis-server >/tmp/redis-install.log && redis-server --daemonize yes && bundle install --jobs 4 --retry 2 >/tmp/bundle.log && bundle exec ruby -Itest test/coverband/utils/dead_methods_test.rb'`

Closes #630
