### PR TITLE
Fix concrete_target glob to match packwerk pack directories

### DIFF
--- a/lib/coverband/collectors/view_tracker.rb
+++ b/lib/coverband/collectors/view_tracker.rb
@@ -126,7 +126,7 @@ module Coverband
 
       def concrete_target
         if defined?(Rails.application)
-          Dir.glob("#{@project_directory}/{,packs,engines/*}/app/{views,components}/**/*.html.{erb,haml,slim}")
+          Dir.glob("#{@project_directory}/{,packs/*,engines/*}/app/{views,components}/**/*.html.{erb,haml,slim}")
         else
           []
         end


### PR DESCRIPTION
Commit 329fa632 changed the ViewTracker glob from `**` to explicit paths `{,packs,engines/*}` to avoid traversing the entire project tree. However, `packs` only matches `packs/app/views/...`, not the standard packwerk structure of `packs/*/app/views/...`, causing concrete_target to return 0 results for packwerk-based apps.