### PR TITLE
Remove dead configuration options for Coverband 7.0

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -3,6 +3,7 @@
 **Breaking changes**
 
 * **Coverage and tracker history do not survive this upgrade.** Stored documents now carry the metadata the new merge protocol needs, and keys are scoped by a generation token, so the storage format version changed for both `RedisStore` and the cache adapters. Old keys are ignored rather than migrated, and coverage accumulates fresh from the upgrade. Delete the old `coverband_3_2.*` keys once you are happy with the new data.
+* Removed configuration settings that no longer had production consumers: `s3_region`, `s3_bucket`, `s3_access_key_id`, `s3_secret_access_key`, `track_gems`, `gem_details`, and `simulate_oneshot_lines_coverage`. The S3 and gem-tracking settings were already deprecated no-ops.
 * **`Coverband::Adapters::MemcachedStore` is deprecated** and is now a thin subclass of the new `ActiveSupportCacheStore`. Its `memcached_namespace` option and reader keep working; its stored data is not migrated.
 * **`background_reporting_sleep_seconds` now defaults to 600** for the new cache adapter (`HashRedisStore` still defaults to 300, everything else to 60), because each report rewrites a whole document.
 * `Adapters::Base#size` now returns bytes as an Integer or `nil`; `size_in_mib` owns the "N/A" presentation. A store returning the string `"N/A"` previously reported `0.00` MiB.

--- a/lib/coverband/configuration.rb
+++ b/lib/coverband/configuration.rb
@@ -19,8 +19,8 @@ module Coverband
       :verbose,
       :reporter, :redis_namespace, :redis_ttl,
       :background_reporting_enabled,
-      :test_env, :web_enable_clear, :gem_details, :web_debug, :report_on_exit,
-      :use_oneshot_lines_coverage, :simulate_oneshot_lines_coverage,
+      :test_env, :web_enable_clear, :web_debug, :report_on_exit,
+      :use_oneshot_lines_coverage,
       :view_tracker, :defer_eager_loading_data,
       :track_routes, :track_redirect_routes, :route_tracker,
       :track_translations, :translations_tracker,
@@ -29,13 +29,12 @@ module Coverband
       :trackers, :csp_policy, :hide_settings,
       :mcp_enabled
 
-    attr_writer :logger, :s3_region, :s3_bucket, :s3_access_key_id,
-      :s3_secret_access_key, :password, :api_key, :service_url, :coverband_timeout, :service_dev_mode,
+    attr_writer :logger, :password, :api_key, :service_url, :coverband_timeout, :service_dev_mode,
       :service_test_mode, :process_type, :track_views, :redis_url,
       :background_reporting_sleep_seconds, :reporting_wiggle,
       :send_deferred_eager_loading_data, :paged_reporting, :mcp_allowed_environments, :mcp_password
 
-    attr_reader :track_gems, :ignore
+    attr_reader :ignore
 
     #####
     # TODO: This is is brittle and not a great solution to avoid deploy time
@@ -100,7 +99,6 @@ module Coverband
       @web_debug = false
       @report_on_exit = true
       @use_oneshot_lines_coverage = ENV["ONESHOT"] || false
-      @simulate_oneshot_lines_coverage = false # this is being deprecated
       @current_root = nil
       @all_root_paths = nil
       @all_root_patterns = nil
@@ -131,14 +129,6 @@ module Coverband
       self.class.dynamic_flag_defaults.each do |name, default|
         instance_variable_set(:"@#{name}", default)
       end
-
-      # TODO: these are deprecated
-      @s3_region = nil
-      @s3_bucket = nil
-      @s3_access_key_id = nil
-      @s3_secret_access_key = nil
-      @track_gems = false
-      @gem_details = false
     end
 
     def railtie!
@@ -315,7 +305,7 @@ module Coverband
       @all_root_patterns ||= all_root_paths.map { |path| /^#{path}/ }.freeze
     end
 
-    SKIPPED_SETTINGS = %w[@s3_secret_access_key @store @api_key @password @mcp_password]
+    SKIPPED_SETTINGS = %w[@store @api_key @password @mcp_password]
     def to_h
       instance_variables
         .each_with_object({}) do |var, hash|
@@ -376,26 +366,6 @@ module Coverband
 
       (coverband_env == "test" && !Coverband.configuration.service_test_mode) ||
         (coverband_env == "development" && !Coverband.configuration.service_dev_mode)
-    end
-
-    def s3_bucket
-      puts "deprecated, s3 is no longer support"
-    end
-
-    def s3_region
-      puts "deprecated, s3 is no longer support"
-    end
-
-    def s3_access_key_id
-      puts "deprecated, s3 is no longer support"
-    end
-
-    def s3_secret_access_key
-      puts "deprecated, s3 is no longer support"
-    end
-
-    def track_gems=(_value)
-      puts "gem tracking is deprecated, setting this will be ignored & eventually removed"
     end
 
     private

--- a/test/coverband/configuration_test.rb
+++ b/test/coverband/configuration_test.rb
@@ -124,4 +124,21 @@ class BaseTest < Minitest::Test
 
     assert_equal "rediss://my-elasticache.example.com:6379", Coverband.configuration.redis_url
   end
+
+  test "removed configuration options are not exposed" do
+    removed = %i[
+      s3_region
+      s3_bucket
+      s3_access_key_id
+      s3_secret_access_key
+      track_gems
+      gem_details
+      simulate_oneshot_lines_coverage
+    ]
+
+    removed.each do |setting|
+      refute_respond_to Coverband.configuration, setting
+      refute_respond_to Coverband.configuration, :"#{setting}="
+    end
+  end
 end

--- a/test/integration/full_stack_deferred_eager_test.rb
+++ b/test/integration/full_stack_deferred_eager_test.rb
@@ -12,7 +12,6 @@ class FullStackDeferredEagerTest < Minitest::Test
     Coverband::Collectors::Coverage.instance.reset_instance
     Coverband.configure do |config|
       config.background_reporting_enabled = false
-      config.track_gems = true
       config.defer_eager_loading_data = true
     end
     Coverband.start

--- a/test/integration/full_stack_send_deferred_eager_test.rb
+++ b/test/integration/full_stack_send_deferred_eager_test.rb
@@ -12,7 +12,6 @@ class FullStackSendDeferredEagerTest < Minitest::Test
     Coverband::Collectors::Coverage.instance.reset_instance
     Coverband.configure do |config|
       config.background_reporting_enabled = false
-      config.track_gems = true
       config.defer_eager_loading_data = true
       config.send_deferred_eager_loading_data = false
     end

--- a/test/integration/full_stack_test.rb
+++ b/test/integration/full_stack_test.rb
@@ -12,7 +12,6 @@ class FullStackTest < Minitest::Test
     Coverband::Collectors::Coverage.instance.reset_instance
     Coverband.configure do |config|
       config.background_reporting_enabled = false
-      config.track_gems = true
     end
     Coverband.start
     Coverband::Collectors::Coverage.instance.eager_loading!

--- a/test/rails7_dummy/config/coverband_missing_redis.rb
+++ b/test/rails7_dummy/config/coverband_missing_redis.rb
@@ -8,7 +8,5 @@ Coverband.configure do |config|
   config.logger = Rails.logger
   config.verbose = true
   config.background_reporting_enabled = true
-  config.track_gems = true
-  config.gem_details = true
   config.use_oneshot_lines_coverage = true if ENV["ONESHOT"]
 end


### PR DESCRIPTION
## Summary

- remove the deprecated S3 configuration readers, writers, and state
- remove the ignored gem-tracking and simulated one-shot settings
- clean stale integration and dummy-app configuration
- document the removals as Coverband 7.0 breaking changes
- test that the removed readers and writers are no longer exposed

## Verification

- `bundle exec ruby -Ilib -Itest test/coverband/configuration_test.rb`
- `bundle exec rake test` — 596 runs, 1,521 assertions, 0 failures
- `bundle exec rake forked_tests` — 6 runs, 35 assertions, 0 failures
- `bundle exec standardrb --format github`

Closes #653
