### PR TITLE
Test Rails.cache through the full Rails lifecycle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,11 @@ jobs:
         redis-version: [4, 5, 6, 7]
         exclude:
           # Rails 8 requires ruby 3.2+.
-          - gemfile: 'rails_8.0'
+          - gemfile: 'Gemfile.rails8.0'
             ruby: '3.1'
     runs-on: ${{ matrix.os }}-latest
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     services:
       redis:
         image: redis:${{ matrix.redis-version }}

--- a/Gemfile.rails7.0
+++ b/Gemfile.rails7.0
@@ -13,5 +13,8 @@ gem "webrick"
 # which connection_pool 3.x turned into keyword arguments.
 gem "connection_pool", "~> 2.5"
 
+# Rack 2 requires ostruct, which Ruby 4 no longer ships as a default gem.
+gem "ostruct"
+
 # Required for Ruby 3.4+ (extracted from stdlib)
 gem "cgi"

--- a/Gemfile.rails7.0
+++ b/Gemfile.rails7.0
@@ -9,5 +9,9 @@ gem "haml"
 gem "slim"
 gem "webrick"
 
+# ActiveSupport's MemCacheStore passes positional options to ConnectionPool,
+# which connection_pool 3.x turned into keyword arguments.
+gem "connection_pool", "~> 2.5"
+
 # Required for Ruby 3.4+ (extracted from stdlib)
 gem "cgi"

--- a/Gemfile.rails7.1
+++ b/Gemfile.rails7.1
@@ -9,5 +9,9 @@ gem "haml"
 gem "slim"
 gem "webrick"
 
+# ActiveSupport's MemCacheStore passes positional options to ConnectionPool,
+# which connection_pool 3.x turned into keyword arguments.
+gem "connection_pool", "~> 2.5"
+
 # Required for Ruby 3.4+ (extracted from stdlib)
 gem "cgi"

--- a/Gemfile.rails7.2
+++ b/Gemfile.rails7.2
@@ -9,5 +9,9 @@ gem "haml"
 gem "slim"
 gem "webrick"
 
+# ActiveSupport's MemCacheStore passes positional options to ConnectionPool,
+# which connection_pool 3.x turned into keyword arguments.
+gem "connection_pool", "~> 2.5"
+
 # Required for Ruby 3.4+ (extracted from stdlib)
 gem "cgi"

--- a/Gemfile.rails8.0
+++ b/Gemfile.rails8.0
@@ -9,6 +9,10 @@ gem "haml"
 gem "slim"
 gem "webrick"
 
+# ActiveSupport's MemCacheStore passes positional options to ConnectionPool,
+# which connection_pool 3.x turned into keyword arguments.
+gem "connection_pool", "~> 2.5"
+
 # Required for Ruby 3.4+ (extracted from stdlib)
 gem "cgi"
 

--- a/test/forked/rails_cache_full_stack_test.rb
+++ b/test/forked/rails_cache_full_stack_test.rb
@@ -17,6 +17,8 @@ class RailsCacheFullStackTest < Minitest::Test
     # Keep this assertion meaningful when contributors run the suite from a
     # temporary worktree; /tmp is ignored by default for deploy-time builds.
     Coverband.configuration.ignore.delete_if { |pattern| pattern.source == "/tmp" }
+    Coverband::Utils::RelativeFileConverter.reset
+    Coverband::Utils::AbsoluteFileConverter.reset
     Coverband::Collectors::Coverage.instance.reset_instance
     Coverband.report_coverage
   end
@@ -39,12 +41,8 @@ class RailsCacheFullStackTest < Minitest::Test
     assert_content("I am no dummy")
 
     dummy_controller = "./app/controllers/dummy_controller.rb"
-    coverage = nil
-    5.times do
-      Coverband.report_coverage
-      coverage = store.coverage
-      break if coverage.key?(dummy_controller)
-    end
+    Coverband.report_coverage
+    coverage = store.coverage
     assert coverage.key?(dummy_controller), "stored coverage keys: #{coverage.keys.inspect}"
 
     route_tracker = Coverband.configuration.route_tracker

--- a/test/forked/rails_cache_full_stack_test.rb
+++ b/test/forked/rails_cache_full_stack_test.rb
@@ -38,6 +38,8 @@ class RailsCacheFullStackTest < Minitest::Test
     visit "/dummy/show"
     assert_content("I am no dummy")
     Coverband.report_coverage
+    # A quiet follow-up confirms any unconfirmed merge from the request cycle.
+    Coverband.report_coverage
 
     dummy_controller = "./app/controllers/dummy_controller.rb"
     assert store.coverage.key?(dummy_controller)

--- a/test/forked/rails_cache_full_stack_test.rb
+++ b/test/forked/rails_cache_full_stack_test.rb
@@ -18,6 +18,7 @@ class RailsCacheFullStackTest < Minitest::Test
     # temporary worktree; /tmp is ignored by default for deploy-time builds.
     Coverband.configuration.ignore.delete_if { |pattern| pattern.source == "/tmp" }
     Coverband::Collectors::Coverage.instance.reset_instance
+    Coverband.report_coverage
   end
 
   def teardown

--- a/test/forked/rails_cache_full_stack_test.rb
+++ b/test/forked/rails_cache_full_stack_test.rb
@@ -12,6 +12,10 @@ class RailsCacheFullStackTest < Minitest::Test
 
   def setup
     super
+    # This test intentionally skips Coverband::Test.reset because that helper
+    # initializes Redis. Clear configuration state directly so memoized root
+    # paths inherited by the fork cannot leak into this dummy application.
+    Coverband.configuration.reset
     ENV["COVERBAND_RAILS_CACHE"] = "true"
     rails_setup
     # Keep this assertion meaningful when contributors run the suite from a

--- a/test/forked/rails_cache_full_stack_test.rb
+++ b/test/forked/rails_cache_full_stack_test.rb
@@ -37,12 +37,15 @@ class RailsCacheFullStackTest < Minitest::Test
 
     visit "/dummy/show"
     assert_content("I am no dummy")
-    Coverband.report_coverage
-    # A quiet follow-up confirms any unconfirmed merge from the request cycle.
-    Coverband.report_coverage
 
     dummy_controller = "./app/controllers/dummy_controller.rb"
-    assert store.coverage.key?(dummy_controller)
+    coverage = nil
+    5.times do
+      Coverband.report_coverage
+      coverage = store.coverage
+      break if coverage.key?(dummy_controller)
+    end
+    assert coverage.key?(dummy_controller), "stored coverage keys: #{coverage.keys.inspect}"
 
     route_tracker = Coverband.configuration.route_tracker
     assert_same store, route_tracker.store
@@ -53,7 +56,7 @@ class RailsCacheFullStackTest < Minitest::Test
     assert_selector("a", text: /dummy_controller.rb/)
 
     visit "/coverage/routes_tracker"
-    assert_content('controller: "dummy"')
-    assert_content('action: "show"')
+    assert_content(/controller(?::|=>)\s*"dummy"/)
+    assert_content(/action(?::|=>)\s*"show"/)
   end
 end

--- a/test/forked/rails_cache_full_stack_test.rb
+++ b/test/forked/rails_cache_full_stack_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require File.expand_path("../rails_test_helper", File.dirname(__FILE__))
+
+class RailsCacheFullStackTest < Minitest::Test
+  include Capybara::DSL
+  include Capybara::Minitest::Assertions
+
+  def skip_coverband_test_reset?
+    true
+  end
+
+  def setup
+    super
+    ENV["COVERBAND_RAILS_CACHE"] = "true"
+    rails_setup
+    # Keep this assertion meaningful when contributors run the suite from a
+    # temporary worktree; /tmp is ignored by default for deploy-time builds.
+    Coverband.configuration.ignore.delete_if { |pattern| pattern.source == "/tmp" }
+    Coverband::Collectors::Coverage.instance.reset_instance
+  end
+
+  def teardown
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
+    Coverband::Background.stop
+    ENV.delete("COVERBAND_RAILS_CACHE")
+    super
+  end
+
+  test "Rails.cache stores coverage and tracker data through a full Rails lifecycle" do
+    assert_instance_of ActiveSupport::Cache::MemoryStore, Rails.cache
+
+    store = Coverband.configuration.store
+    assert_instance_of Coverband::Adapters::ActiveSupportCacheStore, store
+
+    visit "/dummy/show"
+    assert_content("I am no dummy")
+    Coverband.report_coverage
+
+    dummy_controller = "./app/controllers/dummy_controller.rb"
+    assert store.coverage.key?(dummy_controller)
+
+    route_tracker = Coverband.configuration.route_tracker
+    assert_same store, route_tracker.store
+    route_tracker.save_report
+    assert route_tracker.used_keys.keys.any? { |route| route.include?("dummy") && route.include?("show") }
+
+    visit "/coverage"
+    assert_selector("a", text: /dummy_controller.rb/)
+
+    visit "/coverage/routes_tracker"
+    assert_content('controller: "dummy"')
+    assert_content('action: "show"')
+  end
+end

--- a/test/rails7_dummy/config/application.rb
+++ b/test/rails7_dummy/config/application.rb
@@ -11,5 +11,6 @@ module Rails6Dummy
   class Application < Rails::Application
     config.eager_load = true
     config.consider_all_requests_local = true
+    config.cache_store = :memory_store if ENV["COVERBAND_RAILS_CACHE"]
   end
 end

--- a/test/rails7_dummy/config/coverband_rails_cache.rb
+++ b/test/rails7_dummy/config/coverband_rails_cache.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Coverband.configure do |config|
+  # Keep Rails.cache lazy: Coverband configuration is loaded before Rails has
+  # finished initializing the application's configured cache store.
+  config.store = Coverband::Adapters::ActiveSupportCacheStore.new { Rails.cache }
+  config.root = ::File.expand_path("../../../", __FILE__).to_s + "/rails#{Rails::VERSION::MAJOR}_dummy"
+  config.ignore = %w[.erb$ .slim$]
+  config.root_paths = []
+  config.logger = Rails.logger
+  config.verbose = true
+  config.background_reporting_enabled = true
+  config.track_routes = true
+end

--- a/test/rails7_dummy/config/coverband_rails_cache.rb
+++ b/test/rails7_dummy/config/coverband_rails_cache.rb
@@ -9,6 +9,8 @@ Coverband.configure do |config|
   config.root_paths = []
   config.logger = Rails.logger
   config.verbose = true
-  config.background_reporting_enabled = true
+  # The test triggers reporting explicitly, so no boot-time thread races the
+  # assignment of Rails.cache or introduces timing into the assertions.
+  config.background_reporting_enabled = false
   config.track_routes = true
 end

--- a/test/rails8_dummy/config/application.rb
+++ b/test/rails8_dummy/config/application.rb
@@ -11,5 +11,6 @@ module Rails6Dummy
   class Application < Rails::Application
     config.eager_load = true
     config.consider_all_requests_local = true
+    config.cache_store = :memory_store if ENV["COVERBAND_RAILS_CACHE"]
   end
 end

--- a/test/rails8_dummy/config/coverband_rails_cache.rb
+++ b/test/rails8_dummy/config/coverband_rails_cache.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "../../rails7_dummy/config/coverband_rails_cache"

--- a/test/rails_test_helper.rb
+++ b/test/rails_test_helper.rb
@@ -22,7 +22,8 @@ def rails_setup
   ENV["RAILS_ENV"] = "test"
   require "rails"
   # coverband must be required after rails
-  Coverband.configure("./test/rails#{Rails::VERSION::MAJOR}_dummy/config/coverband.rb")
+  coverband_config = ENV["COVERBAND_RAILS_CACHE"] ? "coverband_rails_cache.rb" : "coverband.rb"
+  Coverband.configure("./test/rails#{Rails::VERSION::MAJOR}_dummy/config/#{coverband_config}")
   load "coverband/utils/railtie.rb"
 
   require_relative "../test/rails#{Rails::VERSION::MAJOR}_dummy/config/environment"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -72,7 +72,11 @@ module Coverband
 
     def setup
       super
-      Coverband::Test.reset
+      Coverband::Test.reset unless skip_coverband_test_reset?
+    end
+
+    def skip_coverband_test_reset?
+      false
     end
   end
 end


### PR DESCRIPTION
## Summary

- add an ENV-selected Rails dummy configuration using `ActiveSupportCacheStore.new { Rails.cache }`
- configure an isolated `ActiveSupport::Cache::MemoryStore` for this path, without changing existing Redis-backed dummy tests
- exercise controller coverage, route tracker persistence, and both coverage web report routes in a forked full-stack test
- let this one no-Redis integration bypass the shared Redis-backed test reset

## Verification

- `bundle exec ruby -Ilib -Itest test/forked/rails_cache_full_stack_test.rb` (1 run, 9 assertions)
- `bundle exec standardrb --format github`
- `bundle exec rake test` and `bundle exec rake forked_tests` were attempted from the assigned `/private/tmp` worktree; pre-existing coverage assertions outside the new test fail because Coverband intentionally ignores `/tmp` source paths. The new integration compensates for temporary worktrees and passes. GitHub CI runs from a normal checkout and is the authoritative full-suite verification.

Closes #657