### PR TITLE
Fix MCP dead method formatting

### DIFF
--- a/lib/coverband/mcp/tools/get_dead_methods.rb
+++ b/lib/coverband/mcp/tools/get_dead_methods.rb
@@ -28,21 +28,21 @@ module Coverband
 
           if file_pattern
             dead_methods = dead_methods.select do |method|
-              File.fnmatch(file_pattern, method[:file_path], File::FNM_PATHNAME)
+              File.fnmatch(file_pattern, method.file_path, File::FNM_PATHNAME)
             end
           end
 
           # Group by file for easier reading
-          grouped = dead_methods.group_by { |m| m[:file_path] }
+          grouped = dead_methods.group_by(&:file_path)
 
           result = grouped.map do |file_path, methods|
             {
               file: file_path,
               dead_methods: methods.map do |m|
                 {
-                  class_name: m[:class_name],
-                  method_name: m[:method_name],
-                  line_number: m[:line_number]
+                  class_name: m.class_name,
+                  method_name: m.name,
+                  line_number: m.first_line_number
                 }
               end
             }

--- a/test/coverband/mcp/tools/get_dead_methods_test.rb
+++ b/test/coverband/mcp/tools/get_dead_methods_test.rb
@@ -10,6 +10,16 @@ end
 
 if defined?(Coverband::MCP)
   class GetDeadMethodsTest < Minitest::Test
+    def build_dead_method(file_path:, class_name:, method_name:, line_number:)
+      Coverband::Utils::MethodDefinitionScanner::MethodDefinition.new(
+        first_line_number: line_number,
+        last_line_number: line_number,
+        name: method_name,
+        class_name: class_name,
+        file_path: file_path
+      )
+    end
+
     def setup
       super
       Coverband.configure do |config|
@@ -35,24 +45,24 @@ if defined?(Coverband::MCP)
     if defined?(RubyVM::AbstractSyntaxTree)
       test "call returns dead methods when AST support available" do
         mock_dead_methods = [
-          {
+          build_dead_method(
             file_path: "/app/models/user.rb",
             class_name: "User",
             method_name: "unused_method",
             line_number: 10
-          },
-          {
+          ),
+          build_dead_method(
             file_path: "/app/models/user.rb",
             class_name: "User",
             method_name: "another_unused",
             line_number: 15
-          },
-          {
+          ),
+          build_dead_method(
             file_path: "/app/models/order.rb",
             class_name: "Order",
             method_name: "dead_method",
             line_number: 20
-          }
+          )
         ]
 
         Coverband::Utils::DeadMethods.expects(:scan_all).returns(mock_dead_methods)
@@ -83,18 +93,18 @@ if defined?(Coverband::MCP)
 
       test "call filters by file_pattern when provided" do
         mock_dead_methods = [
-          {
+          build_dead_method(
             file_path: "/app/models/user.rb",
             class_name: "User",
             method_name: "unused_method",
             line_number: 10
-          },
-          {
+          ),
+          build_dead_method(
             file_path: "/app/helpers/user_helper.rb",
             class_name: "UserHelper",
             method_name: "dead_helper",
             line_number: 5
-          }
+          )
         ]
 
         Coverband::Utils::DeadMethods.expects(:scan_all).returns(mock_dead_methods)


### PR DESCRIPTION
## Summary
- format `get_dead_methods` results using the `MethodDefinition` reader methods returned by `DeadMethods.scan_all`
- update the MCP tool tests to use real `MethodDefinition` objects instead of hash-shaped doubles

## Why
`Coverband::Utils::DeadMethods.scan_all` returns `Coverband::Utils::MethodDefinitionScanner::MethodDefinition` objects.

But `Coverband::MCP::Tools::GetDeadMethods` currently formats those results as if each entry were a hash, using lookups like:
- `m[:file_path]`
- `m[:method_name]`
- `m[:line_number]`

That causes the MCP tool to fail with:

```text
undefined method `[]' for an instance of Coverband::Utils::MethodDefinitionScanner::MethodDefinition
```

This patch switches the formatter to use the object's actual API:
- `file_path`
- `class_name`
- `name`
- `first_line_number`

## Testing
- `docker run --rm -v /private/tmp/coverband-upstream.bEzwtd/repo:/repo -w /repo ruby:3.3 bash -lc 'apt-get update >/tmp/apt.log && apt-get install -y redis-server >/tmp/redis-install.log && redis-server --daemonize yes && bundle install --jobs 4 --retry 2 >/tmp/bundle.log && bundle exec ruby -Itest test/coverband/mcp/tools/get_dead_methods_test.rb'`

Closes #631
