### PR TITLE
Expose structured storage health through JSON and MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,28 @@ The MCP server provides the following tools:
 | `get_view_tracker_data` | Get view/template usage data |
 | `get_route_tracker_data` | Get route usage statistics |
 | `get_translation_tracker_data` | Get translation key usage data |
+| `get_storage_health` | Get observed coverage and tracker storage protocol state |
+
+#### Storage health
+
+`Coverband.storage_health` returns normalized diagnostics for coverage and every initialized
+tracker. The normal JSON report also includes this value as its top-level `storage_health`
+field, and MCP exposes the same representation through `get_storage_health`:
+
+```ruby
+Coverband.storage_health
+# => {
+#   coverage: {status: "ok", data_loss: nil, unwritten: nil},
+#   trackers: {view_tracker: {status: "stalled", data_loss: nil,
+#     unwritten: {deltas: 3, since: "2026-08-19T12:01:00Z"}}}
+# }
+```
+
+Statuses are `ok`, `stalled`, `data_loss`, or `unsupported`; `data_loss` takes precedence
+when both loss and unwritten work are present. These diagnostics describe state Coverband's
+storage protocol has already observed. They are not an active backend availability or
+connectivity probe. SimpleCov-compatible JSON generated with `for_merged_report` does not
+include this metadata.
 
 #### Running the MCP Server
 

--- a/changes.md
+++ b/changes.md
@@ -25,6 +25,7 @@
 
 **Features**
 
+* Added structured storage health through `Coverband.storage_health`, normal JSON reports, and the MCP `get_storage_health` tool, so monitoring can distinguish healthy, stalled, data-loss, and unsupported diagnostic states (#658)
 * Added `Coverband::Adapters::ActiveSupportCacheStore`, which stores coverage in any `ActiveSupport::Cache::Store` — Redis, Memcached, files, or Solid Cache for Postgres/MySQL/SQLite. The cache target can be passed lazily (`ActiveSupportCacheStore.new { Rails.cache }`) so it works from `config/coverband.rb`, where `Rails.cache` does not exist yet (#533)
 * Trackers (views, routes, translations, query bursts) now work on non-Redis stores. They previously reached through the store to raw Redis commands, so file and memcached users got trackers that silently collected nothing and empty web UI tabs
 * Fixed the read-modify-write conflict Coverband has always had on `RedisStore`: concurrent reports could silently drop one process's contribution. Reports are now applied under a per-writer sequence, so a conflicting write is detected and repaired on the next cycle without double counting. `QueryBurstTracker` had the same conflict on its cumulative counters and is fixed the same way

--- a/lib/coverband.rb
+++ b/lib/coverband.rb
@@ -15,6 +15,7 @@ require "coverband/storage/generation"
 require "coverband/storage/generation_lifecycle"
 require "coverband/storage/writer"
 require "coverband/storage/session"
+require "coverband/storage_health"
 require "coverband/adapters/base"
 require "coverband/adapters/session_coverage"
 require "coverband/adapters/tracker_storage/base"
@@ -124,6 +125,12 @@ module Coverband
   def self.report_coverage
     prefetch_report_pointers!
     coverage_instance.report_coverage
+  end
+
+  # Returns normalized diagnostics for coverage and every initialized tracker.
+  # This is Coverband's observed protocol state, not an active backend probe.
+  def self.storage_health(coverage: configuration.store)
+    StorageHealth.report(coverage: coverage)
   end
 
   def self.configuration

--- a/lib/coverband/mcp/server.rb
+++ b/lib/coverband/mcp/server.rb
@@ -7,6 +7,7 @@ require_relative "tools/get_dead_methods"
 require_relative "tools/get_view_tracker_data"
 require_relative "tools/get_route_tracker_data"
 require_relative "tools/get_translation_tracker_data"
+require_relative "tools/get_storage_health"
 
 module Coverband
   module MCP
@@ -66,6 +67,7 @@ module Coverband
             - get_view_tracker_data
             - get_route_tracker_data
             - get_translation_tracker_data
+            - get_storage_health
 
           For Claude Desktop, configure with:
             {
@@ -108,7 +110,8 @@ module Coverband
           Tools::GetDeadMethods,
           Tools::GetViewTrackerData,
           Tools::GetRouteTrackerData,
-          Tools::GetTranslationTrackerData
+          Tools::GetTranslationTrackerData,
+          Tools::GetStorageHealth
         ]
       end
     end

--- a/lib/coverband/mcp/tools/get_storage_health.rb
+++ b/lib/coverband/mcp/tools/get_storage_health.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Coverband
+  module MCP
+    module Tools
+      class GetStorageHealth < ::MCP::Tool
+        description "Get Coverband's observed coverage and tracker storage protocol state, " \
+                    "including stalled writes and recorded data loss. This is not an active backend probe."
+
+        input_schema(
+          properties: {}
+        )
+
+        def self.call(server_context:, **)
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: JSON.pretty_generate(Coverband.storage_health)
+          }])
+        rescue => e
+          ::MCP::Tool::Response.new([{
+            type: "text",
+            text: "Error getting storage health: #{e.message}"
+          }])
+        end
+      end
+    end
+  end
+end

--- a/lib/coverband/reporters/json_report.rb
+++ b/lib/coverband/reporters/json_report.rb
@@ -85,7 +85,8 @@ module Coverband
 
         data = {
           **coverage_totals(source_files),
-          files: coverage_files(result, source_files)
+          files: coverage_files(result, source_files),
+          storage_health: Coverband.storage_health(coverage: store)
         }
 
         if as_report

--- a/lib/coverband/reporters/web.rb
+++ b/lib/coverband/reporters/web.rb
@@ -114,8 +114,7 @@ module Coverband
       def index
         notice = "<strong>Notice:</strong> #{Rack::Utils.escape_html(request.params["notice"])}<br/>"
         notice = request.params["notice"] ? notice : ""
-        notice += data_loss_notice(Coverband.configuration.store, subject: "coverage")
-        notice += unwritten_notice(Coverband.configuration.store, subject: "coverage")
+        notice += storage_notices(Coverband.configuration.store, subject: "coverage")
         page = (request.params["page"] || 1).to_i
         options = {
           static: false,
@@ -155,8 +154,7 @@ module Coverband
       def display_abstract_tracker(tracker)
         notice = "<strong>Notice:</strong> #{Rack::Utils.escape_html(request.params["notice"])}<br/>"
         notice = request.params["notice"] ? notice : ""
-        notice += data_loss_notice(tracker, subject: "tracker")
-        notice += unwritten_notice(tracker, subject: "tracker")
+        notice += storage_notices(tracker, subject: "tracker")
         used_keys_sort = tracker_used_keys_sort_mode(tracker)
         options = {
           tracker: tracker,
@@ -228,36 +226,37 @@ module Coverband
       # loss -- when the failure is that nothing can be stored, what this process
       # is holding is the only evidence there is.
       ###
-      def unwritten_notice(source, subject:)
-        return "" unless source.respond_to?(:unwritten)
+      def storage_notices(source, subject:)
+        health = Coverband::StorageHealth.for_source(source)
+        data_loss_notice(health, subject: subject) + unwritten_notice(health, subject: subject)
+      end
 
-        held = source.unwritten
+      def unwritten_notice(health, subject:)
+        held = health[:unwritten]
         return "" unless held
 
-        "<strong>Notice:</strong> #{held.deltas} #{subject} #{(held.deltas == 1) ? "report" : "reports"} " \
-          "could not be stored, the oldest since #{held.since.iso8601}. What is shown is missing them, " \
+        deltas = held[:deltas]
+        "<strong>Notice:</strong> #{deltas} #{subject} #{(deltas == 1) ? "report" : "reports"} " \
+          "could not be stored, the oldest since #{held[:since]}. What is shown is missing them, " \
           "and the log says why each write was refused.<br/>"
       end
 
-      def data_loss_notice(source, subject:)
-        # stores and trackers registered by an app or gem need not implement this
-        return "" unless source.respond_to?(:data_loss)
-
-        loss = source.data_loss
+      def data_loss_notice(health, subject:)
+        loss = health[:data_loss]
         return "" unless loss
 
-        detail = Rack::Utils.escape_html(loss.detail.to_s)
-        kind = Rack::Utils.escape_html(loss.kind.to_s)
-        lead, consequence = data_loss_wording(loss, subject)
-        "<strong>Notice:</strong> #{lead} at #{loss.at.iso8601} " \
+        detail = Rack::Utils.escape_html(loss[:detail].to_s)
+        kind = Rack::Utils.escape_html(loss[:kind])
+        lead, consequence = data_loss_wording(kind, subject)
+        "<strong>Notice:</strong> #{lead} at #{loss[:at]} " \
           "(#{kind}): #{detail}. #{consequence}<br/>"
       end
 
       # a forfeited retry is not lost data -- that work is in the document unless
       # another writer clobbered the write it went out in -- so it must not read
       # like a real eviction
-      def data_loss_wording(loss, subject)
-        if loss.kind.to_s == "unconfirmed_dropped"
+      def data_loss_wording(kind, subject)
+        if kind == "unconfirmed_dropped"
           ["some #{subject} data may be undercounted",
             "Affected only if another process overwrote that write."]
         else

--- a/lib/coverband/storage_health.rb
+++ b/lib/coverband/storage_health.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "time"
+
+module Coverband
+  # Normalizes the storage protocol diagnostics exposed by coverage stores and
+  # trackers. These values describe state Coverband has already observed; they
+  # do not probe the backend or promise that it is currently reachable.
+  module StorageHealth
+    module_function
+
+    def report(configuration: Coverband.configuration, coverage: configuration.store)
+      {
+        coverage: for_source(coverage),
+        trackers: tracker_health(configuration)
+      }
+    end
+
+    def for_source(source)
+      return unsupported unless diagnostics_supported?(source)
+
+      loss = source.data_loss
+      held = source.unwritten
+
+      {
+        status: status(loss, held),
+        data_loss: normalize_data_loss(loss),
+        unwritten: normalize_unwritten(held)
+      }
+    rescue
+      unsupported
+    end
+
+    def tracker_health(configuration)
+      Coverband::Collectors::TrackerRegistry.names.each_with_object({}) do |name, health|
+        tracker = configuration.tracker_for(name)
+        health[name] = for_source(tracker) if tracker
+      end
+    end
+    private_class_method :tracker_health
+
+    def diagnostics_supported?(source)
+      source&.respond_to?(:data_loss) && source.respond_to?(:unwritten)
+    end
+    private_class_method :diagnostics_supported?
+
+    def status(loss, held)
+      return "data_loss" if loss
+      return "stalled" if held
+
+      "ok"
+    end
+    private_class_method :status
+
+    def normalize_data_loss(loss)
+      return unless loss
+
+      {
+        kind: loss.kind.to_s,
+        at: format_time(loss.at),
+        detail: loss.detail
+      }
+    end
+    private_class_method :normalize_data_loss
+
+    def normalize_unwritten(held)
+      return unless held
+
+      {
+        deltas: held.deltas,
+        since: format_time(held.since)
+      }
+    end
+    private_class_method :normalize_unwritten
+
+    def format_time(value)
+      value.respond_to?(:iso8601) ? value.iso8601 : value&.to_s
+    end
+    private_class_method :format_time
+
+    def unsupported
+      {
+        status: "unsupported",
+        data_loss: nil,
+        unwritten: nil
+      }
+    end
+    private_class_method :unsupported
+  end
+end

--- a/test/coverband/mcp/server_test.rb
+++ b/test/coverband/mcp/server_test.rb
@@ -40,7 +40,8 @@ if defined?(Coverband::MCP)
         "get_dead_methods",
         "get_view_tracker_data",
         "get_route_tracker_data",
-        "get_translation_tracker_data"
+        "get_translation_tracker_data",
+        "get_storage_health"
       ]
 
       expected_tools.each do |tool_name|

--- a/test/coverband/mcp/tools/get_storage_health_test.rb
+++ b/test/coverband/mcp/tools/get_storage_health_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../../test_helper", File.dirname(__FILE__))
+
+begin
+  require "coverband/mcp"
+rescue LoadError
+  puts "MCP gem not available, skipping MCP tools tests"
+end
+
+if defined?(Coverband::MCP)
+  class GetStorageHealthTest < Minitest::Test
+    test "tool explains that diagnostics are observed state" do
+      description = Coverband::MCP::Tools::GetStorageHealth.description
+
+      assert_includes description, "observed"
+      assert_includes description, "not an active backend probe"
+    end
+
+    test "tool returns the public storage health representation" do
+      health = {
+        coverage: {status: "stalled", data_loss: nil, unwritten: {deltas: 2, since: "2026-08-19T12:00:00Z"}},
+        trackers: {}
+      }
+      Coverband.expects(:storage_health).returns(health)
+
+      response = Coverband::MCP::Tools::GetStorageHealth.call(server_context: {})
+
+      assert_instance_of ::MCP::Tool::Response, response
+      assert_equal JSON.parse(JSON.generate(health)), JSON.parse(response.content.first[:text])
+    end
+
+    test "tool returns a formatted error response" do
+      Coverband.expects(:storage_health).raises(StandardError.new("broken diagnostics"))
+
+      response = Coverband::MCP::Tools::GetStorageHealth.call(server_context: {})
+
+      assert_includes response.content.first[:text], "Error getting storage health: broken diagnostics"
+    end
+  end
+end

--- a/test/coverband/reporters/json_test.rb
+++ b/test/coverband/reporters/json_test.rb
@@ -21,6 +21,29 @@ class ReportJSONTest < Minitest::Test
     parsed = JSON.parse(json)
     expected_keys = ["total_files", "lines_of_code", "lines_covered", "lines_missed", "covered_strength", "covered_percent"]
     assert expected_keys - parsed.keys == []
+    assert_equal "ok", parsed.dig("storage_health", "coverage", "status")
+  end
+
+  test "does not add storage health to merged report JSON" do
+    @store.send(:save_report, basic_coverage)
+
+    parsed = JSON.parse(Coverband::Reporters::JSONReport.new(@store, for_merged_report: true).report)
+
+    refute_includes parsed, "storage_health"
+    assert_includes parsed, Coverband::RUNTIME_TYPE.to_s
+  end
+
+  test "storage health describes the report's store" do
+    @store.send(:save_report, basic_coverage)
+    configured_store = @store
+    report_store = Object.new
+    report_store.define_singleton_method(:get_coverage_report) do |options|
+      configured_store.get_coverage_report(options)
+    end
+
+    parsed = JSON.parse(Coverband::Reporters::JSONReport.new(report_store).report)
+
+    assert_equal "unsupported", parsed.dig("storage_health", "coverage", "status")
   end
 
   test "honors ignore list" do

--- a/test/coverband/storage_health_test.rb
+++ b/test/coverband/storage_health_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require File.expand_path("../test_helper", File.dirname(__FILE__))
+
+class StorageHealthTest < Minitest::Test
+  DiagnosticSource = Struct.new(:data_loss, :unwritten)
+
+  test "reports healthy diagnostics" do
+    assert_equal({
+      status: "ok",
+      data_loss: nil,
+      unwritten: nil
+    }, Coverband::StorageHealth.for_source(DiagnosticSource.new))
+  end
+
+  test "reports stalled work with an ISO 8601 timestamp" do
+    since = Time.utc(2026, 8, 19, 12, 1, 2)
+    held = Coverband::Storage::Session::UnwrittenWork.new(deltas: 3, since: since)
+
+    assert_equal({
+      status: "stalled",
+      data_loss: nil,
+      unwritten: {deltas: 3, since: "2026-08-19T12:01:02Z"}
+    }, Coverband::StorageHealth.for_source(DiagnosticSource.new(nil, held)))
+  end
+
+  test "reports data loss without losing its classification or detail" do
+    at = Time.utc(2026, 8, 19, 12, 0, 1)
+    loss = Coverband::Storage::Session::DataLoss.new(
+      kind: :pending_dropped,
+      at: at,
+      detail: "dropped 2 pending deltas"
+    )
+
+    assert_equal({
+      status: "data_loss",
+      data_loss: {
+        kind: "pending_dropped",
+        at: "2026-08-19T12:00:01Z",
+        detail: "dropped 2 pending deltas"
+      },
+      unwritten: nil
+    }, Coverband::StorageHealth.for_source(DiagnosticSource.new(loss, nil)))
+  end
+
+  test "data loss takes precedence while retaining unwritten details" do
+    loss = Coverband::Storage::Session::DataLoss.new(
+      kind: :eviction,
+      at: Time.utc(2026, 8, 19, 12),
+      detail: "document disappeared"
+    )
+    held = Coverband::Storage::Session::UnwrittenWork.new(
+      deltas: 1,
+      since: Time.utc(2026, 8, 19, 12, 1)
+    )
+
+    health = Coverband::StorageHealth.for_source(DiagnosticSource.new(loss, held))
+
+    assert_equal "data_loss", health[:status]
+    assert_equal "eviction", health.dig(:data_loss, :kind)
+    assert_equal 1, health.dig(:unwritten, :deltas)
+  end
+
+  test "sources without diagnostics are unsupported" do
+    assert_equal({
+      status: "unsupported",
+      data_loss: nil,
+      unwritten: nil
+    }, Coverband::StorageHealth.for_source(Object.new))
+  end
+
+  test "diagnostic errors degrade to unsupported" do
+    source = Object.new
+    source.define_singleton_method(:data_loss) { raise "unavailable" }
+    source.define_singleton_method(:unwritten) { nil }
+
+    assert_equal "unsupported", Coverband::StorageHealth.for_source(source)[:status]
+  end
+
+  test "public report includes coverage and initialized trackers by registered name" do
+    coverage = DiagnosticSource.new
+    healthy_tracker = DiagnosticSource.new
+    unsupported_tracker = Object.new
+    configuration = Coverband.configuration
+
+    configuration.stubs(:store).returns(coverage)
+    Coverband::Collectors::TrackerRegistry.stubs(:names).returns([:custom_tracker, :legacy_tracker, :disabled_tracker])
+    configuration.stubs(:tracker_for).with(:custom_tracker).returns(healthy_tracker)
+    configuration.stubs(:tracker_for).with(:legacy_tracker).returns(unsupported_tracker)
+    configuration.stubs(:tracker_for).with(:disabled_tracker).returns(nil)
+
+    health = Coverband.storage_health
+
+    assert_equal "ok", health.dig(:coverage, :status)
+    assert_equal "ok", health.dig(:trackers, :custom_tracker, :status)
+    assert_equal "unsupported", health.dig(:trackers, :legacy_tracker, :status)
+    refute_includes health[:trackers], :disabled_tracker
+  end
+end

--- a/test/integration/mcp_integration_test.rb
+++ b/test/integration/mcp_integration_test.rb
@@ -72,7 +72,8 @@ if defined?(Coverband::MCP)
         Coverband::MCP::Tools::GetDeadMethods,
         Coverband::MCP::Tools::GetViewTrackerData,
         Coverband::MCP::Tools::GetRouteTrackerData,
-        Coverband::MCP::Tools::GetTranslationTrackerData
+        Coverband::MCP::Tools::GetTranslationTrackerData,
+        Coverband::MCP::Tools::GetStorageHealth
       ].each do |tool_class|
         assert_respond_to tool_class, :call
         assert_respond_to tool_class, :title
@@ -136,7 +137,8 @@ if defined?(Coverband::MCP)
         [Coverband::MCP::Tools::GetDeadMethods, {}],
         [Coverband::MCP::Tools::GetViewTrackerData, {}],
         [Coverband::MCP::Tools::GetRouteTrackerData, {}],
-        [Coverband::MCP::Tools::GetTranslationTrackerData, {}]
+        [Coverband::MCP::Tools::GetTranslationTrackerData, {}],
+        [Coverband::MCP::Tools::GetStorageHealth, {}]
       ]
 
       tools.each do |tool_class, params|


### PR DESCRIPTION
## Summary

- add one normalized storage-health representation for coverage and initialized registered trackers
- expose observed ok, stalled, data-loss, and unsupported states through Coverband.storage_health and normal JSON reports
- add an MCP get_storage_health tool that returns the same representation
- reuse normalized diagnostics for existing web banners and document that this is observed protocol state, not an active backend probe
- preserve SimpleCov-compatible merged-report JSON unchanged

## Verification

- bundle exec rake test (608 runs, 1,563 assertions, 0 failures, 4 skips)
- bundle exec rake forked_tests (6 runs, 35 assertions, 0 failures)
- bundle exec standardrb --format github

Closes #658