### PR TITLE
Fix: use empty string in Rack::Static urls instead of incorrect usage

### DIFF
--- a/lib/coverband/reporters/web.rb
+++ b/lib/coverband/reporters/web.rb
@@ -32,9 +32,9 @@ module Coverband
 
       def init_web
         full_path = Gem::Specification.find_by_name("coverband").full_gem_path
-        @static = Rack::Static.new(self,
-          root: File.expand_path("public", full_path),
-          urls: [/.*\.css/, /.*\.js/, /.*\.gif/, /.*\.png/])
+        @file_server = Rack::Files.new(
+          File.expand_path("public", full_path)
+        )
       end
 
       def check_auth
@@ -85,7 +85,7 @@ module Coverband
           else
             case request_path_info
             when /.*\.(css|js|gif|png)/
-              @static.call(env)
+              @file_server.get(env)
             when %r{/settings}
               [200, coverband_headers, [settings]]
             when %r{/view_tracker_data}

--- a/test/coverband/reporters/web_test.rb
+++ b/test/coverband/reporters/web_test.rb
@@ -45,6 +45,16 @@ module Coverband
       get "/json?line_coverage=true"
       assert last_response.ok?
     end
+
+    test "renders static files" do
+      get "/application.js"
+      assert last_response.ok?
+    end
+
+    test "renders 404 if static file doesn't exist" do
+      get "/unknown.js"
+      assert last_response.not_found?
+    end
   end
 end
 

--- a/test/coverband/utils/dead_methods_test.rb
+++ b/test/coverband/utils/dead_methods_test.rb
@@ -53,8 +53,8 @@ if defined?(RubyVM::AbstractSyntaxTree)
           existing_file = "./test/dog.rb"
           coverage_report = {
             Coverband::MERGED_TYPE => {
-              missing_file => { "data" => [] },
-              existing_file => { "data" => [] }
+              missing_file => {"data" => []},
+              existing_file => {"data" => []}
             }
           }
           dead_method = Object.new


### PR DESCRIPTION
The usage of providing non-string values in the urls array was incorrect. related: 
We need to merge this PR before we can use a version that includes the Rack security patch. https://github.com/rack/rack/commit/6d434bbccdc2ffc3086dbce3930c3816945a35ec

`Rack::Static` expects urls to be an array of strings, but coverband was using it incorrectly.