### PR TITLE
Add ViewComponent render tracking to ViewTracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,20 @@ This feature is enabled by default. To stop this feature, disable the feature in
 
 `config.track_views = false`
 
+#### ViewComponent Support
+
+Coverband can also track [ViewComponent](https://viewcomponent.org/) renders. This requires:
+
+- ViewComponent **>= 4.6.0**
+- Instrumentation enabled in your app config:
+
+```ruby
+# config/application.rb (or environment-specific config)
+config.view_component.instrumentation_enabled = true
+```
+
+When enabled, Coverband subscribes to the `render.view_component` notification and tracks which component templates are rendered, just like standard Rails views.
+
 ![image](https://raw.github.com/danmayer/coverband/main/docs/coverband_view_tracker.png)
 
 ### Hiding settings

--- a/lib/coverband/collectors/view_tracker.rb
+++ b/lib/coverband/collectors/view_tracker.rb
@@ -33,6 +33,13 @@ module Coverband
         ActiveSupport::Notifications.subscribe(/render_(template|partial|collection).action_view/) do |name, start, finish, id, payload|
           Coverband.configuration.view_tracker.track_key(payload) unless name.include?("!")
         end
+
+        # ViewComponent >= 4.6.0 emits render.view_component with a view_identifier key
+        # containing the template path. Requires config.view_component.instrumentation_enabled = true
+        # in the host app.
+        ActiveSupport::Notifications.subscribe("render.view_component") do |name, start, finish, id, payload|
+          Coverband.configuration.view_tracker.track_key(identifier: payload[:view_identifier]) unless name.include?("!")
+        end
       end
 
       ###

--- a/test/coverband/collectors/view_tracker_test.rb
+++ b/test/coverband/collectors/view_tracker_test.rb
@@ -107,6 +107,19 @@ class ViewTrackerTest < Minitest::Test
     assert_equal [], tracker.used_keys.keys
   end
 
+  test "track view_component renders via railtie" do
+    Coverband::Collectors::ViewTracker.expects(:supported_version?).returns(true)
+    store = fake_store
+    file_path = "#{File.expand_path(Coverband.configuration.root)}/app/components/example_component.html.erb"
+    tracker = Coverband::Collectors::ViewTracker.new(store: store, roots: "dir")
+    Coverband.configuration.expects(:view_tracker).returns(tracker).at_least_once
+    tracker.railtie!
+
+    ActiveSupport::Notifications.instrument("render.view_component", view_identifier: file_path)
+
+    assert_includes tracker.logged_keys, file_path
+  end
+
   test "reset store" do
     Coverband::Collectors::ViewTracker.expects(:supported_version?).returns(true)
     store = fake_store


### PR DESCRIPTION
This is a followup on the conversation on #591. The solution is now possible, since https://github.com/ViewComponent/view_component/pull/2572 was merged

Subscribe to render.view_component notifications in ViewTracker#railtie! so that ViewComponent template renders are tracked alongside standard Rails view renders. The ViewComponent payload uses view_identifier (not identifier) for the template path, so the subscription maps it accordingly.

Requires ViewComponent >= 4.6.0 (which added view_identifier to the payload) and config.view_component.instrumentation_enabled = true in the host app.

Also updated the tests and docs.