### PR TITLE
feat: dead-code review session (hide/mark files & folders, CSV export) in the web report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ test/unique_files
 test/rails7_dummy/tmp
 CLAUDE.md
 .claude/
+scratch/

--- a/README.md
+++ b/README.md
@@ -366,6 +366,16 @@ You can disable the settings view like so:
 
 `config.hide_settings = true`
 
+### Dead-code review session
+
+The web report includes a client-side "dead-code session" toolbar to help drive code-removal work:
+
+- Hide files or whole folders from the report via the ✕ icon that appears when hovering path segments, or hide everything with runtime % > 0 with one toggle.
+- Mark files or folders for deletion via the 🗑 icon (with an optional comment). Marked items disappear from the view and are listed in the "Marked for deletion" modal.
+- Export the marked list as a CSV (`path,comment,marked_at`) to feed a code-removal PR process.
+
+Session state lives in your browser's localStorage: "Reset session" clears the hidden set; "Start over" (in the modal) clears the marked list.
+
 ### Fixing Coverage Only Shows Loading Hits
 
 If all your coverage is being counted as loading or eager_loading coverage, and nothing is showing as runtime Coverage the initialization hook failed for some reason. The most likely reason for this issue is manually calling `eager_load!` on some Plugin/Gem. If you or a plugin is altering the Rails initialization process, you can manually flip Coverband to runtime coverage by calling these two lines, in an `after_initialize` block, in `application.rb`.

--- a/public/application.css
+++ b/public/application.css
@@ -867,3 +867,12 @@ td:has(> span.green) {
   background-color: #fbf0c0; }
 .source_table .skipped:nth-child(even) {
   background-color: #fbffcf; }
+
+/* Dead-code review session */
+#dcs-toolbar { margin: 8px 0 12px 0; padding: 8px 10px; background: #f4f4f4; border: 1px solid #ddd; border-radius: 4px; font-size: 0.85em; }
+#dcs-toolbar label { margin: 0 10px; cursor: pointer; }
+#dcs-toolbar button { margin: 0 4px; cursor: pointer; }
+.dcs-badge { background: #666; color: #fff; border-radius: 8px; padding: 1px 8px; margin: 0 6px; }
+#dcs-chips { margin-top: 6px; display: none; }
+.dcs-chip { display: inline-block; background: #e8e8e8; border: 1px solid #ccc; border-radius: 10px; padding: 1px 6px; margin: 2px; font-family: monospace; }
+.dcs-chip-x { border: none; background: transparent; cursor: pointer; font-weight: bold; margin-left: 4px; }

--- a/public/application.css
+++ b/public/application.css
@@ -876,3 +876,8 @@ td:has(> span.green) {
 #dcs-chips { margin-top: 6px; display: none; }
 .dcs-chip { display: inline-block; background: #e8e8e8; border: 1px solid #ccc; border-radius: 10px; padding: 1px 6px; margin: 2px; font-family: monospace; }
 .dcs-chip-x { border: none; background: transparent; cursor: pointer; font-weight: bold; margin-left: 4px; }
+.dcs-seg { position: relative; }
+.dcs-actions { display: none; white-space: nowrap; }
+.dcs-seg:hover > .dcs-actions { display: inline; }
+.dcs-actions button { border: none; background: #ddd; border-radius: 3px; cursor: pointer; font-size: 0.85em; padding: 0 3px; margin-left: 2px; line-height: 1.2; }
+.dcs-actions button:hover { background: #bbb; }

--- a/public/application.css
+++ b/public/application.css
@@ -881,3 +881,16 @@ td:has(> span.green) {
 .dcs-seg:hover > .dcs-actions { display: inline; }
 .dcs-actions button { border: none; background: #ddd; border-radius: 3px; cursor: pointer; font-size: 0.85em; padding: 0 3px; margin-left: 2px; line-height: 1.2; }
 .dcs-actions button:hover { background: #bbb; }
+#dcs-mark-popup { position: absolute; z-index: 10000; background: #fff; border: 1px solid #999; border-radius: 4px; box-shadow: 0 2px 8px rgba(0,0,0,0.3); padding: 10px; width: 320px; }
+#dcs-mark-popup .dcs-popup-path { font-family: monospace; font-weight: bold; margin-bottom: 6px; word-break: break-all; }
+#dcs-mark-popup textarea { width: 100%; box-sizing: border-box; }
+#dcs-mark-popup .dcs-popup-actions { margin-top: 6px; text-align: right; }
+#dcs-modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 10001; }
+#dcs-modal { background: #fff; border-radius: 6px; width: 80%; max-width: 900px; max-height: 80%; overflow: auto; margin: 5% auto; padding: 16px; }
+#dcs-modal-head { display: flex; justify-content: space-between; margin-bottom: 10px; }
+#dcs-modal-table { width: 100%; border-collapse: collapse; }
+#dcs-modal-table th, #dcs-modal-table td { border-bottom: 1px solid #eee; padding: 4px 8px; text-align: left; }
+#dcs-modal-foot { margin-top: 12px; text-align: right; }
+#dcs-modal-foot button { margin-left: 8px; }
+.dcs-mono { font-family: monospace; }
+.dcs-comment-edit { width: 100%; box-sizing: border-box; }

--- a/public/application.js
+++ b/public/application.js
@@ -344,6 +344,38 @@ $(document).ready(function () {
       updateBadges();
     };
 
+    function escapeHtml(s) {
+      return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+    }
+
+    window.deadCodeDecorate = function (oSettings) {
+      $(oSettings.nTable).find("tbody td a.src_link").not(".dcs-done").each(function () {
+        var link = $(this);
+        var fullPath = link.attr("title");
+        if (!fullPath) return;
+        var segs = D.segmentPrefixes(fullPath);
+        var html = "";
+        for (var i = 0; i < segs.length; i++) {
+          html += '<span class="dcs-seg" data-prefix="' + escapeHtml(segs[i].prefix) + '">' +
+            escapeHtml(segs[i].label) +
+            '<span class="dcs-actions">' +
+            '<button type="button" class="dcs-hide" title="Hide ' + escapeHtml(segs[i].prefix) + (segs[i].isFile ? "" : " and everything under it") + '">&times;</button>' +
+            '<button type="button" class="dcs-mark" title="Mark ' + escapeHtml(segs[i].prefix) + ' for deletion">&#128465;</button>' +
+            '</span></span>' + (segs[i].isFile ? "" : "/");
+        }
+        link.html(html).addClass("dcs-done");
+      });
+    };
+
+    $(document).on("click", ".dcs-hide", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      D.addHidden(state, $(this).closest(".dcs-seg").attr("data-prefix"));
+      saveState();
+      redrawTables();
+      return false;
+    });
+
     redrawTables();
   }
 });

--- a/public/application.js
+++ b/public/application.js
@@ -376,6 +376,104 @@ $(document).ready(function () {
       return false;
     });
 
+    function closeMarkPopup() { $("#dcs-mark-popup").remove(); }
+
+    function openMarkPopup(prefix, x, y) {
+      closeMarkPopup();
+      var popup = $(
+        '<div id="dcs-mark-popup">' +
+        '  <div class="dcs-popup-path"></div>' +
+        '  <textarea id="dcs-mark-comment" rows="2" placeholder="Optional comment (why is this dead?)"></textarea>' +
+        '  <div class="dcs-popup-actions">' +
+        '    <button type="button" id="dcs-mark-confirm">Mark for deletion</button>' +
+        '    <button type="button" id="dcs-mark-cancel">Cancel</button>' +
+        '  </div>' +
+        '</div>'
+      );
+      popup.find(".dcs-popup-path").text(prefix);
+      popup.css({ left: Math.min(x, $(window).width() - 340) + "px", top: (y + 8) + "px" });
+      $("body").append(popup);
+      $("#dcs-mark-comment").focus();
+      $("#dcs-mark-cancel").on("click", closeMarkPopup);
+      $("#dcs-mark-confirm").on("click", function () {
+        D.addMark(state, prefix, $("#dcs-mark-comment").val(), new Date().toISOString());
+        saveState();
+        closeMarkPopup();
+        redrawTables();
+      });
+    }
+
+    $(document).on("click", ".dcs-mark", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      openMarkPopup($(this).closest(".dcs-seg").attr("data-prefix"), e.pageX, e.pageY);
+      return false;
+    });
+
+    function closeMarkedModal() { $("#dcs-modal-overlay").remove(); }
+
+    function downloadCSV() {
+      var blob = new Blob([D.toCSV(state.markedPaths)], { type: "text/csv;charset=utf-8" });
+      var a = document.createElement("a");
+      a.href = URL.createObjectURL(blob);
+      a.download = "coverband-dead-code-" + new Date().toISOString().slice(0, 10) + ".csv";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(a.href);
+    }
+
+    function openMarkedModal() {
+      closeMarkedModal();
+      var overlay = $('<div id="dcs-modal-overlay"><div id="dcs-modal">' +
+        '<div id="dcs-modal-head"><strong>Marked for deletion</strong>' +
+        '<button type="button" id="dcs-modal-close">&times;</button></div>' +
+        '<table id="dcs-modal-table"><thead><tr>' +
+        '<th>Path</th><th>Comment</th><th>Marked at</th><th></th>' +
+        '</tr></thead><tbody></tbody></table>' +
+        '<div id="dcs-modal-foot">' +
+        '<button type="button" id="dcs-csv">Download CSV</button>' +
+        '<button type="button" id="dcs-start-over">Start over</button>' +
+        '</div></div></div>');
+      var tbody = overlay.find("tbody");
+      if (state.markedPaths.length === 0) {
+        tbody.append('<tr><td colspan="4"><em>Nothing marked yet.</em></td></tr>');
+      }
+      $.each(state.markedPaths.slice(), function (_i, m) {
+        var tr = $("<tr></tr>");
+        $('<td class="dcs-mono"></td>').text(m.path).appendTo(tr);
+        var commentInput = $('<input type="text" class="dcs-comment-edit">').val(m.comment)
+          .on("change", function () {
+            D.updateComment(state, m.path, $(this).val());
+            saveState();
+          });
+        $("<td></td>").append(commentInput).appendTo(tr);
+        $('<td class="dcs-mono"></td>').text(m.markedAt).appendTo(tr);
+        $("<td></td>").append(
+          $('<button type="button" title="Unmark">&times;</button>').on("click", function () {
+            D.removeMark(state, m.path);
+            saveState();
+            redrawTables();
+            openMarkedModal(); // rebuild
+          })
+        ).appendTo(tr);
+        tbody.append(tr);
+      });
+      $("body").append(overlay);
+      $("#dcs-modal-close").on("click", closeMarkedModal);
+      overlay.on("click", function (e) { if (e.target === this) closeMarkedModal(); });
+      $("#dcs-csv").on("click", downloadCSV);
+      $("#dcs-start-over").on("click", function () {
+        if (!confirm("Clear the entire marked-for-deletion list?")) return;
+        D.clearMarks(state);
+        saveState();
+        redrawTables();
+        openMarkedModal();
+      });
+    }
+
+    $("#dcs-marked-btn").on("click", openMarkedModal);
+
     redrawTables();
   }
 });

--- a/public/application.js
+++ b/public/application.js
@@ -272,10 +272,11 @@ $(document).ready(function () {
 
     function updateBadges() {
       var hidden = 0;
+      var stateNoMarks = { hiddenPaths: state.hiddenPaths, markedPaths: [], hideRuntimeUsed: state.hideRuntimeUsed };
       $(".file_list").each(function () {
         var data = $(this).dataTable().fnGetData();
         for (var i = 0; i < data.length; i++) {
-          if (D.isExcluded(state, extractPath(data[i][0]), rowRuntime(data[i]))) hidden++;
+          if (D.isExcluded(stateNoMarks, extractPath(data[i][0]), rowRuntime(data[i]))) hidden++;
         }
       });
       $("#dcs-hidden-count").text(hidden + " hidden");
@@ -364,17 +365,23 @@ $(document).ready(function () {
             '</span></span>' + (segs[i].isFile ? "" : "/");
         }
         link.html(html).addClass("dcs-done");
+
+        link.find(".dcs-hide").on("click", function (e) {
+          e.preventDefault();
+          e.stopPropagation();
+          D.addHidden(state, $(this).closest(".dcs-seg").attr("data-prefix"));
+          saveState();
+          redrawTables();
+          return false;
+        });
+        link.find(".dcs-mark").on("click", function (e) {
+          e.preventDefault();
+          e.stopPropagation();
+          openMarkPopup($(this).closest(".dcs-seg").attr("data-prefix"), e.pageX, e.pageY);
+          return false;
+        });
       });
     };
-
-    $(document).on("click", ".dcs-hide", function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      D.addHidden(state, $(this).closest(".dcs-seg").attr("data-prefix"));
-      saveState();
-      redrawTables();
-      return false;
-    });
 
     function closeMarkPopup() { $("#dcs-mark-popup").remove(); }
 
@@ -402,13 +409,6 @@ $(document).ready(function () {
         redrawTables();
       });
     }
-
-    $(document).on("click", ".dcs-mark", function (e) {
-      e.preventDefault();
-      e.stopPropagation();
-      openMarkPopup($(this).closest(".dcs-seg").attr("data-prefix"), e.pageX, e.pageY);
-      return false;
-    });
 
     function closeMarkedModal() { $("#dcs-modal-overlay").remove(); }
 

--- a/public/application.js
+++ b/public/application.js
@@ -33,7 +33,13 @@ $(document).ready(function () {
     ],
   }
 
+  tableOptions.fnDrawCallback = function (oSettings) {
+    if (window.deadCodeOnDraw) window.deadCodeOnDraw(oSettings);
+  };
+
   $(".file_list").dataTable(tableOptions);
+
+  initDeadCodeSession();
 
   // TODO: add support for searching on server side
   // best docs on our version of datatables 1.7 https://datatables.net/beta/1.7/examples/server_side/server_side.html
@@ -220,4 +226,124 @@ $(document).ready(function () {
   $("#loading").fadeOut();
   $("#wrapper").show();
   $(".dataTables_filter input").focus();
+
+  function initDeadCodeSession() {
+    if (!window.CoverbandDeadCode || !$(".file_list").length) return;
+    var D = window.CoverbandDeadCode;
+    var storageKey = "coverband_deadcode_session:" + ($(".file_list").data("coverageurl") || "/");
+    var state;
+    try {
+      state = D.parseState(window.localStorage.getItem(storageKey));
+    } catch (e) {
+      console && console.warn && console.warn("coverband dead-code session: localStorage unavailable", e);
+      state = D.emptyState();
+    }
+    if (!state.startedAt) state.startedAt = new Date().toISOString();
+
+    function saveState() {
+      try {
+        window.localStorage.setItem(storageKey, JSON.stringify(state));
+      } catch (e) { /* private mode etc.; session still works in-memory */ }
+    }
+    saveState();
+
+    function extractPath(cellHtml) {
+      var m = String(cellHtml).match(/title="([^"]*)"/);
+      return m ? m[1] : "";
+    }
+
+    function rowRuntime(aData) {
+      var n = parseFloat(String(aData[2]));
+      return isNaN(n) ? null : n;
+    }
+
+    // Custom filter: hide rows excluded by the session (DataTables 1.7 API)
+    $.fn.dataTableExt.afnFiltering.push(function (oSettings, aData, iDataIndex) {
+      if (!$(oSettings.nTable).hasClass("file_list")) return true;
+      return !D.isExcluded(state, extractPath(aData[0]), rowRuntime(aData));
+    });
+
+    function redrawTables() {
+      $(".file_list").each(function () {
+        $(this).dataTable().fnDraw();
+      });
+      updateBadges();
+    }
+
+    function updateBadges() {
+      var hidden = 0;
+      $(".file_list").each(function () {
+        var data = $(this).dataTable().fnGetData();
+        for (var i = 0; i < data.length; i++) {
+          if (D.isExcluded(state, extractPath(data[i][0]), rowRuntime(data[i]))) hidden++;
+        }
+      });
+      $("#dcs-hidden-count").text(hidden + " hidden");
+      $("#dcs-marked-count").text(state.markedPaths.length);
+      var chips = $("#dcs-chips").empty();
+      $.each(state.hiddenPaths, function (_i, entry) {
+        var chip = $('<span class="dcs-chip"></span>').text(entry);
+        $('<button class="dcs-chip-x" title="Unhide">&times;</button>')
+          .appendTo(chip)
+          .on("click", function () {
+            D.removeHidden(state, entry);
+            saveState();
+            redrawTables();
+          });
+        chips.append(chip);
+      });
+      chips.toggle(state.hiddenPaths.length > 0 && chips.data("open") === true);
+      $("#dcs-chips-toggle").toggle(state.hiddenPaths.length > 0)
+        .text("Hidden items (" + state.hiddenPaths.length + ")");
+    }
+
+    // Toolbar
+    var toolbar = $(
+      '<div id="dcs-toolbar">' +
+      '  <strong>Dead-code session</strong>' +
+      '  <label><input type="checkbox" id="dcs-runtime-toggle"> Hide files with runtime % &gt; 0</label>' +
+      '  <span class="dcs-badge" id="dcs-hidden-count">0 hidden</span>' +
+      '  <button type="button" id="dcs-marked-btn">Marked for deletion: <span id="dcs-marked-count">0</span></button>' +
+      '  <button type="button" id="dcs-chips-toggle">Hidden items</button>' +
+      '  <button type="button" id="dcs-reset">Reset session</button>' +
+      '  <div id="dcs-chips"></div>' +
+      '</div>'
+    );
+    $("#content").prepend(toolbar);
+
+    $("#dcs-runtime-toggle")
+      .prop("checked", state.hideRuntimeUsed)
+      .on("change", function () {
+        state.hideRuntimeUsed = this.checked;
+        saveState();
+        redrawTables();
+      });
+
+    $("#dcs-chips-toggle").on("click", function () {
+      var chips = $("#dcs-chips");
+      chips.data("open", chips.data("open") !== true);
+      updateBadges();
+    });
+
+    $("#dcs-reset").on("click", function () {
+      if (!confirm("Reset session? This unhides everything (marked-for-deletion list is kept).")) return;
+      window.CoverbandDeadCode.clearHides(state);
+      $("#dcs-runtime-toggle").prop("checked", false);
+      saveState();
+      redrawTables();
+    });
+
+    // Exposed for Tasks 3-4 and the shared fnDrawCallback
+    window.deadCodeSession = {
+      D: D, state: state, saveState: saveState,
+      redrawTables: redrawTables, updateBadges: updateBadges,
+      extractPath: extractPath
+    };
+    window.deadCodeOnDraw = function (oSettings) {
+      if (window.deadCodeDecorate) window.deadCodeDecorate(oSettings);
+      updateBadges();
+    };
+
+    redrawTables();
+  }
 });

--- a/public/application.js
+++ b/public/application.js
@@ -286,7 +286,7 @@ $(document).ready(function () {
         var chip = $('<span class="dcs-chip"></span>').text(entry);
         $('<button class="dcs-chip-x" title="Unhide">&times;</button>')
           .appendTo(chip)
-          .on("click", function () {
+          .bind("click", function () {
             D.removeHidden(state, entry);
             saveState();
             redrawTables();
@@ -314,19 +314,19 @@ $(document).ready(function () {
 
     $("#dcs-runtime-toggle")
       .prop("checked", state.hideRuntimeUsed)
-      .on("change", function () {
+      .bind("change", function () {
         state.hideRuntimeUsed = this.checked;
         saveState();
         redrawTables();
       });
 
-    $("#dcs-chips-toggle").on("click", function () {
+    $("#dcs-chips-toggle").bind("click", function () {
       var chips = $("#dcs-chips");
       chips.data("open", chips.data("open") !== true);
       updateBadges();
     });
 
-    $("#dcs-reset").on("click", function () {
+    $("#dcs-reset").bind("click", function () {
       if (!confirm("Reset session? This unhides everything (marked-for-deletion list is kept).")) return;
       window.CoverbandDeadCode.clearHides(state);
       $("#dcs-runtime-toggle").prop("checked", false);
@@ -366,7 +366,7 @@ $(document).ready(function () {
         }
         link.html(html).addClass("dcs-done");
 
-        link.find(".dcs-hide").on("click", function (e) {
+        link.find(".dcs-hide").bind("click", function (e) {
           e.preventDefault();
           e.stopPropagation();
           D.addHidden(state, $(this).closest(".dcs-seg").attr("data-prefix"));
@@ -374,7 +374,7 @@ $(document).ready(function () {
           redrawTables();
           return false;
         });
-        link.find(".dcs-mark").on("click", function (e) {
+        link.find(".dcs-mark").bind("click", function (e) {
           e.preventDefault();
           e.stopPropagation();
           openMarkPopup($(this).closest(".dcs-seg").attr("data-prefix"), e.pageX, e.pageY);
@@ -401,8 +401,8 @@ $(document).ready(function () {
       popup.css({ left: Math.min(x, $(window).width() - 340) + "px", top: (y + 8) + "px" });
       $("body").append(popup);
       $("#dcs-mark-comment").focus();
-      $("#dcs-mark-cancel").on("click", closeMarkPopup);
-      $("#dcs-mark-confirm").on("click", function () {
+      $("#dcs-mark-cancel").bind("click", closeMarkPopup);
+      $("#dcs-mark-confirm").bind("click", function () {
         D.addMark(state, prefix, $("#dcs-mark-comment").val(), new Date().toISOString());
         saveState();
         closeMarkPopup();
@@ -443,14 +443,14 @@ $(document).ready(function () {
         var tr = $("<tr></tr>");
         $('<td class="dcs-mono"></td>').text(m.path).appendTo(tr);
         var commentInput = $('<input type="text" class="dcs-comment-edit">').val(m.comment)
-          .on("change", function () {
+          .bind("change", function () {
             D.updateComment(state, m.path, $(this).val());
             saveState();
           });
         $("<td></td>").append(commentInput).appendTo(tr);
         $('<td class="dcs-mono"></td>').text(m.markedAt).appendTo(tr);
         $("<td></td>").append(
-          $('<button type="button" title="Unmark">&times;</button>').on("click", function () {
+          $('<button type="button" title="Unmark">&times;</button>').bind("click", function () {
             D.removeMark(state, m.path);
             saveState();
             redrawTables();
@@ -460,10 +460,10 @@ $(document).ready(function () {
         tbody.append(tr);
       });
       $("body").append(overlay);
-      $("#dcs-modal-close").on("click", closeMarkedModal);
-      overlay.on("click", function (e) { if (e.target === this) closeMarkedModal(); });
-      $("#dcs-csv").on("click", downloadCSV);
-      $("#dcs-start-over").on("click", function () {
+      $("#dcs-modal-close").bind("click", closeMarkedModal);
+      overlay.bind("click", function (e) { if (e.target === this) closeMarkedModal(); });
+      $("#dcs-csv").bind("click", downloadCSV);
+      $("#dcs-start-over").bind("click", function () {
         if (!confirm("Clear the entire marked-for-deletion list?")) return;
         D.clearMarks(state);
         saveState();
@@ -472,7 +472,7 @@ $(document).ready(function () {
       });
     }
 
-    $("#dcs-marked-btn").on("click", openMarkedModal);
+    $("#dcs-marked-btn").bind("click", openMarkedModal);
 
     redrawTables();
   }

--- a/public/dead_code_session.js
+++ b/public/dead_code_session.js
@@ -1,0 +1,143 @@
+// Pure logic for the dead-code review session. Loaded in the browser as
+// window.CoverbandDeadCode and in Node (tests) via require.
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    root.CoverbandDeadCode = factory();
+  }
+})(typeof self !== "undefined" ? self : this, function () {
+  function emptyState() {
+    return { hiddenPaths: [], markedPaths: [], hideRuntimeUsed: false, startedAt: null };
+  }
+
+  function parseState(json) {
+    var raw;
+    try { raw = JSON.parse(json); } catch (e) { raw = null; }
+    var state = emptyState();
+    if (!raw || typeof raw !== "object") return state;
+    if (Object.prototype.toString.call(raw.hiddenPaths) === "[object Array]") {
+      state.hiddenPaths = raw.hiddenPaths.filter(function (p) {
+        return typeof p === "string" && p.length > 0;
+      });
+    }
+    if (Object.prototype.toString.call(raw.markedPaths) === "[object Array]") {
+      state.markedPaths = raw.markedPaths.filter(function (m) {
+        return m && typeof m.path === "string" && m.path.length > 0;
+      }).map(function (m) {
+        return {
+          path: m.path,
+          comment: typeof m.comment === "string" ? m.comment : "",
+          markedAt: typeof m.markedAt === "string" ? m.markedAt : ""
+        };
+      });
+    }
+    state.hideRuntimeUsed = raw.hideRuntimeUsed === true;
+    state.startedAt = typeof raw.startedAt === "string" ? raw.startedAt : null;
+    return state;
+  }
+
+  function pathMatches(entry, path) {
+    if (entry.charAt(entry.length - 1) === "/") return path.indexOf(entry) === 0;
+    return path === entry;
+  }
+
+  function matchesAny(entries, path) {
+    for (var i = 0; i < entries.length; i++) {
+      if (pathMatches(entries[i], path)) return true;
+    }
+    return false;
+  }
+
+  function isMarked(state, path) {
+    for (var i = 0; i < state.markedPaths.length; i++) {
+      if (pathMatches(state.markedPaths[i].path, path)) return true;
+    }
+    return false;
+  }
+
+  function isExcluded(state, path, runtimePercent) {
+    if (matchesAny(state.hiddenPaths, path)) return true;
+    if (isMarked(state, path)) return true;
+    if (state.hideRuntimeUsed && typeof runtimePercent === "number" && runtimePercent > 0) return true;
+    return false;
+  }
+
+  function addHidden(state, entry) {
+    if (state.hiddenPaths.indexOf(entry) === -1) state.hiddenPaths.push(entry);
+  }
+
+  function removeHidden(state, entry) {
+    var i = state.hiddenPaths.indexOf(entry);
+    if (i !== -1) state.hiddenPaths.splice(i, 1);
+  }
+
+  function clearHides(state) {
+    state.hiddenPaths = [];
+    state.hideRuntimeUsed = false;
+  }
+
+  function addMark(state, path, comment, markedAt) {
+    removeMark(state, path);
+    state.markedPaths.push({ path: path, comment: comment || "", markedAt: markedAt || "" });
+  }
+
+  function removeMark(state, path) {
+    for (var i = state.markedPaths.length - 1; i >= 0; i--) {
+      if (state.markedPaths[i].path === path) state.markedPaths.splice(i, 1);
+    }
+  }
+
+  function updateComment(state, path, comment) {
+    for (var i = 0; i < state.markedPaths.length; i++) {
+      if (state.markedPaths[i].path === path) state.markedPaths[i].comment = comment;
+    }
+  }
+
+  function clearMarks(state) {
+    state.markedPaths = [];
+  }
+
+  function csvField(value) {
+    var s = String(value == null ? "" : value);
+    if (/[",\n\r]/.test(s)) return '"' + s.replace(/"/g, '""') + '"';
+    return s;
+  }
+
+  function toCSV(markedPaths) {
+    var lines = ["path,comment,marked_at"];
+    for (var i = 0; i < markedPaths.length; i++) {
+      var m = markedPaths[i];
+      lines.push([csvField(m.path), csvField(m.comment), csvField(m.markedAt)].join(","));
+    }
+    return lines.join("\r\n") + "\r\n";
+  }
+
+  function segmentPrefixes(path) {
+    var parts = path.split("/");
+    var out = [];
+    var prefix = "";
+    for (var i = 0; i < parts.length; i++) {
+      var isFile = i === parts.length - 1;
+      prefix += parts[i] + (isFile ? "" : "/");
+      out.push({ label: parts[i], prefix: prefix, isFile: isFile });
+    }
+    return out;
+  }
+
+  return {
+    emptyState: emptyState,
+    parseState: parseState,
+    pathMatches: pathMatches,
+    isExcluded: isExcluded,
+    addHidden: addHidden,
+    removeHidden: removeHidden,
+    clearHides: clearHides,
+    addMark: addMark,
+    removeMark: removeMark,
+    updateComment: updateComment,
+    clearMarks: clearMarks,
+    toCSV: toCSV,
+    segmentPrefixes: segmentPrefixes
+  };
+});

--- a/test/javascript/dead_code_session.test.mjs
+++ b/test/javascript/dead_code_session.test.mjs
@@ -1,0 +1,90 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const D = require("../../public/dead_code_session.js");
+
+test("parseState returns empty state on garbage", () => {
+  assert.deepEqual(D.parseState(null), D.emptyState());
+  assert.deepEqual(D.parseState("{not json"), D.emptyState());
+  assert.deepEqual(D.parseState('{"hiddenPaths": "nope"}').hiddenPaths, []);
+});
+
+test("parseState keeps valid entries and normalizes marks", () => {
+  const s = D.parseState(JSON.stringify({
+    hiddenPaths: ["app/", 5, "lib/foo.rb"],
+    markedPaths: [{ path: "old/" }, { nope: true }],
+    hideRuntimeUsed: true
+  }));
+  assert.deepEqual(s.hiddenPaths, ["app/", "lib/foo.rb"]);
+  assert.deepEqual(s.markedPaths, [{ path: "old/", comment: "", markedAt: "" }]);
+  assert.equal(s.hideRuntimeUsed, true);
+});
+
+test("pathMatches: folder prefix vs exact file", () => {
+  assert.ok(D.pathMatches("app/models/", "app/models/foo.rb"));
+  assert.ok(!D.pathMatches("app/models/", "app/models2/foo.rb"));
+  assert.ok(D.pathMatches("app/foo.rb", "app/foo.rb"));
+  assert.ok(!D.pathMatches("app/foo.rb", "app/foo.rb.bak"));
+});
+
+test("isExcluded combines hides, marks, and runtime rule", () => {
+  const s = D.emptyState();
+  D.addHidden(s, "app/hidden/");
+  D.addMark(s, "lib/dead.rb", "bye", "2026-08-07T00:00:00Z");
+  assert.ok(D.isExcluded(s, "app/hidden/x.rb", 0));
+  assert.ok(D.isExcluded(s, "lib/dead.rb", 0));
+  assert.ok(!D.isExcluded(s, "app/live.rb", 12.5));
+  s.hideRuntimeUsed = true;
+  assert.ok(D.isExcluded(s, "app/live.rb", 12.5));
+  assert.ok(!D.isExcluded(s, "app/unused.rb", 0));
+  assert.ok(!D.isExcluded(s, "app/unknown.rb", null));
+});
+
+test("addHidden dedupes; removeHidden removes; clearHides resets toggle", () => {
+  const s = D.emptyState();
+  D.addHidden(s, "app/");
+  D.addHidden(s, "app/");
+  assert.deepEqual(s.hiddenPaths, ["app/"]);
+  D.removeHidden(s, "app/");
+  assert.deepEqual(s.hiddenPaths, []);
+  s.hideRuntimeUsed = true;
+  D.addHidden(s, "x.rb");
+  D.clearHides(s);
+  assert.deepEqual(s.hiddenPaths, []);
+  assert.equal(s.hideRuntimeUsed, false);
+});
+
+test("addMark replaces same path; updateComment; removeMark; clearMarks", () => {
+  const s = D.emptyState();
+  D.addMark(s, "a.rb", "one", "t1");
+  D.addMark(s, "a.rb", "two", "t2");
+  assert.deepEqual(s.markedPaths, [{ path: "a.rb", comment: "two", markedAt: "t2" }]);
+  D.updateComment(s, "a.rb", "three");
+  assert.equal(s.markedPaths[0].comment, "three");
+  D.removeMark(s, "a.rb");
+  assert.deepEqual(s.markedPaths, []);
+  D.addMark(s, "b.rb", "", "t");
+  D.clearMarks(s);
+  assert.deepEqual(s.markedPaths, []);
+});
+
+test("toCSV escapes per RFC 4180", () => {
+  const csv = D.toCSV([
+    { path: "app/a.rb", comment: 'has "quotes", commas\nand newline', markedAt: "2026-08-07T01:02:03Z" },
+    { path: "lib/", comment: "", markedAt: "" }
+  ]);
+  assert.equal(csv,
+    'path,comment,marked_at\r\n' +
+    'app/a.rb,"has ""quotes"", commas\nand newline",2026-08-07T01:02:03Z\r\n' +
+    'lib/,,\r\n');
+});
+
+test("segmentPrefixes splits path into cumulative prefixes", () => {
+  assert.deepEqual(D.segmentPrefixes("app/models/foo.rb"), [
+    { label: "app", prefix: "app/", isFile: false },
+    { label: "models", prefix: "app/models/", isFile: false },
+    { label: "foo.rb", prefix: "app/models/foo.rb", isFile: true }
+  ]);
+  assert.deepEqual(D.segmentPrefixes("foo.rb"), [{ label: "foo.rb", prefix: "foo.rb", isFile: true }]);
+});

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -4,6 +4,7 @@
     <title>Coverband: <%= Coverband::VERSION %></title>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <script src='<%= assets_path('dependencies.js') %>' type='text/javascript'></script>
+    <script src='<%= assets_path('dead_code_session.js') %>' type='text/javascript'></script>
     <script src='<%= assets_path('application.js') %>' type='text/javascript'></script>
     <link href='<%= assets_path('application.css') %>' media='screen, projection, print' rel='stylesheet' type='text/css'>
     <link rel="shortcut icon" type="image/png" href="<%= assets_path("favicon_#{coverage_css_class(result.source_files.covered_percent)}.png") %>" />


### PR DESCRIPTION
## What

Adds a client-side **"dead-code review session"** to the web report to help drive code-removal work:

- **Hide** files or whole folders from the report via a small ✕ icon that appears when hovering any path segment (VS Code find-results style), or hide everything with runtime % > 0 with one toolbar toggle
- **Mark for deletion**: a 🗑 icon per path segment opens a small popup with an optional comment; marked entries disappear from the view
- **Marked-for-deletion modal**: lists marks with inline-editable comments, per-row unmark, **Download CSV** (`path,comment,marked_at`, RFC-4180) to feed an out-of-band code-removal process, and a "Start over" reset
- Session state lives in the browser's localStorage — no server/storage changes; "Reset session" (hides) and "Start over" (marks) are independent

## How

Entirely client-side and dependency-free:

- `public/dead_code_session.js` — new pure-logic module (state, prefix matching, CSV escaping), UMD-wrapped so it's unit-tested with `node --test test/javascript/` (8 tests, no new dev deps)
- `public/application.js` — toolbar injection, a `$.fn.dataTableExt.afnFiltering` filter, row decoration via `fnDrawCallback` (covers both ERB-rendered and paged `report_json` rows), popup/modal
- `views/layout.erb` — one script tag
- Written against the bundled jQuery 1.6.2 / DataTables 1.7 APIs (`.bind`, `fnDraw`, etc.)

## Testing

- `node --test test/javascript/` — 8/8 pass
- Manually verified against a seeded `Coverband::Reporters::Web` rackup app: hide/unhide, runtime toggle persistence across reloads, mark→modal→CSV round-trip, and that sorting/search/source popups (colorbox) still work
- No Ruby behavior changes; existing suite unaffected

Happy to adjust naming/UX or split the PR if you'd prefer smaller pieces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
