### PR TITLE
fix: scope ruby-head memory leak check to coverband-only retention

### DIFF
--- a/test/benchmarks/benchmark.rake
+++ b/test/benchmarks/benchmark.rake
@@ -173,12 +173,18 @@ namespace :benchmarks do
     }.pretty_print
     data = $stdout.string
     $stdout = previous_out
-    unless data.match?("Total retained:  0 bytes")
-      puts data
-      raise "leaking memory!!!"
-    end
+    assert_no_coverband_leak(data)
   ensure
     $stdout = previous_out
+  end
+
+  # Check only that coverband itself retains no objects.
+  # External gems (json, redis-client) may retain strings via internal
+  # deduplication caches in newer Ruby versions — that is not a coverband leak.
+  def assert_no_coverband_leak(data)
+    return unless data.match(/retained objects by gem(.*)retained objects by file/m)&.[](0)&.match?(/coverband/)
+    puts data
+    raise "leaking memory!!!"
   end
 
   def measure_memory_report_coverage
@@ -216,13 +222,7 @@ namespace :benchmarks do
     }.pretty_print
     data = $stdout.string
     $stdout = previous_out
-    # Check only that coverband itself retains no objects.
-    # External gems (json, redis-client) may retain strings via internal
-    # deduplication caches in newer Ruby versions — that is not a coverband leak.
-    if data.match(/retained objects by gem(.*)retained objects by file/m)&.[](0)&.match?(/coverband/)
-      puts data
-      raise "leaking memory!!!"
-    end
+    assert_no_coverband_leak(data)
   ensure
     $stdout = previous_out
   end

--- a/test/coverband/benchmarks/benchmark_memory_leak_check_test.rb
+++ b/test/coverband/benchmarks/benchmark_memory_leak_check_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../test_helper", File.dirname(__FILE__))
+require "rake"
+
+load File.expand_path("../../benchmarks/benchmark.rake", File.dirname(__FILE__)) unless respond_to?(:assert_no_coverband_leak, true)
+
+class BenchmarkMemoryLeakCheckTest < Minitest::Test
+  def test_raises_when_coverband_retains_objects
+    data = <<~REPORT
+      retained objects by gem
+      -----------------------------------
+               1  coverband
+
+      retained objects by file
+      -----------------------------------
+    REPORT
+
+    error = assert_raises(RuntimeError) { send(:assert_no_coverband_leak, data) }
+    assert_equal "leaking memory!!!", error.message
+  end
+
+  # Regression test for https://github.com/danmayer/coverband/pull/647 CI failures:
+  # newer Ruby/json versions retain a small internal string-dedup cache that is not
+  # a Coverband leak, so it must not trip the check.
+  def test_does_not_raise_when_only_external_gems_retain_memory
+    data = <<~REPORT
+      retained objects by gem
+      -----------------------------------
+               7  json-2.21.2
+               1  redis-client-0.30.1
+
+      retained objects by file
+      -----------------------------------
+    REPORT
+
+    send(:assert_no_coverband_leak, data)
+  end
+
+  def test_does_not_raise_when_nothing_retained
+    send(:assert_no_coverband_leak, "Total retained:  0 bytes (0 objects)\n")
+  end
+end


### PR DESCRIPTION
## What

CI on `ruby-head` has been failing across all Gemfile variants (rails7.0/7.1/7.2/8.0) with:

```
rake aborted!
leaking memory!!!
test/benchmarks/benchmark.rake:178:in 'Object#measure_memory'
```

This showed up on #647's CI run even though that PR only touched JS/CSS/ERB files — the failure is unrelated to that diff.

## Why

`test/benchmarks/benchmark.rake`'s `measure_memory` (used by `benchmarks:memory_reporting`, which is part of `rake test:all`) asserted `Total retained: 0 bytes` after 10 `store.save_report` calls via `memory_profiler`. On `ruby-head`, `retained objects by gem` showed only `json-2.21.2` and `redis-client-0.30.1` — no `coverband` entry — confirming it's a stdlib/gem-internal string-deduplication artifact on newer Ruby, not a real Coverband leak.

Two prior commits (323c420, 2b252d1) already established the right fix for this exact class of false positive — scope the check to only fail if `coverband` itself shows up in `retained objects by gem` — but only applied it to `measure_memory_report_coverage`. `measure_memory` (the one actually failing in CI) still had the old strict zero-byte check.

## What changed

- Extracted the existing "coverband-only" retention check into a shared `assert_no_coverband_leak(data)` helper (removes duplication between the two methods).
- Applied it to `measure_memory`.
- Added `test/coverband/benchmarks/benchmark_memory_leak_check_test.rb` — unit tests for the helper directly (raises when coverband retains, doesn't raise for external-gem-only retention, doesn't raise when nothing retained).

## Testing

- `bundle exec standardrb` — clean
- `bundle exec rake test` — 379 runs, 0 failures (includes the 3 new tests)
- `bundle exec rake test:all` — full suite including the real `benchmarks:memory` memory-profiler run and the `benchmarks` ips suite — all green, no leak raised

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8uCiaqtDHUjd5fYGa88VN