### PR TITLE
Remove legacy raw-array input from SourceFile

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -4,6 +4,7 @@
 
 * **Coverage and tracker history do not survive this upgrade.** Stored documents now carry the metadata the new merge protocol needs, and keys are scoped by a generation token, so the storage format version changed for both `RedisStore` and the cache adapters. Old keys are ignored rather than migrated, and coverage accumulates fresh from the upgrade. Delete the old `coverband_3_2.*` keys once you are happy with the new data.
 * Removed configuration settings that no longer had production consumers: `s3_region`, `s3_bucket`, `s3_access_key_id`, `s3_secret_access_key`, `track_gems`, `gem_details`, and `simulate_oneshot_lines_coverage`. The S3 and gem-tracking settings were already deprecated no-ops.
+* `Coverband::Utils::SourceFile` and `Coverband::Utils::Result` now accept only enriched file records from stored Coverband reports. Passing the legacy bare line-coverage Array is no longer supported.
 * **`Coverband::Adapters::MemcachedStore` is deprecated** and is now a thin subclass of the new `ActiveSupportCacheStore`. Its `memcached_namespace` option and reader keep working; its stored data is not migrated.
 * **`background_reporting_sleep_seconds` now defaults to 600** for the new cache adapter (`HashRedisStore` still defaults to 300, everything else to 60), because each report rewrites a whole document.
 * `Adapters::Base#size` now returns bytes as an Integer or `nil`; `size_in_mib` owns the "N/A" presentation. A store returning the string `"N/A"` previously reported `0.00` MiB.

--- a/lib/coverband/utils/result.rb
+++ b/lib/coverband/utils/result.rb
@@ -7,15 +7,16 @@ require "forwardable"
 # Thanks for all the help SimpleCov https://github.com/colszowka/simplecov
 # initial version pulled into Coverband from Simplecov 12/04/2018
 #
-# A code coverage result, initialized from the Hash stdlib built-in coverage
-# library generates (Coverage.result).
+# A code coverage result initialized from a stored Coverband report. The report
+# maps filenames to enriched file records; each record contains a line-coverage
+# Array under "data" and may contain Coverband's timestamp and loading metadata.
 ####
 module Coverband
   module Utils
     class Result
       extend Forwardable
 
-      # Returns the original Coverage.result used for this instance of Coverband::Result
+      # Returns the original stored Coverband report used for this result
       attr_reader :original_result
       # Returns all files that are applicable to this result (sans filters!)
       # as instances of Coverband::SourceFile. Aliased as :source_files
@@ -27,8 +28,7 @@ module Coverband
       def_delegators :files, :covered_percent, :covered_percentages, :covered_strength, :covered_lines, :missed_lines
       def_delegator :files, :lines_of_code, :total_lines
 
-      # Initialize a new Coverband::Result from given Coverage.result (a Hash of filenames each containing an array of
-      # coverage data)
+      # Initialize a result from a Hash mapping filenames to enriched file records.
       def initialize(original_result)
         @original_result = (original_result || {}).freeze
 

--- a/lib/coverband/utils/source_file.rb
+++ b/lib/coverband/utils/source_file.rb
@@ -4,8 +4,11 @@
 # Thanks for all the help SimpleCov https://github.com/colszowka/simplecov
 # initial version pulled into Coverband from Simplecov 12/04/2018
 #
-# Representation of a source file including it's coverage data, source code,
-# source lines and featuring helpers to interpret that data.
+# Representation of a source file including its coverage data, source code,
+# source lines and featuring helpers to interpret that data. Coverage is supplied
+# as an enriched file record from a stored Coverband report. The record must be a
+# Hash with a line-coverage Array under the "data" key and may include "timedata",
+# "first_updated_at", "last_updated_at", and "never_loaded" metadata.
 ####
 require_relative "source_file/line"
 
@@ -14,9 +17,9 @@ module Coverband
     class SourceFile
       # The full path to this source file (e.g. /User/colszowka/projects/simplecov/lib/simplecov/source_file.rb)
       attr_reader :filename
-      # The array of coverage data received from the Coverage.result
+      # The array of line coverage data from the enriched file record
       attr_reader :coverage
-      # The array of coverage timedata received from the Coverage.result
+      # The array of coverage timestamps from the enriched file record
       attr_reader :coverage_posted
 
       # the date this version of the file first started to record coverage
@@ -28,21 +31,18 @@ module Coverband
       NOT_AVAILABLE = "not available"
 
       def initialize(filename, file_data)
+        unless file_data.is_a?(Hash) && file_data["data"].is_a?(Array)
+          raise ArgumentError, 'file_data must be an enriched coverage record with an Array at "data"'
+        end
+
         @filename = filename
         @runtime_relavant_lines = nil
-        if file_data.is_a?(Hash)
-          @coverage = file_data["data"]
-          @coverage_posted = file_data["timedata"] || [] # NOTE: only implement timedata for HashRedisStore
-          @first_updated_at = @last_updated_at = NOT_AVAILABLE
-          @first_updated_at = Time.at(file_data["first_updated_at"]) if file_data["first_updated_at"]
-          @last_updated_at = Time.at(file_data["last_updated_at"]) if file_data["last_updated_at"]
-          @never_loaded = file_data["never_loaded"] || false
-        else
-          # TODO: Deprecate this code path this was backwards compatibility from 3-4
-          @coverage = file_data
-          @first_updated_at = NOT_AVAILABLE
-          @last_updated_at = NOT_AVAILABLE
-        end
+        @coverage = file_data["data"]
+        @coverage_posted = file_data["timedata"] || [] # NOTE: only implement timedata for HashRedisStore
+        @first_updated_at = @last_updated_at = NOT_AVAILABLE
+        @first_updated_at = Time.at(file_data["first_updated_at"]) if file_data["first_updated_at"]
+        @last_updated_at = Time.at(file_data["last_updated_at"]) if file_data["last_updated_at"]
+        @never_loaded = file_data["never_loaded"] || false
       end
 
       def runtime_relavant_calculations(runtime_relavant_lines)

--- a/test/coverband/utils/file_list_test.rb
+++ b/test/coverband/utils/file_list_test.rb
@@ -10,8 +10,8 @@ describe Coverband::Utils::FileList do
   subject do
     original_result = {
       source_fixture("sample.rb") => {"first_updated_at" => Time.at(0), "data" => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]},
-      source_fixture("app/models/user.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
-      source_fixture("app/controllers/sample_controller.rb") => [nil, 2, 2, 0, nil, nil, 0, nil, nil, nil]
+      source_fixture("app/models/user.rb") => {"data" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
+      source_fixture("app/controllers/sample_controller.rb") => {"data" => [nil, 2, 2, 0, nil, nil, 0, nil, nil, nil]}
     }
     Coverband::Utils::Result.new(original_result).files
   end

--- a/test/coverband/utils/result_test.rb
+++ b/test/coverband/utils/result_test.rb
@@ -7,12 +7,12 @@ require File.expand_path("../../test_helper", File.dirname(__FILE__))
 # initial version of test pulled into Coverband from Simplecov 12/19/2018
 ####
 describe "result" do
-  describe "with a (mocked) Coverage.result" do
+  describe "with a stored Coverband report" do
     let(:original_result) do
       {
-        source_fixture("sample.rb") => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil],
-        source_fixture("app/models/user.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil],
-        source_fixture("app/controllers/sample_controller.rb") => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]
+        source_fixture("sample.rb") => {"data" => [nil, 1, 1, 1, nil, nil, 1, 1, nil, nil]},
+        source_fixture("app/models/user.rb") => {"data" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]},
+        source_fixture("app/controllers/sample_controller.rb") => {"data" => [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil]}
       }
     end
 

--- a/test/coverband/utils/results_test.rb
+++ b/test/coverband/utils/results_test.rb
@@ -3,21 +3,26 @@
 require File.expand_path("../../test_helper", File.dirname(__FILE__))
 
 describe "results" do
-  describe "with a (mocked) Coverage.result" do
-    let(:source_file) { Coverband::Utils::SourceFile.new(source_fixture("app/models/user.rb"), run_lines) }
+  describe "with a stored Coverband report" do
+    let(:source_file) { Coverband::Utils::SourceFile.new(source_fixture("app/models/user.rb"), record(source_lines)) }
     let(:eager_lines) { [nil, 1, 1, 0, nil, nil, 1, 0, nil, nil] }
+    let(:source_lines) { [nil, nil, nil, 1, nil, nil, nil, nil, nil, nil] }
     let(:run_lines) { [nil, nil, nil, 1, nil, nil, nil, nil, nil, nil] }
     let(:missing_run_coverage_file) { false }
     let(:original_result) do
       orig = {
-        Coverband::MERGED_TYPE => {source_fixture("app/models/user.rb") => eager_lines}
+        Coverband::MERGED_TYPE => {source_fixture("app/models/user.rb") => record(eager_lines)}
       }
-      orig[Coverband::EAGER_TYPE] = {source_fixture("app/models/user.rb") => eager_lines} if eager_lines
-      orig[Coverband::RUNTIME_TYPE] = {source_fixture("app/models/user.rb") => run_lines} if run_lines
-      orig[Coverband::RUNTIME_TYPE] = {"random.rb" => [nil, 1, nil]} if missing_run_coverage_file
+      orig[Coverband::EAGER_TYPE] = {source_fixture("app/models/user.rb") => record(eager_lines)} if eager_lines
+      orig[Coverband::RUNTIME_TYPE] = {source_fixture("app/models/user.rb") => record(run_lines)} if run_lines
+      orig[Coverband::RUNTIME_TYPE] = {"random.rb" => record([nil, 1, nil])} if missing_run_coverage_file
       orig
     end
     subject { Coverband::Utils::Results.new(original_result) }
+
+    def record(lines)
+      {"data" => lines}
+    end
 
     describe "runtime relevant lines is supported" do
       it "has correct runtime relevant coverage" do

--- a/test/coverband/utils/source_file_test.rb
+++ b/test/coverband/utils/source_file_test.rb
@@ -10,7 +10,7 @@ describe Coverband::Utils::SourceFile do
   coverage_for_sample_rb = [nil, 1, 1, 1, nil, nil, 1, 0, nil, nil, nil, nil, nil, nil, nil, nil].freeze
   describe "a source file initialized with some coverage data" do
     subject do
-      Coverband::Utils::SourceFile.new(source_fixture("sample.rb"), coverage_for_sample_rb)
+      Coverband::Utils::SourceFile.new(source_fixture("sample.rb"), {"data" => coverage_for_sample_rb})
     end
 
     it "has a filename" do
@@ -66,11 +66,27 @@ describe Coverband::Utils::SourceFile do
     it "working for nil last_updated_at" do
       assert_equal "not available", subject.last_updated_at
     end
+
+    it "reads metadata from the enriched record" do
+      file_data = {
+        "data" => coverage_for_sample_rb,
+        "timedata" => [nil, 1_725_000_000],
+        "first_updated_at" => 1_724_000_000,
+        "last_updated_at" => 1_725_000_000,
+        "never_loaded" => true
+      }
+      source_file = Coverband::Utils::SourceFile.new(source_fixture("sample.rb"), file_data)
+
+      assert_equal file_data["timedata"], source_file.coverage_posted
+      assert_equal Time.at(1_724_000_000), source_file.first_updated_at
+      assert_equal Time.at(1_725_000_000), source_file.last_updated_at
+      assert source_file.never_loaded
+    end
   end
 
   describe "simulating potential Ruby 1.9 defect -- see Issue #56" do
     subject do
-      Coverband::Utils::SourceFile.new(source_fixture("sample.rb"), coverage_for_sample_rb + [nil])
+      Coverband::Utils::SourceFile.new(source_fixture("sample.rb"), {"data" => coverage_for_sample_rb + [nil]})
     end
 
     it "has 16 source lines regardless of extra data in coverage array" do
@@ -87,11 +103,29 @@ describe Coverband::Utils::SourceFile do
     end
   end
 
+  describe "invalid coverage data" do
+    it "rejects a bare coverage array" do
+      error = assert_raises(ArgumentError) do
+        Coverband::Utils::SourceFile.new(source_fixture("sample.rb"), coverage_for_sample_rb)
+      end
+
+      assert_equal 'file_data must be an enriched coverage record with an Array at "data"', error.message
+    end
+
+    it "rejects a record without an Array at data" do
+      error = assert_raises(ArgumentError) do
+        Coverband::Utils::SourceFile.new(source_fixture("sample.rb"), {"data" => nil})
+      end
+
+      assert_equal 'file_data must be an enriched coverage record with an Array at "data"', error.message
+    end
+  end
+
   describe "a file that is never relevant" do
     coverage_for_never_rb = [nil, nil].freeze
 
     subject do
-      Coverband::Utils::SourceFile.new(source_fixture("never.rb"), coverage_for_never_rb)
+      Coverband::Utils::SourceFile.new(source_fixture("never.rb"), {"data" => coverage_for_never_rb})
     end
 
     it "has 0.0 covered_strength" do
@@ -107,7 +141,7 @@ describe Coverband::Utils::SourceFile do
     coverage_for_skipped_rb = [nil, nil, nil, nil].freeze
 
     subject do
-      Coverband::Utils::SourceFile.new(source_fixture("skipped.rb"), coverage_for_skipped_rb)
+      Coverband::Utils::SourceFile.new(source_fixture("skipped.rb"), {"data" => coverage_for_skipped_rb})
     end
 
     it "has 0.0 covered_strength" do
@@ -123,7 +157,7 @@ describe Coverband::Utils::SourceFile do
     coverage_for_skipped_rb_2 = [nil, nil, 0, nil].freeze
 
     subject do
-      Coverband::Utils::SourceFile.new(source_fixture("skipped.rb"), coverage_for_skipped_rb_2)
+      Coverband::Utils::SourceFile.new(source_fixture("skipped.rb"), {"data" => coverage_for_skipped_rb_2})
     end
 
     it "has 0.0 covered_strength" do
@@ -139,7 +173,7 @@ describe Coverband::Utils::SourceFile do
     coverage_for_skkiped_and_executed_rb = [nil, nil, 1, 1, 0, nil, nil, nil].freeze
 
     subject do
-      Coverband::Utils::SourceFile.new(source_fixture("skipped_and_executed.rb"), coverage_for_skkiped_and_executed_rb)
+      Coverband::Utils::SourceFile.new(source_fixture("skipped_and_executed.rb"), {"data" => coverage_for_skkiped_and_executed_rb})
     end
 
     it "has 0.0 covered_strength" do


### PR DESCRIPTION
## Summary

- require enriched stored-report records in `Coverband::Utils::SourceFile`
- raise a clear `ArgumentError` for bare arrays and malformed records
- migrate `SourceFile`, `Result`, `Results`, and `FileList` fixtures to the enriched shape
- document the accepted reporting shape and the Coverband 7.0 breaking change

## Verification

- focused utility tests: 56 runs, 83 assertions, 0 failures, 0 errors
- `bundle exec standardrb --format github`
- `git diff --check`
- GitHub Actions will provide isolated full/forked verification; concurrent local suites share and reset Redis DB 2, producing unrelated missing-data failures when multiple issue worktrees verify together

Closes #654